### PR TITLE
Fix SEGV in get_product_release

### DIFF
--- a/src/rpminspect/rpminspect.c
+++ b/src/rpminspect/rpminspect.c
@@ -81,9 +81,18 @@ static char *get_product_release(const char *before, const char *after) {
 
     assert(after != NULL);
 
-    pos = rindex(after, '.') + 1;
-    after_product = strdup(pos);
+    pos = rindex(after, '.');
+    if (!pos) {
+        fprintf(stderr, "*** Product release for after build (%s) is empty\n", after);
+        return NULL;
+    }
 
+    /*
+     * Get the character after the last occurrence of a period. This should
+     * tell us what release flag the product is.
+     */
+    pos += 1;
+    after_product = strdup(pos);
     if (!after_product) {
         fprintf(stderr, "*** Product release for after build (%s) is empty\n", after);
         return NULL;


### PR DESCRIPTION
When the user passes an obviously bogus release like:

    rpminspect 42

`rindex(after, '.')` returns `NULL`, which then gets incremented to 0x1 and
assigned to `pos`. `strdup(pos)` then segfaults prior to the `NULL` check on
`after_product`.


I might think about the error message some more but that should be a later PR. I need to understand more what "build" means in the context of rpminspect (e.g., what artifacts it can be given -- it looks like package names and local RPMs) and if there's a better way of informing the user about their mistake that makes it clear what is wrong with their argument and what they could pass instead.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`