### PR TITLE
Add regression test for segfault

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,7 @@ SUBDIRS = librpminspect
 
 AM_TESTS_ENVIRONMENT = RPMINSPECT=$(top_builddir)/src/rpminspect/rpminspect
 
-TESTS = rpminspect-help.sh
+TESTS = rpminspect-help.sh \
+        rpminspect-segv.sh
 
 EXTRA_DIST = $(TESTS)

--- a/tests/rpminspect-segv.sh
+++ b/tests/rpminspect-segv.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Verify rpminspect doesn't segfault on release-less args
+
+if [ ! -x "${RPMINSPECT}" ]; then
+    echo "*** Missing rpminspect executable" >&2
+    exit 1
+fi
+
+"${RPMINSPECT}" 42 >/dev/null 2>&1
+T1=$?
+
+if [ ${T1} -eq 139 ]; then
+    echo "*** rpminspect should not segfault" 2>&1
+    exit 1
+fi


### PR DESCRIPTION
Ensure that builds without product releases don't cause a segfault. As
the text of the error might change in the future (or, 42 might become a
valid build id), only check that we get a non-SEGV return code and don't
check program output.

Regression test for #33. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`