### PR TITLE
Fix config file detection

### DIFF
--- a/src/rpminspect/rpminspect.c
+++ b/src/rpminspect/rpminspect.c
@@ -397,9 +397,22 @@ int main(int argc, char **argv) {
         }
     }
 
-    /* Find an appropriate configuration file */
-    if ((cfgfile == NULL) || (access(CFGFILE, F_OK|R_OK) == -1)) {
+    /*
+     * Find an appropriate configuration file. This involves:
+     *
+     *  - Using the user-passed value and sanity-checking it,
+     *  - Using the global default if it exists, or
+     *  - Telling the user they need to install a required dependency.
+     */
+    if (cfgfile != NULL && access(cfgfile, F_OK|R_OK) == -1) {
+        fprintf(stderr, "Specified config file (%s) is unreadable.\n", cfgfile);
+        exit(EXIT_FAILURE);
+    } else if (cfgfile == NULL && access(CFGFILE, F_OK|R_OK) == 0) {
         cfgfile = strdup(CFGFILE);
+    } else if (cfgfile == NULL) {
+        fprintf(stderr, "Unable to read the default config file (%s).\n", CFGFILE);
+        fprintf(stderr, "Have you installed an rpminspect-data package for your distro?\n");
+        exit(EXIT_FAILURE);
     }
 
     /* Initialize librpminspect */


### PR DESCRIPTION
When a configuration file is passed on the command line, it should
always be used. In particular, that should mean erring out and telling
the user that their parameter was bad. When no config parameter was
passed, we should use the default if it exists. However, since
rpminspect is a new package (and choice of default `rpminspect-data-*`
depends on the distro), we should inform the user what they're missing.

The issue with the old behavior is, if an explicit configuration file was passed *and* the user lacked `rpminspect-data-fedora`, they'd default to using a file which doesn't exist. :-) 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`
