### PR TITLE
Fix distcheck

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,3 +3,5 @@ SUBDIRS = librpminspect
 AM_TESTS_ENVIRONMENT = RPMINSPECT=$(top_builddir)/src/rpminspect/rpminspect
 
 TESTS = rpminspect-help.sh
+
+EXTRA_DIST = $(TESTS)


### PR DESCRIPTION
CI uses `make distcheck` to run the unit tests. In the previous commit,
distcheck fails because there is no rule to make `rpminspect-help.sh`;
this is because it isn't added to the dist archive.

Adding `TESTS` to `EXTRA_DIST` fixes this.


@dcantrell I'm not sure if this is the best approach to fix it, but it works on my system. Thoughts? 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`