### PR TITLE
Add IPv6 blacklist check

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -477,6 +477,13 @@ int init_rpminspect(struct rpminspect *ri, const char *cfgfile) {
         parse_list(tmp, &ri->forbidden_directories);
     }
 
+    tmp = iniparser_getstring(cfg, "tests:elf_ipv6_blacklist", NULL);
+    if (tmp == NULL) {
+        ri->ipv6_blacklist = NULL;
+    } else {
+        parse_list(tmp, &ri->ipv6_blacklist);
+    }
+
     /* If any of the regular expressions fail to compile, stop and return failure */
     if (add_regex(cfg, "tests:elf_path_include", &ri->elf_path_include) != 0) {
         return -1;

--- a/lib/results.h
+++ b/lib/results.h
@@ -67,6 +67,7 @@
 #define REMEDY_ELF_GNU_RELRO            "Ensure executables are linked with with '-z relro -z now'"
 #define REMEDY_ELF_FORTIFY_SOURCE       "Ensure all object files are compiled with '-O2 -D_FORTIFY_SOURCE=2', and that all appropriate headers are included (no implicit function declarations). Symbols may also appear as unfortified if the compiler is unable to determine the size of a buffer, which is not necessarily an error."
 #define REMEDY_ELF_FPIC                 "Ensure all object files are compiled with -fPIC"
+#define REMEDY_ELF_IPV6                 "Please review all usages of IPv4-only functions and ensure IPv6 compliance."
 
 /* man */
 #define REMEDY_MAN_ERRORS   "Correct the errors in the man page as reported by the libmandoc parser."

--- a/lib/rpminspect.h
+++ b/lib/rpminspect.h
@@ -92,6 +92,7 @@ void list_free(string_list_t *, list_entry_data_free_func);
 size_t list_len(const string_list_t *);
 string_list_t * list_sort(const string_list_t *);
 string_list_t * list_copy(const string_list_t *);
+string_list_t * list_split(const char *data, char separator);
 
 /* local.c */
 bool is_local_build(const char *);

--- a/lib/types.h
+++ b/lib/types.h
@@ -199,6 +199,12 @@ struct rpminspect {
     string_list_t *forbidden_path_suffixes;
     string_list_t *forbidden_directories;
 
+    /*
+     * Optional: if not NULL, contains a list of functions known to have
+     * IPv6-compatibility issues.
+     */
+    string_list_t *ipv6_blacklist;
+
     /* Optional: if not NULL, contains list of architectures */
     string_list_t *arches;
 


### PR DESCRIPTION
Use the new tests:ipv6_blacklist from the config file to enable checking
of IPv4-only function usage. When these functions are used, it likely
means the program isn't compatible with IPv6 addresses, which are
becoming increasingly more widely used.

Depends on https://github.com/rpminspect/rpminspect-data-fedora/pull/1. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`