### PR TITLE
Fix segfault when path to RPM contains ..

### DIFF
--- a/lib/rpminspect.h
+++ b/lib/rpminspect.h
@@ -137,7 +137,7 @@ int get_rpm_header(const char *, Header *);
 /* peers.c */
 rpmpeer_t *init_rpmpeer(void);
 void free_rpmpeer(rpmpeer_t *);
-void add_peer(rpmpeer_t **, int, bool, const char *, Header *);
+int add_peer(rpmpeer_t **, int, bool, const char *, Header *);
 
 /* files.c */
 void free_files(rpmfile_t *files);

--- a/src/builds.c
+++ b/src/builds.c
@@ -100,7 +100,10 @@ static int get_rpm_info(const char *pkg) {
     arch = headerGetString(h, RPMTAG_ARCH);
 
     if (allowed_arch(workri, arch)) {
-        add_peer(&workri->peers, whichbuild, fetch_only, pkg, &h);
+        ret = add_peer(&workri->peers, whichbuild, fetch_only, pkg, &h);
+        if (ret != 0) {
+            return ret;
+        }
     }
 
     headerFree(h);


### PR DESCRIPTION
When the path to the before or after RPM contained '..' in it,
rpminspect would previously segfault:

    $ rpminspect ../koji/resteasy-3.0.19-9.fc30.noarch.rpm resteasy-3.0.26-1.fc32.noarch.rpm
    *** Error extracting /var/tmp/rpminspect/local.6nixV7/before/../koji/resteasy-3.0.19-9.fc30.noarch.rpm: Path contains '..'
    Segmentation fault (core dumped)

This is undesirable. To prevent the segfault, fix error handling in
add_peer and get_rpm_info in order to detect when extract_rpm fails.

This has the side effect of showing a bogus second error message though:

    $ rpminspect ../koji/resteasy-3.0.19-9.fc30.noarch.rpm resteasy-3.0.26-1.fc32.noarch.rpm
    *** Error extracting /var/tmp/rpminspect/local.hcZD52/before/../koji/resteasy-3.0.19-9.fc30.noarch.rpm: Path contains '..'
    *** Error gathering build ../koji/resteasy-3.0.19-9.fc30.noarch.rpm: No such file or directory
    *** Failed to gather specified builds.

But at least it doesn't segfault any more.


---

Original issue I began filing before figuring out the (partial) solution:

Leaving this one to the expert... :)

`extract_rpm` errors when the path includes `..`. I think this is partly desirable in case the packaged RPM includes it, but in my case, its when specified on the command line to `rpminspect`:

```
$ ~/GitHub/cipherboy/rpminspect/build/rpminspect ../koji/resteasy-3.0.19-9.fc30.noarch.rpm resteasy-3.0.26-1.fc32.noarch.rpm
*** Error extracting /var/tmp/rpminspect/local.6nixV7/before/../koji/resteasy-3.0.19-9.fc30.noarch.rpm: Path contains '..'
Segmentation fault (core dumped)
```

Clearly we at least shouldn't segfault.

The error message (`Error extracting...`) comes from [`extract_rpm`](https://github.com/rpminspect/rpminspect/blob/master/lib/files.c#L245-L251). However, the segfault happens much later:

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7fb85ae in inspect_removedfiles (ri=0x409600 <ri>) at ../lib/inspect_removedfiles.c:158
(gdb) backtrace
#0  0x00007ffff7fb85ae in inspect_removedfiles (ri=0x409600 <ri>) at ../lib/inspect_removedfiles.c:158
#1  0x000000000040387b in main (argc=3, argv=0x7fffffffd6a8) at ../src/rpminspect.c:572
```

In particular, `inspect_removedfiles` seems to assume `before_files` [is non-NULL](https://github.com/rpminspect/rpminspect/blob/master/lib/inspect_removedfiles.c#L158). Fine, that's an assumption we make in a lot of places.

The issue seems to be that `extract_rpm` has no way of returning an error up to `main`. Starting at the end: 

 - `extract_rpm` is called by [`add_peer`](https://github.com/rpminspect/rpminspect/blob/master/lib/peers.c#L142). This doesn't check that the result is non-NULL but also is a void function so nothing can really be done here anyways. 
 - Even if `add_peer` now returns an error value, [`get_rpm_info`](https://github.com/rpminspect/rpminspect/blob/master/src/builds.c#L103) needs to be updated to check it.
 - The rest seems fine.

-----

I'm guessing `errno` is getting set somewhere and we just need to clear it? 

Signed-off-by: Alexander Scheel <ascheel@redhat.com>