### PR TITLE
updating imports to use libcap, matching BuildRequires in specfile

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -27,7 +27,7 @@
 #include <unistd.h>
 #include <libgen.h>
 
-#include <cap-ng.h>
+#include <sys/capability.h>
 
 #include <rpm/header.h>
 #include <rpm/rpmtd.h>

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
-#include <cap-ng.h>
+#include <sys/capability.h>
 
 #include "rpminspect.h"
 


### PR DESCRIPTION
I think this fixes #99 by updating the imports in file.c and inspect_ownership.c
The change builds locally and in mock. Some quick tests locally work with this patch.