### PR TITLE
Add possibility to run integration test suites separately

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -299,12 +299,31 @@ if python.found()
     test_env.set('RPMINSPECT_CONF', meson.source_root() + '/src/rpminspect.conf')
     test_env.set('RPMINSPECT_TEST_DATA_PATH', meson.source_root() + '/tests/data')
 
-    test('rpminspect-test-suite',
-         python,
-         args : ['-B', '-m', 'unittest', 'discover', '-v', meson.source_root() + '/tests'],
-         env : test_env,
-         timeout : 300
-        )
+    test_suites = [
+        'test_default.py',
+        'test_desktop.py',
+        'test_disttag.py',
+        'test_emptyrpm.py',
+        'test_kmod.py',
+        'test_license.py',
+        'test_manpage.py',
+        'test_metadata.py',
+        'test_ownership.py',
+        'test_shellsyntax.py',
+        'test_specname.py',
+        'test_xml.py'
+        ]
+
+    foreach suite : test_suites
+        test('rpminspect-test-suite.' + suite.split('.')[0],
+             python,
+             args : ['-B', '-m', 'unittest', 'discover', '-v', meson.source_root() + '/tests', suite],
+             env : test_env,
+             is_parallel : false,
+             timeout : 300
+            )
+    endforeach
+
 else
     warning('Python not found, skipping integration test suite')
 endif


### PR DESCRIPTION
Output example:
```
Found ninja-1.9.0 at /usr/bin/ninja
ninja: no work to do.
 1/18 test-badwords                           OK       0.02 s 
 2/18 test-koji                               OK       0.02 s 
 3/18 test-tty                                OK       0.02 s 
 4/18 test-strfuncs                           OK       0.01 s 
 5/18 test-init                               OK       0.03 s 
 6/18 test-inspect_elf                        OK       0.03 s 
 7/18 rpminspect-test-suite.test_default      OK       0.32 s 
 8/18 rpminspect-test-suite.test_desktop      OK      11.45 s 
 9/18 rpminspect-test-suite.test_disttag      OK       2.27 s 
10/18 rpminspect-test-suite.test_emptyrpm     OK       2.87 s 
11/18 rpminspect-test-suite.test_kmod         OK      13.95 s 
12/18 rpminspect-test-suite.test_license      OK       4.53 s 
13/18 rpminspect-test-suite.test_manpage      OK       4.94 s 
14/18 rpminspect-test-suite.test_metadata     FAIL     9.69 s (exit status 1)
15/18 rpminspect-test-suite.test_ownership    OK       0.32 s 
16/18 rpminspect-test-suite.test_shellsyntax  FAIL     0.27 s (exit status 1)
17/18 rpminspect-test-suite.test_specname     OK       0.92 s 
18/18 rpminspect-test-suite.test_xml          OK       3.22 s 

Ok:                   16
Expected Fail:         0
Fail:                  2
Unexpected Pass:       0
Skipped:               0
Timeout:               0

```