### PR TITLE
ci: Add ShellCheck to lint shell scripts

### DIFF
--- a/.github/workflows/ci-shell-style.yml
+++ b/.github/workflows/ci-shell-style.yml
@@ -1,0 +1,17 @@
+name: Shell Style Checks
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
+
+jobs:
+    shellcheck:
+        runs-on: ubuntu-latest
+        # Ubuntu's ShellCheck is old enough to not have --severity
+        container: fedora:latest
+        steps:
+            - uses: actions/checkout@v2
+            - run: dnf install -y ShellCheck
+            - run: shellcheck --severity=warning **/*.sh


### PR DESCRIPTION
ShellCheck[0] is a great linting tool for shell scripts and catches a
number of common problems.

[0] https://www.shellcheck.net/