### PR TITLE
ci: Add Python linting jobs

### DIFF
--- a/.github/workflows/ci-python-style.yml
+++ b/.github/workflows/ci-python-style.yml
@@ -1,0 +1,26 @@
+name: Python Style Checks
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
+
+jobs:
+    python_style:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                tox_job: ["flake8", "format"]
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up Python 3.8
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.8
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install tox
+            - name: Checking Python code with ${{ matrix.tox_job }}
+              run: tox -e ${{ matrix.tox_job }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+envlist = flake8,format
+skipsdist=True
+
+[testenv]
+# Fiddle with the base python definitions so the Github CI matrix works neatly
+basepython =
+    py3.8: python3.8
+    py38: python3.8
+sitepackages = False
+
+[testenv:flake8]
+basepython = python3.8
+deps =
+    flake8 > 3.0
+commands =
+    python -m flake8 {posargs}
+
+[testenv:format]
+basepython = python3.8
+deps =
+    black
+commands =
+    python -m black --check {posargs:.}
+
+[flake8]
+basepython = python3.8
+show-source = True
+max-line-length = 100
+exclude = .git,.tox,dist,*egg,contrib/


### PR DESCRIPTION
This runs flake8[0] for PEP8 conformance and Black[1] for style
checking. Black can automatically format code, and while its choices
aren't always my favorite, it's great for a uniform, easily enforceable
style. It has editor integration, can be run manually from the command
line, or as a pre-commit hook so it mostly stays out of your way.

[0] https://flake8.pycqa.org/
[1] https://black.readthedocs.io/