### PR TITLE
Upload coverage report to codecov

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "test/"
+  - "build/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
             # Generate code coverage reports (requires
             # -Db_coverage=true on 'meson setup')
             - name: coverage
-              run: ninja -C build coverage
+              run: |
+                  ninja -C build coverage
+                  curl -s https://codecov.io/bash | bash
 
     ubuntu:
         # This job runs directly on the Ubuntu host provided by GitHub Actions
@@ -74,7 +76,9 @@ jobs:
             # Generate code coverage reports (requires
             # -Db_coverage=true on 'meson setup')
             - name: coverage
-              run: ninja -C build coverage
+              run: |
+                  ninja -C build coverage
+                  curl -s https://codecov.io/bash | bash
 
     opensuse-leap:
         # This job runs in a Docker container of OpenSUSE Leap but the
@@ -115,7 +119,9 @@ jobs:
             # Generate code coverage reports (requires
             # -Db_coverage=true on 'meson setup')
             - name: coverage
-              run: ninja -C build coverage
+              run: |
+                  ninja -C build coverage
+                  curl -s https://codecov.io/bash | bash
 
     centos8:
         # This job runs in a Docker container of the latest CentOS 8
@@ -162,7 +168,9 @@ jobs:
             # Generate code coverage reports (requires
             # -Db_coverage=true on 'meson setup')
             - name: coverage
-              run: ninja -C build coverage
+              run: |
+                  ninja -C build coverage
+                  curl -s https://codecov.io/bash | bash
 
     centos7:
         # This job runs in a Docker container of the latest CentOS 7
@@ -210,4 +218,6 @@ jobs:
             # Generate code coverage reports (requires
             # -Db_coverage=true on 'meson setup')
             - name: coverage
-              run: ninja -C build coverage
+              run: |
+                  ninja -C build coverage
+                  curl -s https://codecov.io/bash | bash


### PR DESCRIPTION
codecov provides a nice online code coverage tracker (with a badge!) so
that code coverage can be tracked over time and examined from the
browser. All that's necessary to enable this add the upload token[0] to
the repository secrets (Settings -> Secrets) with the name CODECOV_TOKEN

[0] https://codecov.io/gh/rpminspect/rpminspect/

An example report: https://codecov.io/gh/jeremycline/rpminspect/tree/c4866f0848cbf5516b17c6e9415e56ec9cbb503e