### PR TITLE
Tidy up the test base classes

### DIFF
--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -177,9 +177,6 @@ class TestSRPM(RequiresRpminspect):
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
-    def configFile(self):
-        RequiresRpminspect.configFile(self)
-
     def runTest(self):
         self.configFile()
 
@@ -251,9 +248,6 @@ class TestCompareSRPM(RequiresRpminspect):
         self.exitcode = 0
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
-
-    def configFile(self):
-        RequiresRpminspect.configFile(self)
 
     def runTest(self):
         self.configFile()

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -162,7 +162,7 @@ class RequiresRpminspect(unittest.TestCase):
 # Base test case class that tests on the SRPM package only
 class TestSRPM(RequiresRpminspect):
     def setUp(self):
-        RequiresRpminspect.setUp(self)
+        super().setUp()
         self.rpm = rpmfluff.SimpleRpmBuild(AFTER_NAME, AFTER_VER, AFTER_REL)
 
         # turn off all rpmbuild post processing stuff for the purposes of testing
@@ -232,7 +232,7 @@ class TestSRPM(RequiresRpminspect):
 # Base test case class that compares a before and after SRPM
 class TestCompareSRPM(RequiresRpminspect):
     def setUp(self):
-        RequiresRpminspect.setUp(self)
+        super().setUp()
         self.before_rpm = rpmfluff.SimpleRpmBuild(BEFORE_NAME, BEFORE_VER, BEFORE_REL)
         self.after_rpm = rpmfluff.SimpleRpmBuild(AFTER_NAME, AFTER_VER, AFTER_REL)
 

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -308,7 +308,7 @@ class TestCompareSRPM(RequiresRpminspect):
 # Base test case class that tests the binary RPMs
 class TestRPMs(TestSRPM):
     def runTest(self):
-        TestSRPM.configFile(self)
+        self.configFile()
 
         if not self.inspection and not self.label:
             return
@@ -367,7 +367,7 @@ class TestRPMs(TestSRPM):
 # Base test case class that compares before and after built RPMs
 class TestCompareRPMs(TestCompareSRPM):
     def runTest(self):
-        TestCompareSRPM.configFile(self)
+        self.configFile()
 
         if not self.inspection and not self.label:
             return
@@ -428,7 +428,7 @@ class TestCompareRPMs(TestCompareSRPM):
 # Base test case class that tests a fake Koji build
 class TestKoji(TestSRPM):
     def runTest(self):
-        TestSRPM.configFile(self)
+        self.configFile()
 
         if not self.inspection:
             return
@@ -498,7 +498,7 @@ class TestKoji(TestSRPM):
 # Base test case class that compares before and after Koji builds
 class TestCompareKoji(TestCompareSRPM):
     def runTest(self):
-        TestCompareSRPM.configFile(self)
+        self.configFile()
 
         if not self.inspection:
             return


### PR DESCRIPTION
While skimming through the test interface to figure out what's required to implement a test, there were a few oddities that made me jump around the code a bit more than is strictly necessary. These changes are strictly equivalent, but somewhat more (in my opinion) idiomatic and clear.