### PR TITLE
Improve the error reporting for test result checking

### DIFF
--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -53,21 +53,21 @@ class MissingRpminspectConf(Exception):
 # have at least one result that matches the result and waiver_auth we
 # were expecting.
 def check_results(results, label, result, waiver_auth):
-    ret = False
-
     if results == {} or results == [] or results is None:
-        return False
+        raise AssertionError("JSON test result is empty")
 
     if label not in results:
-        return False
+        raise AssertionError(f'The label "{label}" is missing from results "{results}"')
 
     for r in results[label]:
         if "result" in r and "waiver authorization" in r:
             if r["result"] == result and r["waiver authorization"] == waiver_auth:
-                ret = True
                 break
-
-    return ret
+    else:
+        raise AssertionError(
+            f"Expected result={result} with waiver authorization={waiver_auth} in "
+            f"{json.dumps(results[label], sort_keys=True, indent=4)}"
+        )
 
 
 # Base test case class that ensures we have 'rpminspect'
@@ -221,9 +221,7 @@ class TestSRPM(RequiresRpminspect):
             self.dumpResults()
 
         self.assertEqual(self.p.returncode, self.exitcode)
-        self.assertTrue(
-            check_results(self.results, self.label, self.result, self.waiver_auth)
-        )
+        check_results(self.results, self.label, self.result, self.waiver_auth)
 
     def tearDown(self):
         shutil.rmtree(self.rpm.get_base_dir(), ignore_errors=True)
@@ -296,9 +294,7 @@ class TestCompareSRPM(RequiresRpminspect):
             self.dumpResults()
 
         self.assertEqual(self.p.returncode, self.exitcode)
-        self.assertTrue(
-            check_results(self.results, self.label, self.result, self.waiver_auth)
-        )
+        check_results(self.results, self.label, self.result, self.waiver_auth)
 
     def tearDown(self):
         shutil.rmtree(self.before_rpm.get_base_dir(), ignore_errors=True)
@@ -416,9 +412,7 @@ class TestCompareRPMs(TestCompareSRPM):
                 self.dumpResults()
 
             self.assertEqual(self.p.returncode, self.exitcode)
-            self.assertTrue(
-                check_results(self.results, self.label, self.result, self.waiver_auth)
-            )
+            check_results(self.results, self.label, self.result, self.waiver_auth)
 
     def tearDown(self):
         shutil.rmtree(self.before_rpm.get_base_dir(), ignore_errors=True)
@@ -487,9 +481,7 @@ class TestKoji(TestSRPM):
                 self.dumpResults()
 
             self.assertEqual(self.p.returncode, self.exitcode)
-            self.assertTrue(
-                check_results(self.results, self.label, self.result, self.waiver_auth)
-            )
+            check_results(self.results, self.label, self.result, self.waiver_auth)
 
     def tearDown(self):
         shutil.rmtree(self.rpm.get_base_dir(), ignore_errors=True)
@@ -568,9 +560,7 @@ class TestCompareKoji(TestCompareSRPM):
                 self.dumpResults()
 
             self.assertEqual(self.p.returncode, self.exitcode)
-            self.assertTrue(
-                check_results(self.results, self.label, self.result, self.waiver_auth)
-            )
+            check_results(self.results, self.label, self.result, self.waiver_auth)
 
     def tearDown(self):
         shutil.rmtree(self.before_rpm.get_base_dir(), ignore_errors=True)

--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -199,9 +199,7 @@ class DistTagInMacroSRPM(RequiresRpminspect):
             self.dumpResults()
 
         self.assertEqual(self.p.returncode, self.exitcode)
-        self.assertTrue(
-            check_results(self.results, self.label, self.result, self.waiver_auth)
-        )
+        check_results(self.results, self.label, self.result, self.waiver_auth)
 
     def tearDown(self):
         self.tmpdir.cleanup()
@@ -293,9 +291,7 @@ class TabbedDistTagInMacroSRPM(RequiresRpminspect):
             self.dumpResults()
 
         self.assertEqual(self.p.returncode, self.exitcode)
-        self.assertTrue(
-            check_results(self.results, self.label, self.result, self.waiver_auth)
-        )
+        check_results(self.results, self.label, self.result, self.waiver_auth)
 
     def tearDown(self):
         self.tmpdir.cleanup()


### PR DESCRIPTION
While developing a new test, I provided the wrong waiver_auth and got a
test that failed with:

Traceback (most recent call last):
  File "/home/jcline/devel/rpminspect/test/baseclass.py", line 419, in
  runTest
      self.assertTrue(
      AssertionError: False is not true

It is indeed true that False is not true, but I had to do a bit of
digging to determine what was wrong with my test.

This changes check_results to raise an AssertionError with details about
what exactly was wrong with the results. For example, the issue that generated
the above error now generates:

Traceback (most recent call last):
  File "/home/jcline/devel/rpminspect/test/baseclass.py", line 414, in runTest
    check_results(self.results, self.label, self.result, self.waiver_auth)
  File "/home/jcline/devel/rpminspect/test/baseclass.py", line 67, in check_results
    raise AssertionError(
AssertionError: Expected result=VERIFY with waiver authorization=Not Waivable in [
    {
        "message": "/some/file grew by +2000% on x86_64",
        "result": "VERIFY",
        "waiver authorization": "Anyone"
    }
]