### PR TITLE
Fix memory corruption in init_rpminspect

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -1096,14 +1096,14 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         ri->specprimary = PRIMARY_NAME;
 
         /* Store full paths to all config files read */
-        ri->cfgfiles = calloc(1, sizeof(ri->cfgfiles));
+        ri->cfgfiles = calloc(1, sizeof(*ri->cfgfiles));
         assert(ri->cfgfiles != NULL);
         TAILQ_INIT(ri->cfgfiles);
     }
 
     /* Read in the config file if we have it */
     if (cfgfile) {
-        cfg = calloc(1, sizeof(cfg));
+        cfg = calloc(1, sizeof(*cfg));
         assert(cfg != NULL);
         cfg->data = realpath(cfgfile, NULL);
 


### PR DESCRIPTION
In init_rpminspect, the data member rpminspect::cfgfiles of type
string_list_t is allocated less bytes than it should.  And then later
when the statement "TAILQ_INIT(ri->cfgfiles)" corrupts memory by
writing passed the (wrongly) allocated memory region.

Something similar happens to the entry that get appended to that
instance of string_list_t.  The entry gets allocated less bytes than
it should and then the statement "TAILQ_INSERT_TAIL(ri->cfgfiles, cfg,
items)" corrupts memory y writing passed the wrongly allocated memory
region.

These two memory corruptions further lead to inconsistent behaviour
down the road.

This patch fixes that by allocating the right amount of memory for
these two cases.

Signed-off-by: Dodji Seketeli <dodji@seketeli.org>