### PR TITLE
Avoid comparing elf files that are not shared libraries

### DIFF
--- a/include/readelf.h
+++ b/include/readelf.h
@@ -42,6 +42,7 @@ Elf *get_elf_archive(const char *, int *);
 GElf_Half get_elf_type(Elf *);
 GElf_Half get_elf_machine(Elf *);
 bool is_elf(const char *);
+bool is_elf_shared_library(const char *);
 bool have_elf_section(Elf *, int64_t, const char *);
 string_list_t *get_elf_section_names(Elf *elf, size_t start);
 Elf_Scn *get_elf_section(Elf *, int64_t, const char *, Elf_Scn *, GElf_Shdr *);

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -148,8 +148,8 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
         return true;
     }
 
-    /* skip anything that is not an ELF file */
-    if (!S_ISREG(file->st.st_mode) || !is_elf(file->fullpath)) {
+    /* skip anything that is not an ELF shared library file.  */
+    if (!S_ISREG(file->st.st_mode) || !is_elf_shared_library(file->fullpath)) {
         return true;
     }
 

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -160,6 +160,23 @@ bool is_elf(const char *fullpath) {
     return true;
 }
 
+/*
+ * Return true if a specified file is an ELF shared library file, that
+ * is, of type ET_DYN.
+ */
+bool is_elf_shared_library(const char *fullpath)
+{
+    int fd = 0;
+    Elf *elf = NULL;
+
+    elf = get_elf(fullpath, &fd);
+    if (elf && get_elf_type(elf) == ET_DYN) {
+        return true;
+    }
+
+    return false;
+}
+
 bool have_elf_section(Elf *elf, int64_t section, const char *name)
 {
     return get_elf_section(elf, section, name, NULL, NULL) != NULL;


### PR DESCRIPTION
Sometimes, when comparing two packages the abidiff inspection can
wrongly attempt to compare ELF binaries that are not shared
libraries.  For instance, it can try to compare debuginfo files --
which are technically ELF files, but that we should obviously not
compare.  As a result, it sometimes emits spurious errors like this:

	$ rpminspect -k -v  -T abidiff ./workdir/tmp/alsa-lib-1.2.2-2.fc33 ./workdir/tmp/alsa-lib-1.2.3.2-5.fc33
	Running abidiff inspection...        FAIL

	[...]

	abidiff:
	--------
	1) Comparing from /usr/lib/debug/.dwz/alsa-lib-1.2.2-2.fc33.i386 to
	/usr/lib/debug/.dwz/alsa-lib-1.2.3.2-5.fc33.i386 in package alsa-lib-debuginfo on
	i686 revealed ABI differences.
	Result: VERIFY

	[...]

	Details:
	abidiff: failed to read input file ./workdir/local.JV0zj7/before/i686/alsa-lib-debuginfo-1.2.2-2.fc33.i686//usr/lib/debug/.dwz/alsa-lib-1.2.2-2.fc33.i386
	abidiff: could not find the debug info

	[...]

As the abidiff inspection is really meant to compare shared object
files to detect possibly incompatible ABI changes in them, I think we
should restrict it to just those files.

This patch makes sure to only compare ELF files of ET_DYN kind.

Signed-off-by: Dodji Seketeli <dodji@redhat.com>
Signed-off-by: Dodji Seketeli <dodji@seketeli.org>