### PR TITLE
Support single package URLs for before and after builds (#190)

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -21,6 +21,7 @@
 #include <getopt.h>
 #include <assert.h>
 #include <errno.h>
+#include <err.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -758,8 +759,20 @@ int main(int argc, char **argv) {
             peer = TAILQ_FIRST(ri->peers);
             after_rel = headerGetString(peer->after_hdr, RPMTAG_RELEASE);
 
+            if (after_rel == NULL) {
+                warn("invalid after RPM");
+                free_rpminspect(ri);
+                return RI_PROGRAM_ERROR;
+            }
+
             if (ri->before) {
                 before_rel = headerGetString(peer->before_hdr, RPMTAG_RELEASE);
+
+                if (before_rel == NULL) {
+                    warn("invalid before RPM");
+                    free_rpminspect(ri);
+                    return RI_PROGRAM_ERROR;
+                }
             }
 
             ri->product_release = get_product_release(ri->product_keys, ri->products, ri->favor_release, before_rel, after_rel);


### PR DESCRIPTION
rpminspect can work on single RPMs or entire Koji builds.  For the
former, rpminspect expected the RPMs to be locally available.  But
there are times where you may want to compare against an RPM already
built and available for download somewhere.  This patch lets you
specify URLs to single RPM packages.  rpminspect will detect this and
download the package and perform the inspections as if you were
providing a local RPM.