### PR TITLE
Stop the freshclam service for the Ubuntu gate job

### DIFF
--- a/osdeps/ubuntu/post.sh
+++ b/osdeps/ubuntu/post.sh
@@ -32,4 +32,5 @@ cd ..
 rm -rf mandoc.tar.gz ${SUBDIR}
 
 # Update the clamav database
+systemctl stop clamav-freshclam.service
 freshclam


### PR DESCRIPTION
Stop the service and run freshclam manually.