### PR TITLE
Expand message digest support in librpminspect

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -431,4 +431,10 @@
  */
 #define DEFAULT_PATCH_LINE_THRESHOLD 5000
 
+/*
+ * Default message digest to use internally.  The definition comes
+ * from an enum in rpminspect.h
+ */
+#define DEFAULT_MESSAGE_DIGEST SHA256SUM
+
 #endif

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -104,7 +104,15 @@ enum { BEFORE_BUILD, AFTER_BUILD };
 /*
  * Supported checksum types.
  */
-enum checksum { NULLSUM, MD5SUM, SHA1SUM, SHA256SUM };
+enum checksum {
+    NULLSUM,
+    MD5SUM,
+    SHA1SUM,
+    SHA224SUM,
+    SHA256SUM,
+    SHA384SUM,
+    SHA512SUM
+};
 
 /* Common functions */
 

--- a/lib/checksums.c
+++ b/lib/checksums.c
@@ -1,7 +1,7 @@
 /* {{{ Apache License version 2.0
  */
 /*
- * Copyright 2004-2019 David Shea <david@reallylongword.org>
+ * Copyright 2004-2020 David Shea <david@reallylongword.org>
  *                     Chris Lumens <chris@bangmoney.org>
  *                     David Cantrell <david.l.cantrell@gmail.com>
  *
@@ -24,7 +24,7 @@
  * @author David Cantrell &lt;david.l.cantrell@gmail.com&gt;
  * @author Chris Lumens &lt;chris@bangmoney.org&gt;
  * @author David Shea &lt;david@reallylongword.org&gt;
- * @date 2004-2019
+ * @date 2004-2020
  * @brief Calculate an MD5, SHA-1, SHA-224, SHA-256, SHA-384, or SHA-512 checksum for a file.
  * @copyright Apache-2.0
  */
@@ -205,6 +205,6 @@ char *checksum(rpmfile_entry_t *file)
         return file->checksum;
     }
 
-    file->checksum = compute_checksum(file->fullpath, &file->st.st_mode, SHA256SUM);
+    file->checksum = compute_checksum(file->fullpath, &file->st.st_mode, DEFAULT_MESSAGE_DIGEST);
     return file->checksum;
 }

--- a/lib/checksums.c
+++ b/lib/checksums.c
@@ -25,7 +25,7 @@
  * @author Chris Lumens &lt;chris@bangmoney.org&gt;
  * @author David Shea &lt;david@reallylongword.org&gt;
  * @date 2004-2019
- * @brief Calculate an MD5, SHA-1, or SHA-256 checksum for a file.
+ * @brief Calculate an MD5, SHA-1, SHA-224, SHA-256, SHA-384, or SHA-512 checksum for a file.
  * @copyright Apache-2.0
  */
 
@@ -67,6 +67,7 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
     MD5_CTX md5c;
     SHA_CTX sha1c;
     SHA256_CTX sha256c;
+    SHA512_CTX sha512c;
 
     /* if the user did not provide a mode_t, get it */
     if (st_mode == NULL) {
@@ -99,8 +100,10 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
         MD5_Init(&md5c);
     } else if (type == SHA1SUM) {
         SHA1_Init(&sha1c);
-    } else if (type == SHA256SUM) {
+    } else if (type == SHA224SUM || type == SHA256SUM) {
         SHA256_Init(&sha256c);
+    } else if (type == SHA384SUM || type == SHA512SUM) {
+        SHA512_Init(&sha512c);
     }
 
     /* read in the file to generate the requested checksum */
@@ -122,8 +125,10 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
             MD5_Update(&md5c, buf, len);
         } else if (type == SHA1SUM) {
             SHA1_Update(&sha1c, buf, len);
-        } else if (type == SHA256SUM) {
+        } else if (type == SHA224SUM || type == SHA256SUM) {
             SHA256_Update(&sha256c, buf, len);
+        } else if (type == SHA384SUM || type == SHA512SUM) {
+            SHA512_Update(&sha512c, buf, len);
         }
 
         if ((len = read(input, buf, sizeof(buf))) == -1) {
@@ -142,13 +147,26 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
     /* finalize the correct context type and determine the loop length */
     if (type == MD5SUM) {
         MD5_Final(digest, &md5c);
-        len = MD5_DIGEST_LENGTH;
     } else if (type == SHA1SUM) {
         SHA1_Final(digest, &sha1c);
-        len = SHA_DIGEST_LENGTH;
-    } else if (type == SHA256SUM) {
+    } else if (type == SHA224SUM || type == SHA256SUM) {
         SHA256_Final(digest, &sha256c);
+    } else if (type == SHA384SUM || type == SHA512SUM) {
+        SHA512_Final(digest, &sha512c);
+    }
+
+    if (type == MD5SUM) {
+        len = MD5_DIGEST_LENGTH;
+    } else if (type == SHA1SUM) {
+        len = SHA_DIGEST_LENGTH;
+    } else if (type == SHA224SUM) {
+        len = SHA224_DIGEST_LENGTH;
+    } else if (type == SHA256SUM) {
         len = SHA256_DIGEST_LENGTH;
+    } else if (type == SHA384SUM) {
+        len = SHA384_DIGEST_LENGTH;
+    } else if (type == SHA512SUM) {
+        len = SHA512_DIGEST_LENGTH;
     }
 
     /* this is our human readable digest, caller must free */

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -91,8 +91,14 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 type = MD5SUM;
             } else if (strlen(pentry->digest) == (SHA_DIGEST_LENGTH * 2)) {
                 type = SHA1SUM;
+            } else if (strlen(pentry->digest) == (SHA224_DIGEST_LENGTH * 2)) {
+                type = SHA224SUM;
             } else if (strlen(pentry->digest) == (SHA256_DIGEST_LENGTH * 2)) {
                 type = SHA256SUM;
+            } else if (strlen(pentry->digest) == (SHA384_DIGEST_LENGTH * 2)) {
+                type = SHA384SUM;
+            } else if (strlen(pentry->digest) == (SHA512_DIGEST_LENGTH * 2)) {
+                type = SHA512SUM;
             } else {
                 warnx(_("unknown digest type for pattern %s: %s"), pentry->pattern, pentry->digest);
                 continue;

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -105,7 +105,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             }
 
             /* get the digest */
-            if (type == SHA256SUM && !strcmp(pentry->digest, checksum(file))) {
+            if (type == DEFAULT_MESSAGE_DIGEST && !strcmp(pentry->digest, checksum(file))) {
                 matched = true;
                 allowed = pentry->allowed;
             } else {


### PR DESCRIPTION
Expand to cover SHA-244, SHA-384, and SHA-512.  Also make the library default a constant in constants.h.