### PR TITLE
Rename the 'DT_NEEDED' inspection to 'dsodeps'

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -89,7 +89,7 @@ vendor:
     #desktop: off
     #disttag: off
     #doc: off
-    #DT_NEEDED: off
+    #dsodeps: off
     #elf: off
     #emptyrpm: off
     #files: off

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -277,7 +277,7 @@ bool inspect_annocheck(struct rpminspect *ri);
  *
  * @param ri Pointer to the struct rpminspect for the program.
  */
-bool inspect_dt_needed(struct rpminspect *ri);
+bool inspect_dsodeps(struct rpminspect *ri);
 
 /**
  * @brief
@@ -500,7 +500,7 @@ bool inspect_politics(struct rpminspect *ri);
 #define INSPECT_OWNERSHIP                   (((uint64_t) 1) << 17)
 #define INSPECT_SHELLSYNTAX                 (((uint64_t) 1) << 18)
 #define INSPECT_ANNOCHECK                   (((uint64_t) 1) << 19)
-#define INSPECT_DT_NEEDED                   (((uint64_t) 1) << 20)
+#define INSPECT_DSODEPS                     (((uint64_t) 1) << 20)
 #define INSPECT_FILESIZE                    (((uint64_t) 1) << 21)
 #define INSPECT_PERMISSIONS                 (((uint64_t) 1) << 22)
 #define INSPECT_CAPABILITIES                (((uint64_t) 1) << 23)
@@ -563,7 +563,7 @@ bool inspect_politics(struct rpminspect *ri);
 
 #define DESC_ANNOCHECK _("Perform annocheck tests defined in the configuration file on all ELF files in the build.  A single build specified will perform an analysis only.  Two builds specified will compare the test results between the before and after build.  If no annocheck tests are defined in the configuration file, this inspection is skipped.")
 
-#define DESC_DT_NEEDED _("Compare DT_NEEDED entries in dynamic ELF executables and shared libraries between the before and after build and report changes.")
+#define DESC_DSODEPS _("Compare DT_NEEDED entries in dynamic ELF executables and shared libraries between the before and after build and report changes.")
 
 #define DESC_FILESIZE _("Report file size changes between builds.  If empty files became non-empty or non-empty files became empty, report those as results needing verification.  Report file change percentages as info-only.")
 

--- a/include/results.h
+++ b/include/results.h
@@ -50,7 +50,7 @@
 #define HEADER_OWNERSHIP     "ownership"
 #define HEADER_SHELLSYNTAX   "shell-syntax"
 #define HEADER_ANNOCHECK     "annocheck"
-#define HEADER_DT_NEEDED     "DT_NEEDED"
+#define HEADER_DSODEPS       "dso-deps"
 #define HEADER_FILESIZE      "filesize"
 #define HEADER_PERMISSIONS   "permissions"
 #define HEADER_CAPABILITIES  "capabilities"
@@ -153,8 +153,8 @@
 /* annocheck */
 #define REMEDY_ANNOCHECK _("See annocheck(1) for more information.")
 
-/* DT_NEEDED */
-#define REMEDY_DT_NEEDED _("DT_NEEDED symbols have been added or removed.  This happens when the build environment has different versions of the required libraries.  Sometimes this is deliberate but sometimes not.  Verify these changes are expected.  If they are not, modify the package spec file to ensure the build links with the correct shared libraries.")
+/* dsodeps */
+#define REMEDY_DSODEPS _("DT_NEEDED symbols have been added or removed.  This happens when the build environment has different versions of the required libraries.  Sometimes this is deliberate but sometimes not.  Verify these changes are expected.  If they are not, modify the package spec file to ensure the build links with the correct shared libraries.")
 
 /* filesize */
 #define REMEDY_FILESIZE_BECAME_NOT_EMPTY _("A previously empty file is no longer empty.  Make sure this change is intended and fix the package spec file if necessary.")

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -64,7 +64,7 @@ struct inspect inspections[] = {
     { INSPECT_OWNERSHIP,     "ownership",     true,  &inspect_ownership },
     { INSPECT_SHELLSYNTAX,   "shellsyntax",   true,  &inspect_shellsyntax },
     { INSPECT_ANNOCHECK,     "annocheck",     true,  &inspect_annocheck },
-    { INSPECT_DT_NEEDED,     "DT_NEEDED",     false, &inspect_dt_needed },
+    { INSPECT_DSODEPS,       "dsodeps",       false, &inspect_dsodeps },
     { INSPECT_FILESIZE,      "filesize",      false, &inspect_filesize },
     { INSPECT_PERMISSIONS,   "permissions",   true,  &inspect_permissions },
     { INSPECT_CAPABILITIES,  "capabilities",  true,  &inspect_capabilities },
@@ -182,8 +182,8 @@ const char *inspection_desc(const uint64_t inspection)
             return DESC_SHELLSYNTAX;
         case INSPECT_ANNOCHECK:
             return DESC_ANNOCHECK;
-        case INSPECT_DT_NEEDED:
-            return DESC_DT_NEEDED;
+        case INSPECT_DSODEPS:
+            return DESC_DSODEPS;
         case INSPECT_FILESIZE:
             return DESC_FILESIZE;
         case INSPECT_PERMISSIONS:

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -26,7 +26,7 @@
 
 #include "rpminspect.h"
 
-static bool dt_needed_driver(struct rpminspect *ri, rpmfile_entry_t *file)
+static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool result = true;
     const char *bv = NULL;
@@ -102,8 +102,8 @@ static bool dt_needed_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_DT_NEEDED;
-    params.remedy = REMEDY_DT_NEEDED;
+    params.header = HEADER_DSODEPS;
+    params.remedy = REMEDY_DSODEPS;
     params.arch = arch;
     params.file = file->localpath;
 
@@ -217,23 +217,23 @@ done:
 }
 
 /*
- * Main driver for the 'DT_NEEDED' inspection.
+ * Main driver for the dsodeps inspection.
  */
-bool inspect_dt_needed(struct rpminspect *ri) {
+bool inspect_dsodeps(struct rpminspect *ri) {
     bool result;
     struct result_params params;
 
     assert(ri != NULL);
 
-    /* run the DT_NEEDED test across all ELF files */
-    result = foreach_peer_file(ri, dt_needed_driver, true);
+    /* run the dsodeps test across all ELF files */
+    result = foreach_peer_file(ri, dsodeps_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_DT_NEEDED;
+        params.header = HEADER_DSODEPS;
         add_result(ri, &params);
     }
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -37,7 +37,7 @@ librpminspect_sources = [
     'inspect_desktop.c',
     'inspect_disttag.c',
     'inspect_doc.c',
-    'inspect_dt_needed.c',
+    'inspect_dsodeps.c',
     'inspect_elf.c',
     'inspect_emptyrpm.c',
     'inspect_files.c',


### PR DESCRIPTION
Most of the inspections carry short lowercase names.  DT_NEEDED stood
out a bit and it looked weird to me, so I renamed it to dsodeps.