### PR TITLE
Rename 'LTO' inspection to 'lto'

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -98,7 +98,7 @@ vendor:
     #kmod: off
     #license: off
     #lostpayload: off
-    #LTO: off
+    #lto: off
     #manpage: off
     #metadata: off
     #modularity: off

--- a/include/results.h
+++ b/include/results.h
@@ -59,7 +59,7 @@
 #define HEADER_SUBPACKAGES   "subpackages"
 #define HEADER_CHANGELOG     "changelog"
 #define HEADER_PATHMIGRATION "path-migration"
-#define HEADER_LTO           "LTO"
+#define HEADER_LTO           "lto"
 #define HEADER_SYMLINKS      "symlinks"
 #define HEADER_FILES         "files"
 #define HEADER_TYPES         "types"

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -73,7 +73,7 @@ struct inspect inspections[] = {
     { INSPECT_SUBPACKAGES,   "subpackages",   false, &inspect_subpackages },
     { INSPECT_CHANGELOG,     "changelog",     false, &inspect_changelog },
     { INSPECT_PATHMIGRATION, "pathmigration", true,  &inspect_pathmigration },
-    { INSPECT_LTO,           "LTO",           true,  &inspect_lto },
+    { INSPECT_LTO,           "lto",           true,  &inspect_lto },
     { INSPECT_SYMLINKS,      "symlinks",      true,  &inspect_symlinks },
     { INSPECT_FILES,         "files",         true,  &inspect_files },
     { INSPECT_TYPES,         "types",         false, &inspect_types },

--- a/test/test_lto.py
+++ b/test/test_lto.py
@@ -43,7 +43,7 @@ class NoLTOSymbolsRelocRPMs(TestRPMs):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -57,7 +57,7 @@ class NoLTOSymbolsRelocKoji(TestKoji):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -71,7 +71,7 @@ class NoLTOSymbolsRelocCompareRPMs(TestCompareRPMs):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -85,7 +85,7 @@ class NoLTOSymbolsRelocCompareKoji(TestCompareKoji):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -110,7 +110,7 @@ class NoLTOSymbolsStaticLibRPMs(TestRPMs):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -134,7 +134,7 @@ class NoLTOSymbolsStaticLibKoji(TestKoji):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -158,7 +158,7 @@ class NoLTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -182,7 +182,7 @@ class NoLTOSymbolsStaticLibCompareKoji(TestCompareKoji):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -197,7 +197,7 @@ class LTOSymbolsRelocRPMs(TestRPMs):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -211,7 +211,7 @@ class LTOSymbolsRelocKoji(TestKoji):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -225,7 +225,7 @@ class LTOSymbolsRelocCompareRPMs(TestCompareRPMs):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -239,7 +239,7 @@ class LTOSymbolsRelocCompareKoji(TestCompareKoji):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -264,7 +264,7 @@ class LTOSymbolsStaticLibRPMs(TestRPMs):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -288,7 +288,7 @@ class LTOSymbolsStaticLibKoji(TestKoji):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -312,7 +312,7 @@ class LTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -336,6 +336,6 @@ class LTOSymbolsStaticLibCompareKoji(TestCompareKoji):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "LTO"
+        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
This was the last inspection named with all uppercase letters.  Rename
it using lowercase letters to fit in with the other inspection names.