### PR TITLE
No need to check value of allowed in permissions_driver()

### DIFF
--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -98,7 +98,7 @@ static bool permissions_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         result = false;
     }
 
-    return (result && allowed);
+    return result;
 }
 
 /*


### PR DESCRIPTION
Just return the result.  Without this, if permissions reports all INFO
results we will likely get a FAIL result for the inspection.