### PR TITLE
Fix RPMFILE_FLAGS handling for %config files (#221)

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <sys/capability.h>
 #include <rpm/rpmlib.h>
+#include <rpm/rpmfiles.h>
 #include <libkmod.h>
 #include "queue.h"
 
@@ -99,7 +100,7 @@ typedef struct _rpmfile_entry_t {
     char *type;
     char *checksum;
     cap_t cap;
-    uint64_t flags;
+    rpmfileAttrs flags;
     struct _rpmfile_entry_t *peer_file;
     bool moved_path;
     bool moved_subpackage;


### PR DESCRIPTION
A number of problems here.  Make sure we pick up the file flags
correctly when unpacking the payload.  Next, fix the 'config'
inspection so it performs the comparision only when the before and
after file carry RPMFILE_CONFIG flags, not when their flag check
values are equal.  Without this, it was scanning every file in the
package.  Add in some more protections to skip over non-regular files
and non-symlinks.