### PR TITLE
Include rpm/rpmfi.h insted of rpm/rpmfiles.h

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -30,7 +30,7 @@
 #include <sys/stat.h>
 #include <sys/capability.h>
 #include <rpm/rpmlib.h>
-#include <rpm/rpmfiles.h>
+#include <rpm/rpmfi.h>
 #include <libkmod.h>
 #include "queue.h"
 


### PR DESCRIPTION
rpmfiles.h does not exist in older releases of rpm, such as the
version in CentOS 7.  The types we needed are defined by including
rpmfi.h regardless of release, so make sure we do that.