### PR TITLE
Exclude man pages from the 'doc' inspection

### DIFF
--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -57,6 +57,15 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         return true;
     }
 
+    /*
+     * rpm marks man pages with RPMFILE_DOC, but we check those in the
+     * man page inspection.  Exclude them here.
+     */
+    if (process_file_path(file, ri->manpage_path_include, ri->manpage_path_exclude) ||
+        process_file_path(file->peer_file, ri->manpage_path_include, ri->manpage_path_exclude)) {
+        return true;
+    }
+
     /* the package name is used for reporting */
     name = headerGetString(file->rpm_header, RPMTAG_NAME);
 


### PR DESCRIPTION
rpm marks man pages with RPMFILE_DOC, but we check man pages in the
'manpage' inspection so there's really no need to also check them in
the 'doc' inspection.  Exclude man pages here based on path matching
since there isn't anything like RPMFILE_MAN or something that we could
key off of.