### PR TITLE
Honor the -a command line option for downloads as well as runtime (#233)

### DIFF
--- a/lib/arches.c
+++ b/lib/arches.c
@@ -77,3 +77,30 @@ void init_arches(struct rpminspect *ri)
 
     return;
 }
+
+/*
+ * Checks an RPM architecture against the user-specified list.
+ * If the user did not specify a list of architectures, return
+ * true.  If the user specified a list, only return true if the
+ * RPM architecture is in the specified list.  The function
+ * returns false if the architecture is not allowed.
+ */
+bool allowed_arch(const struct rpminspect *ri, const char *rpmarch)
+{
+    string_entry_t *arch = NULL;
+
+    assert(ri != NULL);
+    assert(rpmarch != NULL);
+
+    if (ri->arches == NULL) {
+        return true;
+    }
+
+    TAILQ_FOREACH(arch, ri->arches, items) {
+        if (!strcmp(rpmarch, arch->data)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -1227,30 +1227,3 @@ string_list_t *get_all_arches(const struct rpminspect *ri)
 
     return arches;
 }
-
-/*
- * Checks an RPM architecture against the user-specified list.
- * If the user did not specify a list of architectures, return
- * true.  If the user specified a list, only return true if the
- * RPM architecture is in the specified list.  The function
- * returns false if the architecture is not allowed.
- */
-bool allowed_arch(const struct rpminspect *ri, const char *rpmarch)
-{
-    string_entry_t *arch = NULL;
-
-    assert(ri != NULL);
-    assert(rpmarch != NULL);
-
-    if (ri->arches == NULL) {
-        return true;
-    }
-
-    TAILQ_FOREACH(arch, ri->arches, items) {
-        if (!strcmp(rpmarch, arch->data)) {
-            return true;
-        }
-    }
-
-    return false;
-}


### PR DESCRIPTION
rpminspect has had the -a option to restrict the architectures
examined during a run.  However, that was limited to the peer
detection code and not the download code.  rpminspect would still
always download every architecture and then later make the decision as
to whether or not to use it.  This patch extends the -a handling to
the download side so it covers downloading (or copying in the case of
locally cached builds) and peer detection.