### PR TITLE
Allow optional 'commands' block in the config file

### DIFF
--- a/TODO
+++ b/TODO
@@ -32,9 +32,6 @@ Other:
     - Unify the error and debug reporting using consistent functions
       and messaging.  (e.g., warn() and err())
 
-    - Add a section to the configuration file to specify external
-      commands and their full paths.
-
 
 Test categories that have been migrated:
 ----------------------------------------

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -29,6 +29,32 @@ koji:
     # The download URL for modular packages built in Koji
     download_mbs: http://download.example.com/downloadroot
 
+commands:
+    # External helper commands used by rpminspect.  Defaults are noted.
+
+    # diff(1) command, must support -u, -w, and -I options as defined
+    # in GNU diff.
+    #diff: /usr/bin/diff
+
+    # diffstat(1) command.
+    # https://invisible-island.net/diffstat/
+    #diffstat: /usr/bin/diffstat
+
+    # msgunfmt(1) as found in GNU gettext
+    #msgunfmt: /usr/bin/msgunfmt
+
+    # desktop-file-validate(1) from the desktop-file-utils project at
+    # Freedesktop.org
+    #desktop-file-validate: /usr/bin/desktop-file-validate
+
+    # annocheck(1) from the annobin project:
+    # https://sourceware.org/git/annobin.git
+    #annocheck: /usr/bin/annocheck
+
+    # abidiff(1) and kmidiff(1) from libabigail
+    #abidiff: /usr/bin/abidiff
+    #kmidiff: /usr/bin/kmidiff
+
 vendor:
     # Where the vendor data files can be found.  The
     # rpminspect-data-generic package provides a template of where

--- a/include/types.h
+++ b/include/types.h
@@ -294,6 +294,17 @@ typedef enum _politics_field_t {
     PERMISSION = 2,
 } politics_field_t;
 
+/* Commands used by rpminspect at runtime. */
+struct command_paths {
+    char *diff;
+    char *diffstat;
+    char *msgunfmt;
+    char *desktop_file_validate;
+    char *annocheck;
+    char *abidiff;
+    char *kmidiff;
+};
+
 /*
  * Configuration and state instance for librpminspect run.
  * Applications using librpminspect should initialize the
@@ -305,6 +316,9 @@ struct rpminspect {
     char *workdir;             /* full path to working directory */
     char *profiledir;          /* full path to profiles directory */
     char *worksubdir;          /* within workdir, where these builds go */
+
+    /* Commands */
+    struct command_paths commands;
 
     /* Vendor data */
     char *vendor_data_dir;     /* main vendor data directory */

--- a/lib/free.c
+++ b/lib/free.c
@@ -159,6 +159,15 @@ void free_rpminspect(struct rpminspect *ri) {
 
     free(ri->desktop_entry_files_dir);
     free(ri->vendor);
+
+    free(ri->commands.diff);
+    free(ri->commands.diffstat);
+    free(ri->commands.msgunfmt);
+    free(ri->commands.desktop_file_validate);
+    free(ri->commands.annocheck);
+    free(ri->commands.abidiff);
+    free(ri->commands.kmidiff);
+
     list_free(ri->buildhost_subdomain, free);
     list_free(ri->security_path_prefix, free);
     list_free(ri->header_file_extensions, free);

--- a/lib/init.c
+++ b/lib/init.c
@@ -73,6 +73,7 @@ enum {
     BLOCK_BIN_PATHS,
     BLOCK_BUILDHOST_SUBDOMAIN,
     BLOCK_CHANGEDFILES,
+    BLOCK_COMMANDS,
     BLOCK_COMMON,
     BLOCK_DESKTOP,
     BLOCK_ELF,
@@ -497,6 +498,8 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         block = BLOCK_KOJI;
                     } else if (!strcmp(key, "vendor")) {
                         block = BLOCK_VENDOR;
+                    } else if (!strcmp(key, "commands")) {
+                        block = BLOCK_COMMANDS;
                     } else if (!strcmp(key, "inspections")) {
                         block = BLOCK_INSPECTIONS;
                     } else if (!strcmp(key, "products")) {
@@ -617,6 +620,29 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         } else if (!strcmp(key, "download_mbs")) {
                             free(ri->kojimbs);
                             ri->kojimbs = strdup(t);
+                        }
+                    } else if (block == BLOCK_COMMON) {
+                        if (!strcmp(key, "diff")) {
+                            free(ri->commands.diff);
+                            ri->commands.diff = strdup(t);
+                        } else if (!strcmp(key, "diffstat")) {
+                            free(ri->commands.diffstat);
+                            ri->commands.diffstat = strdup(t);
+                        } else if (!strcmp(key, "msgunfmt")) {
+                            free(ri->commands.msgunfmt);
+                            ri->commands.msgunfmt = strdup(t);
+                        } else if (!strcmp(key, "desktop-file-validate")) {
+                            free(ri->commands.desktop_file_validate);
+                            ri->commands.desktop_file_validate = strdup(t);
+                        } else if (!strcmp(key, "annocheck")) {
+                            free(ri->commands.annocheck);
+                            ri->commands.annocheck = strdup(t);
+                        } else if (!strcmp(key, "abidiff")) {
+                            free(ri->commands.abidiff);
+                            ri->commands.abidiff = strdup(t);
+                        } else if (!strcmp(key, "kmidiff")) {
+                            free(ri->commands.kmidiff);
+                            ri->commands.kmidiff = strdup(t);
                         }
                     } else if (group == BLOCK_METADATA) {
                         /*
@@ -1350,6 +1376,15 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         ri->kmidiff_debuginfo_path = strdup(DEBUG_PATH);
         ri->patch_file_threshold = DEFAULT_PATCH_FILE_THRESHOLD;
         ri->patch_line_threshold = DEFAULT_PATCH_LINE_THRESHOLD;
+
+        /* Initialize commands */
+        ri->commands.diff = strdup(DIFF_CMD);
+        ri->commands.diffstat = strdup(DIFFSTAT_CMD);
+        ri->commands.msgunfmt = strdup(MSGUNFMT_CMD);
+        ri->commands.desktop_file_validate = strdup(DESKTOP_FILE_VALIDATE_CMD);
+        ri->commands.annocheck = strdup(ANNOCHECK_CMD);
+        ri->commands.abidiff = strdup(ABIDIFF_CMD);
+        ri->commands.kmidiff = strdup(KMIDIFF_CMD);
 
         /* Store full paths to all config files read */
         ri->cfgfiles = calloc(1, sizeof(*ri->cfgfiles));

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -250,7 +250,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
         xasprintf(&details, _("Command: %s"), cmd);
         params.msg = _("ABI comparison ended unexpectedly.");
         params.verb = VERB_FAILED;
-        params.noun = ABIDIFF_CMD;
+        params.noun = ri->commands.abidiff;
         report = true;
     } else {
         status = WEXITSTATUS(exitcode);
@@ -258,7 +258,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
         if ((status & ABIDIFF_ERROR) || (status & ABIDIFF_USAGE_ERROR)) {
             params.severity = RESULT_VERIFY;
             params.verb = VERB_FAILED;
-            params.noun = ABIDIFF_CMD;
+            params.noun = ri->commands.abidiff;
             report = true;
         }
 
@@ -355,7 +355,7 @@ bool inspect_abidiff(struct rpminspect *ri) {
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
-    entry->data = strdup(ABIDIFF_CMD);
+    entry->data = strdup(ri->commands.abidiff);
     TAILQ_INSERT_TAIL(firstargs, entry, items);
 
     if (ri->abidiff_extra_args) {

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -86,9 +86,9 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         /* Run the test on the file */
         if (get_after_debuginfo_path(ri, arch) == NULL) {
-            xasprintf(&cmd, "%s %s %s", ANNOCHECK_CMD, (char *) eptr->data, file->fullpath);
+            xasprintf(&cmd, "%s %s %s", ri->commands.annocheck, (char *) eptr->data, file->fullpath);
         } else {
-            xasprintf(&cmd, "%s %s --debug-dir=%s %s", ANNOCHECK_CMD, (char *) eptr->data, get_after_debuginfo_path(ri, arch), file->fullpath);
+            xasprintf(&cmd, "%s %s --debug-dir=%s %s", ri->commands.annocheck, (char *) eptr->data, get_after_debuginfo_path(ri, arch), file->fullpath);
         }
 
         DEBUG_PRINT("%s\n", cmd);
@@ -98,9 +98,9 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         /* If we have a before build, run the command on that */
         if (file->peer_file) {
             if (get_before_debuginfo_path(ri, arch) == NULL) {
-                xasprintf(&cmd, "%s %s %s", ANNOCHECK_CMD, (char *) eptr->data, file->peer_file->fullpath);
+                xasprintf(&cmd, "%s %s %s", ri->commands.annocheck, (char *) eptr->data, file->peer_file->fullpath);
             } else {
-                xasprintf(&cmd, "%s %s --debug-dir=%s %s", ANNOCHECK_CMD, (char *) eptr->data, get_before_debuginfo_path(ri, arch), file->peer_file->fullpath);
+                xasprintf(&cmd, "%s %s --debug-dir=%s %s", ri->commands.annocheck, (char *) eptr->data, get_before_debuginfo_path(ri, arch), file->peer_file->fullpath);
             }
 
             DEBUG_PRINT("%s\n", cmd);

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -272,7 +272,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
          */
 
         /* First, unformat the mo files */
-        params.details = run_and_capture(ri->workdir, &after_tmp, MSGUNFMT_CMD, file->fullpath, &exitcode);
+        params.details = run_and_capture(ri->workdir, &after_tmp, ri->commands.msgunfmt, file->fullpath, &exitcode);
 
         if (exitcode) {
             xasprintf(&params.msg, _("Error running msgunfmt on %s on %s"), file->localpath, arch);
@@ -286,7 +286,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             goto done;
         }
 
-        params.details = run_and_capture(ri->workdir, &before_tmp, MSGUNFMT_CMD, file->peer_file->fullpath, &exitcode);
+        params.details = run_and_capture(ri->workdir, &before_tmp, ri->commands.msgunfmt, file->peer_file->fullpath, &exitcode);
 
         if (exitcode) {
             xasprintf(&params.msg, _("Error running msgunfmt on %s on %s"), file->peer_file->localpath, arch);
@@ -301,7 +301,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
 
         /* Now diff the mo content */
-        params.details = run_cmd(&exitcode, DIFF_CMD, "-u", before_tmp, after_tmp, NULL);
+        params.details = run_cmd(&exitcode, ri->commands.diff, "-u", before_tmp, after_tmp, NULL);
 
         /* Remove the temporary files */
         if (unlink(before_tmp) == -1) {
@@ -343,7 +343,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     if (!strcmp(type, "text/x-c") && possible_header) {
         /* Now diff the header content */
-        errors = run_cmd(&exitcode, DIFF_CMD, "-u", "-w", "--label", file->localpath, file->peer_file->fullpath, file->fullpath, NULL);
+        errors = run_cmd(&exitcode, ri->commands.diff, "-u", "-w", "--label", file->localpath, file->peer_file->fullpath, file->fullpath, NULL);
 
         if (exitcode) {
             /*

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -238,7 +238,7 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     /* Compare the changelogs */
     if (before_output && after_output) {
-        diff_output = run_cmd(&exitcode, DIFF_CMD, "-u", before_output, after_output, NULL);
+        diff_output = run_cmd(&exitcode, ri->commands.diff, "-u", before_output, after_output, NULL);
     }
 
     /* Set up result parameters */
@@ -360,7 +360,7 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     /* Compare the changelogs */
     if (before_output && after_output) {
-        diff_output = run_cmd(&exitcode, DIFF_CMD, "-u", before_output, after_output, NULL);
+        diff_output = run_cmd(&exitcode, ri->commands.diff, "-u", before_output, after_output, NULL);
     }
 
     /* Set up result parameters */

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -163,7 +163,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             if (exitcode) {
                 /* the files differ and not a rebase, see if it's only whitespace changes */
                 free(diff_output);
-                params.details = run_cmd(&exitcode, DIFF_CMD, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
+                params.details = run_cmd(&exitcode, ri->commands.diff, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
 
                 if (exitcode == 0) {
                     xasprintf(&params.msg, _("%%config file content change for %s in %s on %s (comments/whitespace only)"), file->localpath, name, arch);

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -317,14 +317,14 @@ static bool desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
 
     /* Validate the desktop file */
-    params.details = run_cmd(&after_code, DESKTOP_FILE_VALIDATE_CMD, file->fullpath, NULL);
+    params.details = run_cmd(&after_code, ri->commands.desktop_file_validate, file->fullpath, NULL);
     tmpbuf = strreplace(params.details, file->fullpath, file->localpath);
     free(params.details);
     params.details = tmpbuf;
 
     if (file->peer_file && is_desktop_entry_file(ri->desktop_entry_files_dir, file->peer_file)) {
         /* if we have a before peer, validate the corresponding desktop file */
-        before_out = run_cmd(NULL, DESKTOP_FILE_VALIDATE_CMD, file->peer_file->fullpath, NULL);
+        before_out = run_cmd(NULL, ri->commands.desktop_file_validate, file->peer_file->fullpath, NULL);
         tmpbuf = strreplace(before_out, file->peer_file->fullpath, file->peer_file->localpath);
         free(before_out);
         before_out = tmpbuf;

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -105,7 +105,7 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (exitcode) {
             /* the files differ, see if it's only whitespace changes */
             free(diff_output);
-            diff_output = run_cmd(&exitcode, DIFF_CMD, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
+            diff_output = run_cmd(&exitcode, ri->commands.diff, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
 
             /* always report content changes on %doc files as INFO */
             params.severity = RESULT_INFO;

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -308,7 +308,7 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         xasprintf(&details, _("Command: %s"), cmd);
         params.msg = _("KMI comparison ended unexpectedly.");
         params.verb = VERB_FAILED;
-        params.noun = KMIDIFF_CMD;
+        params.noun = ri->commands.kmidiff;
         report = true;
     } else {
         status = WEXITSTATUS(exitcode);
@@ -316,7 +316,7 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if ((status & ABIDIFF_ERROR) || (status & ABIDIFF_USAGE_ERROR)) {
             params.severity = RESULT_VERIFY;
             params.verb = VERB_FAILED;
-            params.noun = KMIDIFF_CMD;
+            params.noun = ri->commands.kmidiff;
             report = true;
         }
 
@@ -400,7 +400,7 @@ bool inspect_kmidiff(struct rpminspect *ri) {
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
-    entry->data = strdup(KMIDIFF_CMD);
+    entry->data = strdup(ri->commands.kmidiff);
     TAILQ_INSERT_TAIL(firstargs, entry, items);
 
     if (ri->kmidiff_extra_args) {

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -230,13 +230,13 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
      * This just reports patches that change content.  It uses the INFO reporting level.
      */
     if (comparison && file->peer_file) {
-        params.details = run_cmd(&exitcode, DIFF_CMD, "-q", before_patch, after_patch, NULL);
+        params.details = run_cmd(&exitcode, ri->commands.diff, "-q", before_patch, after_patch, NULL);
         free(params.details);
         params.details = NULL;
 
         if (exitcode) {
             /* the files differ, see if it's only whitespace changes */
-            params.details = run_cmd(&exitcode, DIFF_CMD, "-u", "-w", "-I^#.*", before_patch, after_patch, NULL);
+            params.details = run_cmd(&exitcode, ri->commands.diff, "-u", "-w", "-I^#.*", before_patch, after_patch, NULL);
 
             if (exitcode) {
                 /* more than whitespace changed */
@@ -280,7 +280,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /*
      * Collect diffstat(1) data and report based on thresholds.
      */
-    params.details = run_cmd(&exitcode, DIFFSTAT_CMD, after_patch, NULL);
+    params.details = run_cmd(&exitcode, ri->commands.diffstat, after_patch, NULL);
 
     if (exitcode == 0 && params.details != NULL) {
         ds = get_diffstat_counts(params.details);
@@ -311,7 +311,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             result = !(params.severity >= RESULT_VERIFY);
         }
     } else if (exitcode) {
-        warn("unable to run %s on %s", DIFFSTAT_CMD, file->localpath);
+        warn("unable to run %s on %s", ri->commands.diffstat, file->localpath);
         free(params.details);
         params.details = NULL;
     }

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -97,7 +97,7 @@ static bool upstream_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (strcmp(before_sum, after_sum)) {
             /* capture 'diff -u' output for text files */
             if (is_text_file(file->peer_file) && is_text_file(file)) {
-                diff_head = diff_output = run_cmd(&exitcode, DIFF_CMD, "-u", file->peer_file->fullpath, file->fullpath, NULL);
+                diff_head = diff_output = run_cmd(&exitcode, ri->commands.diff, "-u", file->peer_file->fullpath, file->fullpath, NULL);
 
                 /* skip the two leading lines */
                 if (strprefix(diff_head, "--- ")) {


### PR DESCRIPTION
This is a new feature allowing runtime overrides of the userspace
tools that rpminspect invokes.  There are default command names in the
code if you do not define the settings, but if you need to refer to
one of these tools in a different installed location, you can.