### PR TITLE
Prevent invalid pointer dereferencing in invalid result in 'patches' …

### DIFF
--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -358,6 +358,7 @@ bool inspect_patches(struct rpminspect *ri)
         xasprintf(&params.msg, _("No source packages available, skipping inspection."));
         add_result(ri, &params);
         free(params.msg);
+        reported = true;
         return result;
     }
 
@@ -400,6 +401,7 @@ bool inspect_patches(struct rpminspect *ri)
                     xasprintf(&params.msg, _("Patch file `%s` removed"), file->localpath);
                     add_result(ri, &params);
                     free(params.msg);
+                    reported = true;
                     result = !(params.severity >= RESULT_VERIFY);
                 }
             }
@@ -408,9 +410,10 @@ bool inspect_patches(struct rpminspect *ri)
 
     /* Sound the everything-is-ok alarm if everything is, in fact, ok */
     if (result && !reported) {
+        init_result_params(&params);
+        params.header = HEADER_PATCHES;
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.remedy = NULL;
         add_result(ri, &params);
     }
 


### PR DESCRIPTION
…(#245)

The patches inspection was not correctly noting when all of the
results were reported so the fall-through 'OK' result was output as
the last result.  However it would hand an invalid pointer in the
params struct to libjson-c and that caused garbage in the output.

This patch prevents that bogus OK message but also ensures any
reporting of that OK message in the future avoids garbage strings.