### PR TITLE
Allow a set of excluded path prefixes in 'pathmigration'

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -437,6 +437,11 @@ pathmigration:
     - /lib: /usr/lib
     - /lib64: /usr/lib64
 
+    # All rules have exceptions.  List paths here to exclude from the
+    # pathmigration rules.
+    excluded_paths:
+        - /lib/modules
+
 files:
     # %files sections in spec files.  Some checks are performed on
     # these sections.  The settings here control those checks.

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -432,10 +432,11 @@ pathmigration:
     #
     # Any package containing a file in /bin will have a failure
     # reporting that file should be in /usr/bin.
-    - /bin: /usr/bin
-    - /sbin: /usr/sbin
-    - /lib: /usr/lib
-    - /lib64: /usr/lib64
+    migrated_paths:
+        - /bin:   /usr/bin
+        - /sbin:  /usr/sbin
+        - /lib:   /usr/lib
+        - /lib64: /usr/lib64
 
     # All rules have exceptions.  List paths here to exclude from the
     # pathmigration rules.

--- a/include/types.h
+++ b/include/types.h
@@ -426,6 +426,7 @@ struct rpminspect {
     /* hash table of path migrations */
     struct hsearch_data *pathmigration;
     string_list_t *pathmigration_keys;
+    string_list_t *pathmigration_excluded_paths;
 
     /* hash table of product release regexps */
     struct hsearch_data *products;

--- a/lib/free.c
+++ b/lib/free.c
@@ -192,6 +192,7 @@ void free_rpminspect(struct rpminspect *ri) {
     free_mapping(ri->jvm, ri->jvm_keys);
     free_mapping(ri->annocheck, ri->annocheck_keys);
     free_mapping(ri->pathmigration, ri->pathmigration_keys);
+    list_free(ri->pathmigration_excluded_paths, free);
     free_mapping(ri->products, ri->product_keys);
     list_free(ri->ignores, free);
     list_free(ri->lto_symbol_name_prefixes, free);

--- a/lib/init.c
+++ b/lib/init.c
@@ -101,6 +101,7 @@ enum {
     BLOCK_PATCHES,
     BLOCK_PATCH_FILENAMES,
     BLOCK_PATHMIGRATION,
+    BLOCK_PATHMIGRATION_EXCLUDED_PATHS,
     BLOCK_PRODUCTS,
     BLOCK_SECURITY_PATH_PREFIX,
     BLOCK_SHELLS,
@@ -566,6 +567,8 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         block = BLOCK_JAVABYTECODE;
                     } else if (!strcmp(key, "pathmigration")) {
                         block = BLOCK_PATHMIGRATION;
+                    } else if (block == BLOCK_PATHMIGRATION && !strcmp(key, "excluded_paths")) {
+                        block = BLOCK_PATHMIGRATION_EXCLUDED_PATHS;
                     } else if (!strcmp(key, "files")) {
                         group = BLOCK_FILES;
                     } else if (group == BLOCK_FILES && !strcmp(key, "forbidden_paths")) {
@@ -915,6 +918,8 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         add_entry(&ri->kernel_filenames, t);
                     } else if (block == BLOCK_PATCH_FILENAMES) {
                         add_entry(&ri->patch_ignore_list, t);
+                    } else if (block == BLOCK_PATHMIGRATION_EXCLUDED_PATHS) {
+                        add_entry(&ri->pathmigration_excluded_paths, t);
                     }
                 }
 


### PR DESCRIPTION
Expand the 'pathmigration' inspection to support path exclusions.  For
example, the kernel package may deliver modules in /lib/modules.  We
may not want rpminspect to warn about modules needing to be in
/usr/lib even if we have set up the rules to warn about libraries in
/lib.  The path exclusions are flexible enough to handle those cases.

The pathmigration section of the configuration file can now have a
block called 'excluded_paths' which lists the excluded path prefixes.
All paths listed must end with a '/'.  rpminspect will add one if it
does not see one at the end of the prefix.  This is to avoid something
like "/lib/modules" matching
"/lib/modulessddfgwerqwefwercver/oopsfile" and ignoring it.