### PR TITLE
[fix] Correctly handle the -w option on rpminspect(1) (#256)

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -440,28 +440,6 @@ int main(int argc, char **argv) {
                     }
 
                     globfree(&expand);
-                } else if (index(optarg, '/') == NULL && (!strprefix(optarg, "./") || !strprefix(optarg, "../"))) {
-                    /* relative path specified with no leading dir spec */
-
-                    /* get current dir */
-                    memset(cwd, '\0', sizeof(cwd));
-                    r = getcwd(cwd, PATH_MAX);
-                    assert(r != NULL);
-
-                    /* combine current dir and option */
-                    xasprintf(&tmp, "%s/%s", r, optarg);
-                    assert(tmp != NULL);
-
-                    /* canonicalize the path if it exists */
-                    if (stat(tmp, &sbuf) == 0) {
-                        workdir = realpath(tmp, NULL);
-                        free(tmp);
-                    } else {
-                        workdir = tmp;
-                    }
-
-                    /* clean up */
-                    tmp = NULL;
                 } else {
                     /* canonicalize the path specified if it exists */
                     if (stat(optarg, &sbuf) == 0) {


### PR DESCRIPTION
Fix two problems with the -w option on rpminspect(1)

1) The test within the '-w' option handler to pick up relative
directory paths was incorrect.  Relative directory paths start with
../ or ./.  The test was missing an extra set of parentheses.

2) The use of realpath(3) in the '-w' option handler should only be
used if the directory specified exists.  Otherwise take the path as
specified by the user and let the mkdirp() call handle it
gather_builds().