### PR TITLE
[ci] Build and install 'rc' from source on opensuse-leap

### DIFF
--- a/osdeps/opensuse-leap/reqs.txt
+++ b/osdeps/opensuse-leap/reqs.txt
@@ -13,6 +13,7 @@ gettext-tools
 git
 glibc-devel-32bit
 html-dtd
+html2text
 kernel-default-devel
 kernel-devel
 ksh


### PR DESCRIPTION
opensuse-leap lacks an installable package for the 'rc' shell.  What I
was doing was fetching it from Fedora's RPM repos, then using rpm2cpio
to unpack the package manually and just copy the 'rc' executable in
place.  This is failing now because of generally yum unpleasantries.
Since rc is small, just download the source from Debian and build it
within the instance.  I'm already doing that for mandoc, so I can do
that for rc.