### PR TITLE
[ci] Adjust curl(1) command line used for 'rc' in opensuse CI jobs

### DIFF
--- a/osdeps/opensuse-leap/post.sh
+++ b/osdeps/opensuse-leap/post.sh
@@ -32,8 +32,8 @@ rm -rf mandoc.tar.gz ${SUBDIR}
 # Download 'rc' source from Debian and build it locally
 # OpenSUSE Leap lacks the rc shell as an installable package
 RC_URL=http://ftp.debian.org/debian/pool/main/r/rc/
-ARCHIVE="$(curl -o - ${RC_URL} | html2text | grep "\.orig\.tar" | cut -d '[' -f 2 | cut -d ']' -f 1 | sort -u | tail -n 1)"
-curl -O ${RC_URL}/${ARCHIVE}
+ARCHIVE="$(curl -s -L ${RC_URL} | html2text | grep "\.orig\.tar" | cut -d '[' -f 2 | cut -d ']' -f 1 | sort -u | tail -n 1)"
+curl -O -L ${RC_URL}/${ARCHIVE}
 SUBDIR="$(tar -tvf ${ARCHIVE} | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 cd ${SUBDIR}
 ./configure --prefix=/usr/local

--- a/osdeps/opensuse-tumbleweed/post.sh
+++ b/osdeps/opensuse-tumbleweed/post.sh
@@ -38,8 +38,8 @@ rm -rf mandoc.tar.gz ${SUBDIR}
 # Download 'rc' source from Debian and build it locally
 # OpenSUSE Leap lacks the rc shell as an installable package
 RC_URL=http://ftp.debian.org/debian/pool/main/r/rc/
-ARCHIVE="$(curl -o - ${RC_URL} | html2text | grep "\.orig\.tar" | cut -d '[' -f 2 | cut -d ']' -f 1 | sort -u | tail -n 1)"
-curl -O ${RC_URL}/${ARCHIVE}
+ARCHIVE="$(curl -s -L ${RC_URL} | html2text | grep "\.orig\.tar" | cut -d '[' -f 2 | cut -d ']' -f 1 | sort -u | tail -n 1)"
+curl -O -L ${RC_URL}/${ARCHIVE}
 SUBDIR="$(tar -tvf ${ARCHIVE} | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 cd ${SUBDIR}
 ./configure --prefix=/usr/local


### PR DESCRIPTION
Suppress the curl progress output and use -L so any redirects are
followed.