### PR TITLE
[ci] s/PowerTools/powertools/g in the centos8 PKG_CMD definition

### DIFF
--- a/osdeps/centos8/defs.mk
+++ b/osdeps/centos8/defs.mk
@@ -1,2 +1,2 @@
-PKG_CMD = dnf --enablerepo=PowerTools install -y
+PKG_CMD = dnf --enablerepo=powertools install -y
 PIP_CMD = pip-3 install -I


### PR DESCRIPTION
CentOS 8 has renamed the 'PowerTools' repo to 'powertools'.  Still the
same thing.  Keeping the previous name would have also been useful.
Or patching dnf to be case-insensitive on repo names.