### PR TITLE
[ci] The output of html2text on opensuse systems is different

### DIFF
--- a/osdeps/opensuse-leap/post.sh
+++ b/osdeps/opensuse-leap/post.sh
@@ -31,17 +31,22 @@ rm -rf mandoc.tar.gz ${SUBDIR}
 
 # Download 'rc' source from Debian and build it locally
 # OpenSUSE Leap lacks the rc shell as an installable package
+#
+# NOTE: The ARCHIVE= line depends on the output of html2text.  You
+# must ensure you are looking at the output on the target system.  The
+# default html2text output on Fedora is not the same as what you see
+# on OpenSUSE, for instance.
 RC_URL=http://ftp.debian.org/debian/pool/main/r/rc
-curl -s -L ${RC_URL} | html2text > filelist
-ARCHIVE="$(grep "\.orig\.tar" filelist | cut -d '[' -f 2 | cut -d ']' -f 1 | sort -u | tail -n 1)"
+ARCHIVE="$(curl -s -L ${RC_URL} | html2text | grep "\.orig\.tar" | awk '{ print $3; }' | sort -u | tail -n 1)"
 curl -O -L ${RC_URL}/${ARCHIVE}
 SUBDIR="$(tar -tvf ${ARCHIVE} | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
+tar -xvf ${ARCHIVE}
 cd ${SUBDIR}
 ./configure --prefix=/usr/local
 make
 make install
 cd ${CWD}
-rm -rf ${ARCHIVE} ${SUBDIR} filelist
+rm -rf ${ARCHIVE} ${SUBDIR}
 
 # Update the clamav database
 freshclam

--- a/osdeps/opensuse-tumbleweed/post.sh
+++ b/osdeps/opensuse-tumbleweed/post.sh
@@ -35,12 +35,18 @@ make lib-install
 cd ${CWD}
 rm -rf mandoc.tar.gz ${SUBDIR}
 
-# Download 'rc' source from Debian and build it locally
-# OpenSUSE Leap lacks the rc shell as an installable package
-RC_URL=http://ftp.debian.org/debian/pool/main/r/rc/
-ARCHIVE="$(curl -s -L ${RC_URL} | html2text | grep "\.orig\.tar" | cut -d '[' -f 2 | cut -d ']' -f 1 | sort -u | tail -n 1)"
+# Download 'rc' source from Debian and build it locally OpenSUSE Leap
+# lacks the rc shell as an installable package
+#
+# NOTE: The ARCHIVE= line depends on the output of html2text.  You
+# must ensure you are looking at the output on the target system.  The
+# default html2text output on Fedora is not the same as what you see
+# on OpenSUSE, for instance.
+RC_URL=http://ftp.debian.org/debian/pool/main/r/rc
+ARCHIVE="$(curl -s -L ${RC_URL} | html2text | grep "\.orig\.tar" | awk '{ print $3; }' | sort -u | tail -n 1)"
 curl -O -L ${RC_URL}/${ARCHIVE}
 SUBDIR="$(tar -tvf ${ARCHIVE} | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
+tar -xvf ${ARCHIVE}
 cd ${SUBDIR}
 ./configure --prefix=/usr/local
 make


### PR DESCRIPTION
The output of html2text is different on opensuse-leap and
opensuse-tumbleweed than it is Fedora, so the same ridiculous
pipelines cannot be used between the two systems.