### PR TITLE
[fix] Skip debug packages in 'filesize', display changes correctly

### DIFF
--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
+ * Copyright (C) 2019-2021  Red Hat, Inc.
  * Author(s):  David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
@@ -20,6 +20,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 #include <errno.h>
@@ -44,6 +45,11 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Ignore files in the SRPM */
     if (headerIsSource(file->rpm_header)) {
+        return true;
+    }
+
+    /* Ignore debug and build paths */
+    if (is_debug_or_build_path(file->localpath)) {
         return true;
     }
 
@@ -100,11 +106,11 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (change > 0) {
             /* file grew */
-            xasprintf(&params.msg, _("%s grew by +%ld%% on %s"), file->localpath, change, arch);
+            xasprintf(&params.msg, _("%s grew by %ld%% on %s"), file->localpath, labs(change), arch);
             params.noun = _("${FILE} size grew");
         } else if (change < 0) {
             /* file shrank */
-            xasprintf(&params.msg, _("%s shrank by %ld%% on %s"), file->localpath, change, arch);
+            xasprintf(&params.msg, _("%s shrank by %ld%% on %s"), file->localpath, labs(change), arch);
             params.noun = _("${FILE} size shrank");
         }
     }

--- a/test/test_filesize.py
+++ b/test/test_filesize.py
@@ -40,7 +40,7 @@ class FileSizeGrowsAtThreshold(TestCompareRPMs):
         self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
-        self.message = f"/some/file grew by +20% on {platform.machine()}"
+        self.message = f"/some/file grew by 20% on {platform.machine()}"
 
 
 class FileSizeGrowsAboveThreshold(TestCompareRPMs):
@@ -61,7 +61,7 @@ class FileSizeGrowsAboveThreshold(TestCompareRPMs):
         self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
-        self.message = f"/some/file grew by +100% on {platform.machine()}"
+        self.message = f"/some/file grew by 100% on {platform.machine()}"
 
 
 class FileSizeGrowsBelowThreshold(TestCompareRPMs):
@@ -81,7 +81,7 @@ class FileSizeGrowsBelowThreshold(TestCompareRPMs):
         self.label = "filesize"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
-        self.message = f"/some/file grew by +10% on {platform.machine()}"
+        self.message = f"/some/file grew by 10% on {platform.machine()}"
 
 
 class EmptyFileSizeGrows(TestCompareRPMs):
@@ -121,7 +121,7 @@ class FileSizeShrinksAtThreshold(TestCompareRPMs):
         self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
-        self.message = f"/some/file shrank by -20% on {platform.machine()}"
+        self.message = f"/some/file shrank by 20% on {platform.machine()}"
 
 
 class FileSizeShrinksAboveThreshold(TestCompareRPMs):
@@ -141,7 +141,7 @@ class FileSizeShrinksAboveThreshold(TestCompareRPMs):
         self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
-        self.message = f"/some/file shrank by -80% on {platform.machine()}"
+        self.message = f"/some/file shrank by 80% on {platform.machine()}"
 
 
 class FileSizeShrinksBelowThreshold(TestCompareRPMs):
@@ -161,7 +161,7 @@ class FileSizeShrinksBelowThreshold(TestCompareRPMs):
         self.label = "filesize"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
-        self.message = f"/some/file shrank by -10% on {platform.machine()}"
+        self.message = f"/some/file shrank by 10% on {platform.machine()}"
 
 
 class FileSizeShrinksToEmpty(TestCompareRPMs):


### PR DESCRIPTION
No need to check size changes on debug package files.  When displaying
the percentage change, show the absolute value and exclude the + or -
sign.