### PR TITLE
[lib] Add abspath() to canonicalize path strings

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -386,4 +386,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
 /* filecmp.c */
 int filecmp(const char *x, const char *y);
 
+/* abspath.c */
+char *abspath(const char *path);
+
 #endif

--- a/lib/abspath.c
+++ b/lib/abspath.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <limits.h>
+
+#include "rpminspect.h"
+
+/*
+ * Canonicalize a path with relative references.  Does not rely on
+ * filesystem existence.  Caller must free the returned string.
+ */
+char *abspath(const char *path)
+{
+    char *r = NULL;
+    char *p = NULL;
+    string_list_t *tokens = NULL;
+    string_list_t *newpath = NULL;
+    string_entry_t *token = NULL;
+    string_entry_t *element = NULL;
+
+    if (path == NULL) {
+        return NULL;
+    }
+
+    /* split path in to tokens */
+    tokens = strsplit(path, "/");
+    assert(tokens != NULL);
+
+    /* our new path elements */
+    newpath = calloc(1, sizeof(*newpath));
+    assert(newpath != NULL);
+    TAILQ_INIT(newpath);
+
+    /* handle each part of the path */
+    TAILQ_FOREACH(token, tokens, items) {
+        if (!strcmp(token->data, "") || !strcmp(token->data, ".") || (!strcmp(token->data, "..") && TAILQ_EMPTY(newpath))) {
+            /* no need to add this token */
+            continue;
+        } else if (!strcmp(token->data, "..") && !TAILQ_EMPTY(newpath)) {
+            /* back up a path element */
+            element = TAILQ_LAST(newpath, string_entry_s);
+            TAILQ_REMOVE(newpath, element, items);
+            free(element->data);
+            free(element);
+        } else {
+            /* take this path element */
+            element = calloc(1, sizeof(*element));
+            assert(element != NULL);
+            element->data = strdup(token->data);
+            TAILQ_INSERT_TAIL(newpath, element, items);
+        }
+    }
+
+    /* generate the final path string */
+    p = list_to_string(newpath, "/");
+    xasprintf(&r, "/%s", p);
+
+    /* clean up */
+    list_free(tokens, free);
+    list_free(newpath, free);
+    free(p);
+
+    return r;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -11,6 +11,7 @@ inspect_elf_bits_dep = declare_dependency(sources : [inspect_elf_bits_c])
 # Build librpminspect
 librpminspect_sources = [
     'abi.c',
+    'abspath.c',
     'arches.c',
     'badwords.c',
     'builds.c',

--- a/test/lib/test-abspath.c
+++ b/test/lib/test-abspath.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2021  Red Hat, Inc.
+ * Author(s):  David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <CUnit/Basic.h>
+#include "rpminspect.h"
+
+#include "test-main.h"
+
+int init_test_abspath(void) {
+    return 0;
+}
+
+int clean_test_abspath(void) {
+    return 0;
+}
+
+void test_abspath(void) {
+    char *r = NULL;
+
+    r = abspath("/../lib/jli");
+    RI_ASSERT_PTR_NOT_NULL(r);
+    RI_ASSERT_EQUAL(strcmp(r, "/lib/jli"), 0);
+    free(r);
+
+    r = abspath("/../lib64/");
+    RI_ASSERT_PTR_NOT_NULL(r);
+    RI_ASSERT_EQUAL(strcmp(r, "/lib64"), 0);
+    free(r);
+
+    r = abspath("/usr/lib/../lib64/../lib");
+    RI_ASSERT_PTR_NOT_NULL(r);
+    RI_ASSERT_EQUAL(strcmp(r, "/usr/lib"), 0);
+    free(r);
+
+    r = abspath("/usr/lib/../lib64/../lib/");
+    RI_ASSERT_PTR_NOT_NULL(r);
+    RI_ASSERT_EQUAL(strcmp(r, "/usr/lib"), 0);
+    free(r);
+}
+
+CU_pSuite get_suite(void) {
+    CU_pSuite pSuite = NULL;
+
+    /* add a suite to the registry */
+    pSuite = CU_add_suite("abspath", init_test_abspath, clean_test_abspath);
+    if (pSuite == NULL) {
+        return NULL;
+    }
+
+    /* add tests to the suite */
+    if (CU_add_test(pSuite, "test abspath()", test_abspath) == NULL) {
+        return NULL;
+    }
+
+    return pSuite;
+}

--- a/test/lib/test-main.h
+++ b/test/lib/test-main.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2019  Red Hat, Inc.
+ * Copyright (C) 2019-2021  Red Hat, Inc.
  * Author(s):  David Shea <dshea@redhat.com>
+ *             David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -73,5 +74,11 @@ CU_BOOL RI_assert_impl(CU_BOOL, unsigned int, const char *, const char *, ...)
 
 #define RI_ASSERT_STRING_EQUAL(actual, expected)        _RI_ASSERT_STR(expected, ==, actual)
 #define RI_ASSERT_STRING_NOT_EQUAL(actual, expected)    _RI_ASSERT_STR(expected, !=, actual)
+
+#define ASSERT_AND_FREE(expr, expected) {\
+    char *actual = (expr);\
+    RI_ASSERT_STRING_EQUAL(actual, expected);\
+    free(actual);\
+}
 
 #endif

--- a/test/lib/test-strfuncs.c
+++ b/test/lib/test-strfuncs.c
@@ -23,12 +23,6 @@
 
 #define LOREM_IPSUM "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
 
-#define ASSERT_AND_FREE(expr, expected) {\
-    char *actual = (expr);\
-    RI_ASSERT_STRING_EQUAL(actual, expected);\
-    free(actual);\
-}
-
 int init_test_strfuncs(void) {
     return 0;
 }

--- a/test/meson.build
+++ b/test/meson.build
@@ -69,6 +69,16 @@ if cunit.found()
         link_with : [ librpminspect ],
     )
 
+    test_abspath = executable(
+        'test-abspath',
+        ['lib/test-abspath.c',
+         'lib/test-main.c'],
+        include_directories : inc,
+        dependencies : [ cunit, libkmod ],
+        c_args : '-D_BUILDDIR_="@0@"'.format(meson.current_build_dir()),
+        link_with : [ librpminspect ],
+    )
+
     # Support program used by test-inspect-elf
     execstack_prog = executable(
         'execstack',
@@ -92,6 +102,7 @@ if cunit.found()
          test_inspect_elf,
          depends : [execstack_prog, noexecstack_prog]
     )
+    test('test-abspath', test_abspath)
 else
     warning('CUnit not found, skipping unit test suite')
 endif


### PR DESCRIPTION
The abspath() function is similar to realpath(), but does not rely on
the filesystem.  All it does is read the actual path string and do
things like back up when it encounters a ".." and skip things like
".".  It is important to note that this function DOES NOT check to see
if the canonicalized path actually exists on the filesystem or not.
The purpose of this function is to reduce a complicated path with
.. redirects down to what it actually means.

This commit also adds some unit tests for the abspath() function.

The caller is responsible for freeing the returned string.

Signed-off-by: David Cantrell <dcantrell@redhat.com>