### PR TITLE
[ci] Fixes for GitHub Actions on Debian and Ubuntu

### DIFF
--- a/.github/workflows/extra-ci.yml
+++ b/.github/workflows/extra-ci.yml
@@ -65,7 +65,10 @@ jobs:
             # Within the container, install the build dependencies and
             # test suite dependencies
             - name: Install Build Dependencies
-              run: sudo make instreqs
+              run: |
+                  apt-get update
+                  apt-get -y install make
+                  make instreqs
 
             # Set up the source tree to build
             - name: setup

--- a/osdeps/debian/post.sh
+++ b/osdeps/debian/post.sh
@@ -36,4 +36,8 @@ cd ..
 rm -rf mandoc.tar.gz ${SUBDIR}
 
 # Update clamav database
+if pgrep freshclam >/dev/null 2>&1 ; then
+    pkill -KILL freshclam
+fi
+
 freshclam

--- a/osdeps/debian/reqs.txt
+++ b/osdeps/debian/reqs.txt
@@ -24,12 +24,14 @@ libxmlrpc-core-c3-dev
 libyaml-dev
 libzstd-dev
 meson
+patchelf
 pkg-config
 python3-pip
 python3-rpm
 python3-setuptools
 rc
 rpm
+rustc
 sssd
 tcsh
 valgrind

--- a/osdeps/ubuntu/reqs.txt
+++ b/osdeps/ubuntu/reqs.txt
@@ -16,6 +16,7 @@ libelf-dev
 libffi-dev
 libjson-c-dev
 libkmod-dev
+libmagic-dev
 librpm-dev
 libssl-dev
 libterm-readline-perl-perl
@@ -24,6 +25,7 @@ libxmlrpc-core-c3-dev
 libyaml-dev
 libzstd-dev
 meson
+patchelf
 pkg-config
 python3-pip
 python3-rpm


### PR DESCRIPTION
Need to make sure rustc is installed on Debian.  Both platforms need
patchelf.  Ubuntu needs an explicit install of libmagic-dev.  And drop
the sudo usage in the Ubuntu environment setup.

Signed-off-by: David Cantrell <dcantrell@redhat.com>