### PR TITLE
[ci] Disable Rust support in pip modules, more extra-ci fixes

### DIFF
--- a/.github/workflows/extra-ci.yml
+++ b/.github/workflows/extra-ci.yml
@@ -66,9 +66,9 @@ jobs:
             # test suite dependencies
             - name: Install Build Dependencies
               run: |
-                  apt-get update
-                  apt-get -y install make
-                  make instreqs
+                  sudo apt-get update
+                  sudo apt-get -y install make
+                  sudo make instreqs
 
             # Set up the source tree to build
             - name: setup

--- a/osdeps/arch/defs.mk
+++ b/osdeps/arch/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = pacman --noconfirm -S
-PIP_CMD = pip3 install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip3 install

--- a/osdeps/centos7/defs.mk
+++ b/osdeps/centos7/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = yum install -y
-PIP_CMD = pip-3 install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install

--- a/osdeps/centos8/defs.mk
+++ b/osdeps/centos8/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf --enablerepo=powertools install -y
-PIP_CMD = pip-3 install -I
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install -I

--- a/osdeps/debian/defs.mk
+++ b/osdeps/debian/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = apt-get -y install
-PIP_CMD = pip3 install -I
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip3 install -I

--- a/osdeps/debian/post.sh
+++ b/osdeps/debian/post.sh
@@ -36,8 +36,5 @@ cd ..
 rm -rf mandoc.tar.gz ${SUBDIR}
 
 # Update clamav database
-if pgrep freshclam >/dev/null 2>&1 ; then
-    pkill -KILL freshclam
-fi
-
+systemctl stop clamav-freshclam.service
 freshclam

--- a/osdeps/debian/reqs.txt
+++ b/osdeps/debian/reqs.txt
@@ -31,7 +31,6 @@ python3-rpm
 python3-setuptools
 rc
 rpm
-rustc
 sssd
 tcsh
 valgrind

--- a/osdeps/fedora-rawhide/defs.mk
+++ b/osdeps/fedora-rawhide/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = pip-3 install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install

--- a/osdeps/fedora/defs.mk
+++ b/osdeps/fedora/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = pip-3 install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install

--- a/osdeps/opensuse-leap/defs.mk
+++ b/osdeps/opensuse-leap/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = zypper install -y
-PIP_CMD = pip install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip install

--- a/osdeps/opensuse-leap/reqs.txt
+++ b/osdeps/opensuse-leap/reqs.txt
@@ -32,6 +32,7 @@ libyaml-devel
 make
 meson
 ninja
+patchelf
 python3-PyYAML
 python3-devel
 python3-pip

--- a/osdeps/opensuse-tumbleweed/defs.mk
+++ b/osdeps/opensuse-tumbleweed/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = zypper install -y
-PIP_CMD = pip install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip install

--- a/osdeps/opensuse-tumbleweed/reqs.txt
+++ b/osdeps/opensuse-tumbleweed/reqs.txt
@@ -31,6 +31,7 @@ libyaml-devel
 make
 meson
 ninja
+patchelf
 python3-PyYAML
 python3-devel
 python3-pip

--- a/osdeps/ubuntu/defs.mk
+++ b/osdeps/ubuntu/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = apt-get -y install
-PIP_CMD = pip3 install -I
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip3 install -I

--- a/utils/determine-os.sh
+++ b/utils/determine-os.sh
@@ -22,14 +22,14 @@ elif [ -r /etc/centos-release ] && [ "${ID}" = "centos" ]; then
     if [ ${VERSION_ID} -eq 7 ] || [ ${VERSION_ID} -eq 8 ]; then
         echo "${ID}${VERSION_ID}"
     else
-        echo "unknown"
+        echo "unknown OS: ${ID}" >&2
     fi
 elif [ -r /etc/redhat-release ] && [ "${ID}" = "rhel" ]; then
     v="$(echo "${VERSION_ID}" | cut -d '.' -f 1)"
     if [ "${v}" = "7" ] || [ "${v}" = "8" ]; then
         echo "${ID}${v}"
     else
-        echo "unknown"
+        echo "unknown OS: ${ID}" >&2
     fi
 elif [ "${ID}" = "opensuse-leap" ] || [ "${ID}" = "opensuse-tumbleweed" ]; then
     echo "${ID}"
@@ -40,5 +40,5 @@ elif [ "${ID}" = "slackware" ]; then
 elif [ "${ID}" = "arch" ]; then
     echo "${ID}"
 else
-    echo "unknown"
+    echo "unknown OS: ${ID}" >&2
 fi


### PR DESCRIPTION
Pass CRYPTOGRAPHY_DONT_BUILD_RUST=1 in the environment for PIP_CMD so
that Python modules installed with pip skip Rust parts.  Remove rustc
from the reqs.txt files that had that listed.

In the Ubuntu job, we have to use sudo because it's the only one not
running in a container.

In osdeps/debian/post.sh replace the pgrep/pkill with 'systemctl stop
clamav-freshclam.service'.

Add patchelf to the reqs.txt files for opensuse-leap and
opensuse-tumbleweed.

Signed-off-by: David Cantrell <dcantrell@redhat.com>