### PR TITLE
[ci] Make sure pip is updated on debian, centos7, and centos8

### DIFF
--- a/osdeps/centos7/defs.mk
+++ b/osdeps/centos7/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = yum install -y
-PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install
+PIP_CMD = pip-3 install

--- a/osdeps/centos7/pre.sh
+++ b/osdeps/centos7/pre.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/sbin:/usr/sbin
+
+# Update pip and setuptools
+yum install -y python36-pip
+pip3 install --upgrade pip setuptools
+
+# Update clamav database
+freshclam

--- a/osdeps/centos8/defs.mk
+++ b/osdeps/centos8/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf --enablerepo=powertools install -y
-PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install -I
+PIP_CMD = pip3 install -I

--- a/osdeps/centos8/pre.sh
+++ b/osdeps/centos8/pre.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/sbin:/usr/sbin
+
+# Update pip and setuptools
+dnf install -y python3-pip
+pip3 install --upgrade pip setuptools
+
+# Update clamav database
+freshclam

--- a/osdeps/debian/defs.mk
+++ b/osdeps/debian/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = apt-get -y install
-PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip3 install -I
+PIP_CMD = pip3 install -I

--- a/osdeps/debian/pre.sh
+++ b/osdeps/debian/pre.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-PATH=/bin:/usr/bin:/sbin:/usr/sbin
+PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/sbin:/usr/sbin
+
 dpkg --add-architecture i386
 apt-get -y install libterm-readline-perl-perl
 apt-get -y install lib32gcc-s1


### PR DESCRIPTION
In the pre.sh scripts for those platforms, make sure pip and
setuptools are updated with pip before proceeding.  We want to make
sure we have the latest pip so that it will install wheels when
available.  If we use source dists with pip, it builds locally and
that will require rustc and many other things.

Signed-off-by: David Cantrell <dcantrell@redhat.com>