### PR TITLE
[ci] Fixes for extra-ci on arch, centos7, centos8, and debian

### DIFF
--- a/.github/workflows/extra-ci.yml
+++ b/.github/workflows/extra-ci.yml
@@ -286,7 +286,9 @@ jobs:
         steps:
             # Update the image
             - name: pacman --noconfirm -Syu
-              run: pacman --noconfirm -Syu
+              run: |
+                  mkdir -p /var/lib/pacman/
+                  pacman --noconfirm -Syu
 
             # Install Build Dependencies - Part I
             - name: Install Build Dependencies - Part I

--- a/osdeps/arch/defs.mk
+++ b/osdeps/arch/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = pacman --noconfirm -S
-PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip3 install
+PIP_CMD = pip3 install

--- a/osdeps/arch/pre.sh
+++ b/osdeps/arch/pre.sh
@@ -2,5 +2,5 @@
 PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/sbin:/usr/sbin
 
 # Update pip and setuptools
-yum install -y python36-pip
+pacman --noconfirm -S python-pip
 pip3 install --upgrade pip setuptools

--- a/osdeps/arch/reqs.txt
+++ b/osdeps/arch/reqs.txt
@@ -14,6 +14,7 @@ lib32-glibc
 libyaml
 linux-headers
 meson
+patchelf
 pkg-config
 python
 python-pip

--- a/osdeps/centos8/pre.sh
+++ b/osdeps/centos8/pre.sh
@@ -4,6 +4,3 @@ PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/sbin:/usr/sbin
 # Update pip and setuptools
 dnf install -y python3-pip
 pip3 install --upgrade pip setuptools
-
-# Update clamav database
-freshclam

--- a/osdeps/debian/pre.sh
+++ b/osdeps/debian/pre.sh
@@ -7,5 +7,5 @@ apt-get -y install lib32gcc-s1
 apt-get update
 
 # install and update pip and setuptools
-apt-get install python3-pip python3-setuptools
+apt-get -y install python3-pip python3-setuptools
 pip3 install --upgrade pip setuptools


### PR DESCRIPTION
Arch Linux needs the initialization process to create the
/var/lib/pacman directory.  centos7 and centos8 had the freshclam call
in pre.sh, which was wrong.  It runs from post.sh.  And debian needed
the '-y' switch to apt-get in pre.sh when installing pip.

Signed-off-by: David Cantrell <dcantrell@redhat.com>