### PR TITLE
[ci] Adjust docker image names for opensuse and arch

### DIFF
--- a/.github/workflows/extra-ci.yml
+++ b/.github/workflows/extra-ci.yml
@@ -94,7 +94,7 @@ jobs:
         # host is 'ubuntu-latest' since that's what GitHub Actions
         # offers that's Linux.
         runs-on: ubuntu-latest
-        container: opensuse/leap:latest
+        container: opensuse/leap
 
         # All of these steps run from within the main source
         # directory, so think of that as your $PWD
@@ -137,7 +137,7 @@ jobs:
         # but the host is 'ubuntu-latest' since that's what GitHub
         # Actions offers that's Linux.
         runs-on: ubuntu-latest
-        container: opensuse/tumbleweed:latest
+        container: opensuse/tumbleweed
 
         # All of these steps run from within the main source
         # directory, so think of that as your $PWD
@@ -279,7 +279,7 @@ jobs:
         # but the host is 'ubuntu-latest' since that's what GitHub
         # Actions offers that's Linux.
         runs-on: ubuntu-latest
-        container: archlinux:latest
+        container: archlinux/archlinux:base-devel
 
         # All of these steps run from within the main source
         # directory, so think of that as your $PWD

--- a/.github/workflows/extra-ci.yml
+++ b/.github/workflows/extra-ci.yml
@@ -144,7 +144,7 @@ jobs:
         steps:
             # Install required packages for the git checkout action
             - name: Install required git checkout packages
-              run: zypper install -y tar gzip
+              run: zypper install -y git busybox systemd-sysvinit tar gzip
 
             # This means clone the git repo
             - uses: actions/checkout@v2
@@ -293,6 +293,54 @@ jobs:
             # Install Build Dependencies - Part I
             - name: Install Build Dependencies - Part I
               run: pacman --noconfirm -S make git
+
+            # This means clone the git repo
+            - uses: actions/checkout@v2
+
+            # Within the container, install the build dependencies and
+            # test suite dependencies
+            - name: Install Build Dependencies - Part II
+              run: make instreqs
+
+            # Set up the source tree to build
+            - name: setup
+              run: meson setup build --werror -Db_buildtype=debug -Db_coverage=true
+
+            # Compile the software
+            - name: build
+              run: ninja -C build -v
+
+            # Run the test suite
+            - name: test
+              run: meson test -C build -v
+
+            # Generate code coverage reports (requires
+            # -Db_coverage=true on 'meson setup')
+            - name: coverage
+              run: |
+                  ninja -C build coverage
+                  curl -s https://codecov.io/bash | bash
+
+    gentoo:
+        # This job runs in a Docker container of the latest Gentoo
+        # Linux but the host is 'ubuntu-latest' since that's what
+        # GitHub Actions offers that's Linux.
+        runs-on: ubuntu-latest
+        container: gentoo/gentoo
+
+        # All of these steps run from within the main source
+        # directory, so think of that as your $PWD
+        steps:
+            # Update package repos
+            # (avoid running 'emerge -uDN world' because the Docker
+            # image is likely up to date enough for the purposes of
+            # CI)
+            - name: emerge --sync
+              run: emerge --sync
+
+            # Install Build Dependencies - Part I
+              name: emerge dev-vcs/git
+              run: emerge dev-vcs/git
 
             # This means clone the git repo
             - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Status
 ![CI](https://github.com/rpminspect/rpminspect/workflows/CI/badge.svg)
 ![Style Checks](https://github.com/rpminspect/rpminspect/workflows/Style%20Checks/badge.svg)
 ![Gate](https://github.com/rpminspect/rpminspect/workflows/Gate/badge.svg)
+![Extra CI](https://github.com/rpminspect/rpminspect/workflows/Extra%20CI/badge.svg)
 
 Build Types Support
 -------------------

--- a/osdeps/gentoo/defs.mk
+++ b/osdeps/gentoo/defs.mk
@@ -1,0 +1,2 @@
+PKG_CMD = emerge
+PIP_CMD = pip-3 install

--- a/osdeps/gentoo/pip.txt
+++ b/osdeps/gentoo/pip.txt
@@ -1,0 +1,4 @@
+cpp-coveralls
+PyYAML
+rpmfluff
+timeout-decorator

--- a/osdeps/gentoo/post.sh
+++ b/osdeps/gentoo/post.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+CWD="$(pwd)"
+
+# The mandoc package in Gentoo Linux is both masked and does not
+# install the library.
+curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
+tar -xvf mandoc.tar.gz
+cd ${SUBDIR}
+echo 'PREFIX=/usr/local'                     > configure.local
+echo 'BINDIR=/usr/local/bin'                >> configure.local
+echo 'SBINDIR=/usr/local/sbin'              >> configure.local
+echo 'MANDIR=/usr/local/share/man'          >> configure.local
+echo 'INCLUDEDIR=/usr/local/include'        >> configure.local
+echo 'LIBDIR=/usr/local/lib'                >> configure.local
+echo 'LN="ln -sf"'                          >> configure.local
+echo 'MANM_MANCONF=mandoc.conf'             >> configure.local
+echo 'INSTALL_PROGRAM="install -D -m 0755"' >> configure.local
+echo 'INSTALL_LIB="install -D -m 0644"'     >> configure.local
+echo 'INSTALL_HDR="install -D -m 0644"'     >> configure.local
+echo 'INSTALL_MAN="install -D -m 0644"'     >> configure.local
+echo 'INSTALL_DATA="install -D -m 0644"'    >> configure.local
+echo 'INSTALL_LIBMANDOC=1'                  >> configure.local
+echo 'CFLAGS="-g -fPIC"'                    >> configure.local
+
+# Makefile fixes for more or less Linux in general
+sed -i -e 's|@echo|@/bin/echo|g' configure
+
+./configure
+make
+make lib-install
+cd ${CWD}
+rm -rf mandoc.tar.gz ${SUBDIR}
+
+# The 'rc' shell in Gentoo Linux is not the rc shell rpminspect
+# expects, so just build it manually.
+git clone https://github.com/rakitzis/rc.git
+cd rc
+autoreconf -f -i -v
+./configure --prefix=/usr/local
+make
+make install
+cd ${CWD}
+rm -rf rc
+
+# Update pip and setuptools
+pip3 install --user --upgrade pip setuptools
+( cd /root/.local/bin
+  for f in * ; do
+      ln -sf $(realpath ${f}) /usr/local/bin/${f}
+  done
+)
+
+# Make sure the Linux source tree is usable for building modules
+make -C /usr/src/linux olddefconfig
+make -C /usr/src/linux prepare
+
+# Update the clamav database
+freshclam

--- a/osdeps/gentoo/pre.sh
+++ b/osdeps/gentoo/pre.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Enable Python support in things like rpm
+echo "USE='caps python'" >> /etc/portage/make.conf
+
+# Allow installation of "masked" packages
+echo "app-shells/ksh ~amd64" >> /etc/portage/package.accept_keywords
+echo "dev-util/gcovr ~amd64" >> /etc/portage/package.accept_keywords
+echo "dev-util/libabigail ~amd64" >> /etc/portage/package.accept_keywords

--- a/osdeps/gentoo/reqs.txt
+++ b/osdeps/gentoo/reqs.txt
@@ -1,0 +1,17 @@
+app-antivirus/clamav
+app-arch/rpm
+app-shells/dash
+app-shells/ksh
+app-shells/tcsh
+app-shells/zsh
+dev-libs/json-c
+dev-libs/libyaml
+dev-libs/xmlrpc-c
+dev-python/pip
+dev-util/cunit
+dev-util/desktop-file-utils
+dev-util/gcovr
+dev-util/libabigail
+dev-util/patchelf
+dev-util/valgrind
+sys-devel/gettext


### PR DESCRIPTION
Drop the latest for tumbleweed.  Not sure if that will make a
difference, but that image looks broken right now.

For arch, try the base-devel image.

Signed-off-by: David Cantrell <dcantrell@redhat.com>