### PR TITLE
[new] In the runpath inspection, fail if DT_RPATH and DT_RUNPATH exist

### DIFF
--- a/include/results.h
+++ b/include/results.h
@@ -224,4 +224,6 @@
 /* runpath */
 #define REMEDY_RUNPATH _("Either DT_RPATH or DT_RUNPATH properties were found on ELF shared objects in this package.  The use of DT_RPATH and DT_RUNPATH is discouraged except in certain situations.  Check to see that you a disabling rpath during the %build stage of the spec file.  If you are unable to do this easily, you can try using a program such as patchelf to remove these properties from the ELF files.")
 
+#define REMEDY_RUNPATH_BOTH _("Both DT_RPATH and DT_RUNPATH properties were found in an ELF shared object.  This indicates a linker error and should not happen.  ELF objects should only carry DT_RPATH or DT_RUNPATH, never both.")
+
 #endif


### PR DESCRIPTION
ELF objects should not have both DT_RPATH and DT_RUNPATH.  If they
happens, it indicates a linker error and should be handled
accordingly.  If rpminspect finds both symbols in the ELF object, the
runpath inspection fails with an unwaivable BAD result.

Signed-off-by: David Cantrell <dcantrell@redhat.com>