### PR TITLE
[fix] Remove duplicate elf_end() call in init_elf_data() (#303)

### DIFF
--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -142,8 +142,6 @@ void init_elf_data(struct rpminspect *ri)
         }
 
         list_free(libc_fortified, NULL);
-        elf_end(libc_elf);
-        close(libc_fd);
 
         /* The fortifiable tailq is to keep track of what all's been malloced.
          * Copy into a hash table for fast lookups.


### PR DESCRIPTION
elf_end() and close() were possibly called twice for successful runs
of init_elf_data().  Calling elf_end() more than once on an opened
libelf entity is undefined.  It could crash or it could run forever.
Point is, don't do it.

Signed-off-by: David Cantrell <dcantrell@redhat.com>