### PR TITLE
[fix] Handle compressed but otherwise empty man pages (#308)

### DIFF
--- a/test/test_manpage.py
+++ b/test/test_manpage.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
+# Copyright (C) 2019-2021  Red Hat, Inc.
 # Author(s):  David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -334,6 +334,82 @@ class InvalidManPageCompareKoji(TestCompareKoji):
             "/usr/share/man/man1/foo.1.gz",
             rpmfluff.GeneratedSourceFile("foo.1", rpmfluff.make_png()),
         )
+
+        # the test
+        self.inspection = "manpage"
+        self.label = "man-pages"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"
+
+
+# Empty but compressed man page RPM build (VERIFY)
+class EmptyManPageRPM(TestRPMs):
+    def setUp(self):
+        TestRPMs.setUp(self)
+
+        # add an empty but gzipped man page
+        self.rpm.section_build += "touch foo.1\n"
+        self.rpm.section_build += "gzip -9 foo.1\n"
+        self.rpm.section_install += "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "%{_mandir}/man1/foo.1.gz\n"
+
+        # the test
+        self.inspection = "manpage"
+        self.label = "man-pages"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"
+
+
+# Empty but compressed man page Koji build (VERIFY)
+class EmptyManPageKoji(TestKoji):
+    def setUp(self):
+        TestKoji.setUp(self)
+
+        # add an empty but gzipped man page
+        self.rpm.section_build += "touch foo.1\n"
+        self.rpm.section_build += "gzip -9 foo.1\n"
+        self.rpm.section_install += "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "%{_mandir}/man1/foo.1.gz\n"
+
+        # the test
+        self.inspection = "manpage"
+        self.label = "man-pages"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"
+
+
+# Empty but compressed man page compare RPM builds (VERIFY)
+class EmptyManPageCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        TestCompareRPMs.setUp(self)
+
+        # add an empty but gzipped man page
+        self.after_rpm.section_build += "touch foo.1\n"
+        self.after_rpm.section_build += "gzip -9 foo.1\n"
+        self.after_rpm.section_install += "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "%{_mandir}/man1/foo.1.gz\n"
+
+        # the test
+        self.inspection = "manpage"
+        self.label = "man-pages"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"
+
+
+# Empty but compressed man page compare Koji builds (VERIFY)
+class EmptyManPageCompareKoji(TestCompareKoji):
+    def setUp(self):
+        TestCompareKoji.setUp(self)
+
+        # add an empty but gzipped man page
+        self.after_rpm.section_build += "touch foo.1\n"
+        self.after_rpm.section_build += "gzip -9 foo.1\n"
+        self.after_rpm.section_install += "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "%{_mandir}/man1/foo.1.gz\n"
 
         # the test
         self.inspection = "manpage"

--- a/test/test_manpage.py
+++ b/test/test_manpage.py
@@ -392,7 +392,7 @@ class EmptyManPageCompareRPMs(TestCompareRPMs):
         # add an empty but gzipped man page
         self.after_rpm.section_build += "touch foo.1\n"
         self.after_rpm.section_build += "gzip -9 foo.1\n"
-        self.rpm.section_install += (
+        self.after_rpm.section_install += (
             "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
         )
         sub = self.after_rpm.get_subpackage(None)
@@ -413,7 +413,7 @@ class EmptyManPageCompareKoji(TestCompareKoji):
         # add an empty but gzipped man page
         self.after_rpm.section_build += "touch foo.1\n"
         self.after_rpm.section_build += "gzip -9 foo.1\n"
-        self.rpm.section_install += (
+        self.after_rpm.section_install += (
             "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
         )
         sub = self.after_rpm.get_subpackage(None)

--- a/test/test_manpage.py
+++ b/test/test_manpage.py
@@ -350,7 +350,9 @@ class EmptyManPageRPM(TestRPMs):
         # add an empty but gzipped man page
         self.rpm.section_build += "touch foo.1\n"
         self.rpm.section_build += "gzip -9 foo.1\n"
-        self.rpm.section_install += "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        self.rpm.section_install += (
+            "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        )
         sub = self.rpm.get_subpackage(None)
         sub.section_files += "%{_mandir}/man1/foo.1.gz\n"
 
@@ -369,7 +371,9 @@ class EmptyManPageKoji(TestKoji):
         # add an empty but gzipped man page
         self.rpm.section_build += "touch foo.1\n"
         self.rpm.section_build += "gzip -9 foo.1\n"
-        self.rpm.section_install += "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        self.rpm.section_install += (
+            "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        )
         sub = self.rpm.get_subpackage(None)
         sub.section_files += "%{_mandir}/man1/foo.1.gz\n"
 
@@ -388,7 +392,9 @@ class EmptyManPageCompareRPMs(TestCompareRPMs):
         # add an empty but gzipped man page
         self.after_rpm.section_build += "touch foo.1\n"
         self.after_rpm.section_build += "gzip -9 foo.1\n"
-        self.after_rpm.section_install += "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        self.rpm.section_install += (
+            "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        )
         sub = self.after_rpm.get_subpackage(None)
         sub.section_files += "%{_mandir}/man1/foo.1.gz\n"
 
@@ -407,7 +413,9 @@ class EmptyManPageCompareKoji(TestCompareKoji):
         # add an empty but gzipped man page
         self.after_rpm.section_build += "touch foo.1\n"
         self.after_rpm.section_build += "gzip -9 foo.1\n"
-        self.after_rpm.section_install += "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        self.rpm.section_install += (
+            "install -D -m 0644 foo.1.gz %{buildroot}%{_mandir}/man1/foo.1.gz\n"
+        )
         sub = self.after_rpm.get_subpackage(None)
         sub.section_files += "%{_mandir}/man1/foo.1.gz\n"
 


### PR DESCRIPTION
A couple of fixes in this patch.  First, make sure uncompress_file()
handles compressed but empty files.  Because libarchive returns
ARCHIVE_EOF on archive_read_next_header() when the payload is empty,
my function was erroring out and returning NULL.  That caused an
assert() failure higher up in the manpage inspection.  So, teach
uncompress_file() how to handle compressed zero-length files.  Since
uncompress_file() creates a temporary file to write the uncompressed
payload to, use fdopen() and fclose() to create a zero-length file in
the case of a compressed empty file.  ARCHIVE_FAILED and ARCHIVE_FATAL
are still handled, but I also treat ARCHIVE_RETRY the same way and
just fail out.  I have not seen ARCHIVE_RETRY triggered in the wild
and in our cases it really only means you can restart everything.  I
thinkg ARCHIVE_RETRY would be useful is streaming from a device or
network but then you'd need some poll() and select() around handling
that case and I kind of want to not do that right now.  Something
tells me I will be back here adding that in the future.

Next is expanding the manpage inspection so it reports empty manpages.
It turns out that libmandoc will successfully validate nothing as
valid mandoc.  So I added a check to see if the uncompressed manpage
is size 0 and if so report that it's probably empty with a VERIFY
warning.  This could be INFO but I image we really don't want packages
including empty man pages so VERIFY feels appropriate here.

Signed-off-by: David Cantrell <dcantrell@redhat.com>