### PR TITLE
[lib] Migrate more code off hsearch and to uthash

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -125,14 +125,14 @@ struct rpminspect *init_rpminspect(struct rpminspect *, const char *, const char
 
 /* free.c */
 void free_regex(regex_t *);
-void free_mapping(struct hsearch_data *, string_list_t *);
+void free_string_map(string_map_t *);
 void free_pair(pair_list_t *);
 void free_rpminspect(struct rpminspect *);
 
 /* listfuncs.c */
 char *list_to_string(const string_list_t *, const char *);
 char **list_to_array(const string_list_t *);
-struct hsearch_data * list_to_table(const string_list_t *);
+string_map_t * list_to_table(const string_list_t *);
 string_list_t * list_difference(const string_list_t *, const string_list_t *);
 string_list_t * list_intersection(const string_list_t *, const string_list_t *);
 string_list_t * list_union(const string_list_t *, const string_list_t *);
@@ -257,7 +257,7 @@ char *checksum(rpmfile_entry_t *);
 /* runcmd.c */
 char *sl_run_cmd(int *exitcode, string_list_t *list);
 char *run_cmd(int *, const char *, ...) __attribute__((__sentinel__));
-void free_argv_table(struct rpminspect *ri, struct hsearch_data *table);
+void free_argv_table(struct rpminspect *ri, string_list_map_t *table);
 
 /* fileinfo.c */
 bool match_fileinfo_mode(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *);
@@ -374,12 +374,12 @@ bool is_rebase(struct rpminspect *ri);
 void init_arches(struct rpminspect *ri);
 
 /* abi.c */
-void add_abi_argument(struct hsearch_data *table, const char *arg, const char *path, const Header hdr);
+void add_abi_argument(string_list_map_t *table, const char *arg, const char *path, const Header hdr);
 size_t count_abi_entries(const string_list_t *contents);
 abi_list_t *read_abi(const char *vendor_data_dir, const char *product_release);
 void free_abi(abi_list_t *list);
 string_list_t *get_abi_suppressions(const struct rpminspect *ri, const char *suppression_file);
-struct hsearch_data *get_abi_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *arg, const char *path, const int type);
+string_list_map_t *get_abi_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *arg, const char *path, const int type);
 
 /* uncompress.c */
 char *uncompress_file(struct rpminspect *ri, const char *infile, const char *subdir);

--- a/include/types.h
+++ b/include/types.h
@@ -33,6 +33,7 @@
 #include <rpm/rpmfi.h>
 #include <libkmod.h>
 #include "queue.h"
+#include "uthash.h"
 
 #ifndef _LIBRPMINSPECT_TYPES_H
 #define _LIBRPMINSPECT_TYPES_H
@@ -305,6 +306,20 @@ struct command_paths {
     char *kmidiff;
 };
 
+/* Hash table used for key/value situations where each is a string. */
+typedef struct _string_map_t {
+    char *key;
+    char *value;
+    UT_hash_handle hh;
+} string_map_t;
+
+/* Hash table with a string key and a string_list_t value. */
+typedef struct _string_list_map_t {
+    char *key;
+    string_list_t *value;
+    UT_hash_handle hh;
+} string_list_map_t;
+
 /*
  * Configuration and state instance for librpminspect run.
  * Applications using librpminspect should initialize the
@@ -416,21 +431,17 @@ struct rpminspect {
     specname_primary_t specprimary;
 
     /* hash table of product release -> JVM major versions */
-    struct hsearch_data *jvm;
-    string_list_t *jvm_keys;
+    string_map_t *jvm;
 
     /* hash table of annocheck tests */
-    struct hsearch_data *annocheck;
-    string_list_t *annocheck_keys;
+    string_map_t *annocheck;
 
     /* hash table of path migrations */
-    struct hsearch_data *pathmigration;
-    string_list_t *pathmigration_keys;
+    string_map_t *pathmigration;
     string_list_t *pathmigration_excluded_paths;
 
     /* hash table of product release regexps */
-    struct hsearch_data *products;
-    string_list_t *product_keys;
+    string_map_t *products;
 
     /* list of paths to ignore (these strings allow glob(3) syntax) */
     string_list_t *ignores;
@@ -523,8 +534,7 @@ struct rpminspect {
     int rebase_build;               /* indicates if this is a rebased build */
 
     /* used by ELF symbol checks */
-    string_list_t *fortifiable;
-    struct hsearch_data *fortifiable_table;
+    string_map_t *fortifiable;
 
     /* spec file macros */
     pair_list_t *macros;

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -57,8 +57,8 @@ void dump_cfg(const struct rpminspect *ri)
 {
     int i = 0;
     string_entry_t *entry = NULL;
-    ENTRY e;
-    ENTRY *eptr;
+    string_map_t *hentry = NULL;
+    string_map_t *tmp_hentry = NULL;
 
     assert(ri != NULL);
 
@@ -140,16 +140,11 @@ void dump_cfg(const struct rpminspect *ri)
         printf("    %s: %s\n", inspections[i].name, (ri->tests & inspections[i].flag) ? "on" : "off");
     }
 
-    if (ri->product_keys && !TAILQ_EMPTY(ri->product_keys)) {
-        printf("products:\n");
+    if (ri->products) {
+        fprintf(stderr, "products:\n");
 
-        TAILQ_FOREACH(entry, ri->product_keys, items) {
-            e.key = entry->data;
-            hsearch_r(e, FIND, &eptr, ri->products);
-
-            if ((eptr != NULL) && (eptr->data != NULL)) {
-                printf("    - %s: %s\n", entry->data, (char *) eptr->data);
-            }
+        HASH_ITER(hh, ri->products, hentry, tmp_hentry) {
+            fprintf(stderr, "    - %s: %s\n", hentry->key, hentry->value);
         }
     }
 
@@ -329,45 +324,30 @@ void dump_cfg(const struct rpminspect *ri)
     printf("    match: %s\n", (ri->specmatch == MATCH_FULL) ? "full" : (ri->specmatch == MATCH_PREFIX) ? "prefix" : (ri->specmatch == MATCH_SUFFIX) ? "suffix" : "?");
     printf("    primary: %s\n", (ri->specprimary == PRIMARY_NAME) ? "name" : (ri->specprimary == PRIMARY_FILENAME) ? "filename" : "?");
 
-    if (ri->annocheck_keys && !TAILQ_EMPTY(ri->annocheck_keys)) {
-        printf("annocheck:\n");
+    if (ri->annocheck) {
+        fprintf(stderr, "annocheck:\n");
 
-        TAILQ_FOREACH(entry, ri->annocheck_keys, items) {
-            e.key = entry->data;
-            hsearch_r(e, FIND, &eptr, ri->annocheck);
-
-            if ((eptr != NULL) && (eptr->data != NULL)) {
-                printf("    - %s: %s\n", entry->data, (char *) eptr->data);
-            }
+        HASH_ITER(hh, ri->annocheck, hentry, tmp_hentry) {
+            fprintf(stderr, "    - %s: %s\n", hentry->key, hentry->value);
         }
     }
 
-    if (ri->jvm_keys && !TAILQ_EMPTY(ri->jvm_keys)) {
-        printf("javabytecode:\n");
+    if (ri->jvm) {
+        fprintf(stderr, "javabytecode:\n");
 
-        TAILQ_FOREACH(entry, ri->jvm_keys, items) {
-            e.key = entry->data;
-            hsearch_r(e, FIND, &eptr, ri->jvm);
-
-            if ((eptr != NULL) && (eptr->data != NULL)) {
-                printf("    - %s: %s\n", entry->data, (char *) eptr->data);
-            }
+        HASH_ITER(hh, ri->jvm, hentry, tmp_hentry) {
+            fprintf(stderr, "    - %s: %s\n", hentry->key, hentry->value);
         }
     }
 
-    if ((ri->pathmigration_keys && !TAILQ_EMPTY(ri->pathmigration_keys)) || (ri->pathmigration_excluded_paths && !TAILQ_EMPTY(ri->pathmigration_excluded_paths))) {
-        printf("pathmigration:\n");
+    if (ri->pathmigration || (ri->pathmigration_excluded_paths && !TAILQ_EMPTY(ri->pathmigration_excluded_paths))) {
+        fprintf(stderr, "pathmigration:\n");
 
-        if (ri->pathmigration_keys && !TAILQ_EMPTY(ri->pathmigration_keys)) {
-            printf("    migrated_paths:\n");
+        if (ri->pathmigration) {
+            fprintf(stderr, "    migrated_paths:\n");
 
-            TAILQ_FOREACH(entry, ri->pathmigration_keys, items) {
-                e.key = entry->data;
-                hsearch_r(e, FIND, &eptr, ri->pathmigration);
-
-                if ((eptr != NULL) && (eptr->data != NULL)) {
-                    printf("        - %s: %s\n", entry->data, (char *) eptr->data);
-                }
+            HASH_ITER(hh, ri->pathmigration, hentry, tmp_hentry) {
+                fprintf(stderr, "        - %s: %s\n", hentry->key, hentry->value);
             }
         }
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -389,7 +389,7 @@ bool process_file_path(const rpmfile_entry_t *file, regex_t *include_regex, rege
 static struct file_data *files_to_table(rpmfile_t *list)
 {
     struct file_data *table = NULL;
-    struct file_data *entry = NULL;
+    struct file_data *fentry = NULL;
     rpmfile_entry_t *iter = NULL;
 
     assert(list != NULL);
@@ -399,11 +399,11 @@ static struct file_data *files_to_table(rpmfile_t *list)
     assert(iter);
 
     TAILQ_FOREACH(iter, list, items) {
-        entry = calloc(1, sizeof(*entry));
-        assert(entry != NULL);
-        entry->path = iter->localpath;
-        entry->rpmfile = iter;
-        HASH_ADD_KEYPTR(hh, table, entry->path, strlen(entry->path), entry);
+        fentry = calloc(1, sizeof(*fentry));
+        assert(fentry != NULL);
+        fentry->path = iter->localpath;
+        fentry->rpmfile = iter;
+        HASH_ADD_KEYPTR(hh, table, fentry->path, strlen(fentry->path), fentry);
     }
 
     return table;
@@ -415,12 +415,12 @@ static struct file_data *files_to_table(rpmfile_t *list)
  * @param file rpmfile_entry_t to set peer_file on.
  * @param entry Hash table entry with the peer_file data.
  */
-static void set_peer(rpmfile_entry_t *file, struct file_data *entry)
+static void set_peer(rpmfile_entry_t *file, struct file_data *fentry)
 {
     rpmfile_entry_t *peer = NULL;
 
-    peer = entry->rpmfile;
-    entry->rpmfile = NULL;
+    peer = fentry->rpmfile;
+    fentry->rpmfile = NULL;
 
     file->peer_file = peer;
     peer->peer_file = file;
@@ -549,15 +549,12 @@ static char *comparable_version_substrings(const char *s, const char *ignore)
  * @brief For the given file from "before", attempt to find a matching
  * file in "after".
  *
- * Any time a match is found, the hash table ENTRY's value field will
+ * Any time a match is found, the hash table entry's value field will
  * be set to NULL so that the match cannot be used again. For the
  * purposes of adding tests to match peers, this means that attempts
  * must be made in order from best match to worst match. This is an
- * important thing to note. To see if a file from the hash table can
- * be used, we need to check that hsearch_r() returns non-zero *and*
- * the value of eptr->data is not NULL. If an entry is still there but
- * eptr->data is now NULL it means we have already matched it with
- * another peer.
+ * important thing to note.  If an entry is still there but the value
+ * is now NULL it means we have already matched it with another peer.
  *
  * In cases where the peer found has changed paths or subpackages,
  * this function will modify the moved_path and moved_subpackage

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -35,10 +35,10 @@
 /* Globals */
 static string_list_t *firstargs = NULL;
 static string_list_t *suppressions = NULL;
-static struct hsearch_data *debug_info_dir1_table;
-static struct hsearch_data *debug_info_dir2_table;
-static struct hsearch_data *headers_dir1_table;
-static struct hsearch_data *headers_dir2_table;
+static string_list_map_t *debug_info_dir1_table;
+static string_list_map_t *debug_info_dir2_table;
+static string_list_map_t *headers_dir1_table;
+static string_list_map_t *headers_dir2_table;
 static abi_list_t *abi = NULL;
 
 static severity_t check_abi(const severity_t sev, const long int threshold, const char *path, const char *pkg, long int *compat)
@@ -114,12 +114,10 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     string_list_t *local_d2 = NULL;
     string_list_t *local_h1 = NULL;
     string_list_t *local_h2 = NULL;
-    string_list_t *arglist = NULL;
     string_entry_t *entry = NULL;
     const char *arch = NULL;
     const char *name = NULL;
-    ENTRY e;
-    ENTRY *eptr;
+    string_list_map_t *hentry = NULL;
     int exitcode = 0;
     int status = 0;
     char *tmp = NULL;
@@ -161,53 +159,33 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     }
 
     /* debug dir args */
-    e.key = (char *) arch;
-    hsearch_r(e, FIND, &eptr, debug_info_dir1_table);
+    HASH_FIND_STR(debug_info_dir1_table, arch, hentry);
 
-    if (eptr != NULL) {
-        arglist = (string_list_t *) eptr->data;
-
-        if (arglist && !TAILQ_EMPTY(arglist)) {
-            local_d1 = list_copy(arglist);
-            TAILQ_CONCAT(argv, local_d1, items);
-        }
+    if (hentry != NULL && hentry->value && !TAILQ_EMPTY(hentry->value)) {
+        local_d1 = list_copy(hentry->value);
+        TAILQ_CONCAT(argv, local_d1, items);
     }
 
-    e.key = (char *) arch;
-    hsearch_r(e, FIND, &eptr, debug_info_dir2_table);
+    HASH_FIND_STR(debug_info_dir2_table, arch, hentry);
 
-    if (eptr != NULL) {
-        arglist = (string_list_t *) eptr->data;
-
-        if (arglist && !TAILQ_EMPTY(arglist)) {
-            local_d2 = list_copy(arglist);
-            TAILQ_CONCAT(argv, local_d2, items);
-        }
+    if (hentry != NULL && hentry->value && !TAILQ_EMPTY(hentry->value)) {
+        local_d2 = list_copy(hentry->value);
+        TAILQ_CONCAT(argv, local_d2, items);
     }
 
     /* header dir args */
-    e.key = (char *) arch;
-    hsearch_r(e, FIND, &eptr, headers_dir1_table);
+    HASH_FIND_STR(headers_dir1_table, arch, hentry);
 
-    if (eptr != NULL) {
-        arglist = (string_list_t *) eptr->data;
-
-        if (arglist && !TAILQ_EMPTY(arglist)) {
-            local_h1 = list_copy(arglist);
-            TAILQ_CONCAT(argv, local_h1, items);
-        }
+    if (hentry != NULL && hentry->value && !TAILQ_EMPTY(hentry->value)) {
+        local_h1 = list_copy(hentry->value);
+        TAILQ_CONCAT(argv, local_h1, items);
     }
 
-    e.key = (char *) arch;
-    hsearch_r(e, FIND, &eptr, headers_dir2_table);
+    HASH_FIND_STR(headers_dir2_table, arch, hentry);
 
-    if (eptr != NULL) {
-        arglist = (string_list_t *) eptr->data;
-
-        if (arglist && !TAILQ_EMPTY(arglist)) {
-            local_h2 = list_copy(arglist);
-            TAILQ_CONCAT(argv, local_h2, items);
-        }
+    if (hentry != NULL && hentry->value && !TAILQ_EMPTY(hentry->value)) {
+        local_h2 = list_copy(hentry->value);
+        TAILQ_CONCAT(argv, local_h2, items);
     }
 
     /* the before build */

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -30,7 +30,6 @@
 
 #include <assert.h>
 #include <fcntl.h>
-#include <search.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -216,11 +215,11 @@ bool has_bind_now(Elf *elf)
 
 static bool is_fortifiable(const char *symbol)
 {
-    ENTRY e;
-    ENTRY *eptr;
-    e.key = (char *) symbol;
-    hsearch_r(e, FIND, &eptr, rip->fortifiable_table);
-    return eptr != NULL;
+    string_map_t *hentry = NULL;
+
+    assert(symbol != NULL);
+    HASH_FIND_STR(rip->fortifiable, symbol, hentry);
+    return hentry != NULL;
 }
 
 /**

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
+ * Copyright (C) 2019-2021  Red Hat, Inc.
  * Author(s):  David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
@@ -184,11 +184,10 @@ char *run_cmd(int *exitcode, const char *cmd, ...)
 /*
  * Free one of the command line option tables.
  */
-void free_argv_table(struct rpminspect *ri, struct hsearch_data *table)
+void free_argv_table(struct rpminspect *ri, string_list_map_t *table)
 {
-    ENTRY e;
-    ENTRY *eptr;
-    string_entry_t *entry = NULL;
+    string_list_map_t *hentry = NULL;
+    string_list_map_t *tmp_hentry = NULL;
 
     assert(ri != NULL);
     assert(ri->arches != NULL);
@@ -197,17 +196,11 @@ void free_argv_table(struct rpminspect *ri, struct hsearch_data *table)
         return;
     }
 
-    TAILQ_FOREACH(entry, ri->arches, items) {
-        e.key = entry->data;
-        hsearch_r(e, FIND, &eptr, table);
-
-        if (eptr != NULL) {
-            list_free(eptr->data, free);
-        }
+    HASH_ITER(hh, table, hentry, tmp_hentry) {
+        HASH_DEL(table, hentry);
+        free(hentry->key);
+        list_free(hentry->value, free);
     }
-
-    hdestroy_r(table);
-    free(table);
 
     return;
 }


### PR DESCRIPTION
This is an internal changeup to use uthash.h over the glibc provided
hsearch hash table routines.  It's just an implementation change and
not a functional change.  This commit gets most of what remains, but
not everything.

Signed-off-by: David Cantrell <dcantrell@redhat.com>