### PR TITLE
[lib] Replace hsearch() with uthash in the kmod inspection

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -760,18 +760,10 @@ typedef void (*modinfo_to_entries)(string_list_t *, const struct kmod_list *);
 typedef void (*module_alias_callback)(const char *, const string_list_t *, const string_list_t *, void *);
 
 /* mapping of an alias string to a module name */
-struct alias_entry_t {
+typedef struct _kernel_alias_data_t {
     char *alias;
-    char *module;
-    TAILQ_ENTRY(alias_entry_t) items;
-};
-
-TAILQ_HEAD(alias_list_t, alias_entry_t);
-
-typedef struct _kernel_alias_data {
-    size_t num_aliases;
-    struct alias_list_t *alias_list;
-    struct hsearch_data *alias_table;
+    string_list_t *modules;
+    UT_hash_handle hh;
 } kernel_alias_data_t;
 
 /* Types of workdirs */


### PR DESCRIPTION
Another bit of code refactoring in the kmod inspection.  Drop the use
of the hsearch routines in kmods.c.  The entire
finalize_module_aliases() function can be removed and the data
structure simplified.  It's now just one hash table as opposed to a
struct, a linked list, an int, and a hash table with a char * key and
a linked list value.

Signed-off-by: David Cantrell <dcantrell@redhat.com>