### PR TITLE
[doc] Update TEST_METADATA status in TODO and MISSING

### DIFF
--- a/MISSING
+++ b/MISSING
@@ -52,3 +52,11 @@ TEST_SPECFILE ($RPM_OPT_FLAGS check on x86 builds)
     were trying to ensure the 32-bit x86 builds were using more
     optimizations than standard i386 builds.  This check is not really
     relevant anymore, so it has been dropped.
+
+TEST_METADATA (the 'fedora without red hat' string check)
+    The substring check of the Summary string and package descriptions
+    for any mention of 'Fedora' (case insensitive) without also
+    mentioning 'Red Hat' (case insensitive) is a branding matter.  The
+    check itself was not foolproof and did not take in to account word
+    boundaries of pathnames.  This kind of check is out of scope for
+    rpminspect as it provides no technical or security benefit.

--- a/TODO
+++ b/TODO
@@ -14,9 +14,6 @@ the specifics will be noted during the work in progress.
 
 Unranked tests categories to migrate (might also decide to skip them):
 ----------------------------------------------------------------------
-!TEST_METADATA
-    need to get the fedora_without_redhat test implemented from checker
-    for the summary and description (call this the 'substring' inspection)
  TEST_REQUIRES
  TEST_SCRIPT
  TEST_STRIP
@@ -70,6 +67,8 @@ Test categories that have been migrated:
 *TEST_VIRUS (virus)
 *TEST_POLITICS (politics)
 *TEST_RPATH (runpath)
+*TEST_METADATA (only checks for bad words, valid license, valid vendor,
+                and valid buildhost)
 
 
 Test categories excluded (see MISSING):
@@ -80,6 +79,7 @@ Test categories excluded (see MISSING):
  TEST_ELFLINT
  TEST_MULTILIB
  TEST_SPECFILE (only the 32-bit x86 $RPM_OPT_FLAGS check)
+ TEST_METADATA (the 'fedora without red hat' string check)
 
 
 +============+


### PR DESCRIPTION
Note what parts of the rpmdiff TEST_METADATA check are implemented and
which parts are not.

Signed-off-by: David Cantrell <dcantrell@redhat.com>