### PR TITLE
[lib] Replace hsearch() with uthash in the abidiff inspection

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -376,8 +376,8 @@ void init_arches(struct rpminspect *ri);
 /* abi.c */
 void add_abi_argument(string_list_map_t *table, const char *arg, const char *path, const Header hdr);
 size_t count_abi_entries(const string_list_t *contents);
-abi_list_t *read_abi(const char *vendor_data_dir, const char *product_release);
-void free_abi(abi_list_t *list);
+abi_t *read_abi(const char *vendor_data_dir, const char *product_release);
+void free_abi(abi_t *list);
 string_list_t *get_abi_suppressions(const struct rpminspect *ri, const char *suppression_file);
 string_list_map_t *get_abi_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *arg, const char *path, const int type);
 

--- a/include/types.h
+++ b/include/types.h
@@ -26,7 +26,6 @@
 #include <regex.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <search.h>
 #include <sys/stat.h>
 #include <sys/capability.h>
 #include <rpm/rpmlib.h>
@@ -839,19 +838,13 @@ enum abidiff_status {
 /*
  * ABI compatibility level types
  */
-typedef struct _abi_entry_t {
+typedef struct _abi_t {
+    char *pkg;
     int level;
-    struct hsearch_data *pkgs;
-    string_list_t *keys;
-    TAILQ_ENTRY(_abi_entry_t) items;
-} abi_entry_t;
-
-typedef TAILQ_HEAD(abi_entry_s, _abi_entry_t) abi_list_t;
-
-typedef struct _abi_pkg_entry_t {
     bool all;
     string_list_t *dsos;
-} abi_pkg_entry_t;
+    UT_hash_handle hh;
+} abi_t;
 
 /*
  * diffstat(1) findings for reporting in the patches inspection

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <search.h>
 
 #include "rpminspect.h"
 


### PR DESCRIPTION
The data structures have been replaced with a single abi_t hash table.

Signed-off-by: David Cantrell <dcantrell@redhat.com>