### PR TITLE
[fix] Correct misuse of 'entry' with 'hentry' variables (#321)

### DIFF
--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -31,7 +31,6 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     bool result = true;
     const char *arch = NULL;
     char *cmd = NULL;
-    string_entry_t *entry = NULL;
     string_map_t *hentry = NULL;
     string_map_t *tmp_hentry = NULL;
     char *wrkdir = NULL;
@@ -103,20 +102,20 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         /* Build a reporting message if we need to */
         if (before_out && after_out) {
             if (before_exit == 0 && after_exit == 0) {
-                xasprintf(&params.msg, _("annocheck '%s' test passes for %s on %s"), entry->data, file->localpath, arch);
+                xasprintf(&params.msg, _("annocheck '%s' test passes for %s on %s"), hentry->key, file->localpath, arch);
             } else if (before_exit == 1 && after_exit == 0) {
-                xasprintf(&params.msg, _("annocheck '%s' test now passes for %s on %s"), entry->data, file->localpath, arch);
+                xasprintf(&params.msg, _("annocheck '%s' test now passes for %s on %s"), hentry->key, file->localpath, arch);
             } else if (before_exit == 0 && after_exit == 1) {
-                xasprintf(&params.msg, _("annocheck '%s' test now fails for %s on %s"), entry->data, file->localpath, arch);
+                xasprintf(&params.msg, _("annocheck '%s' test now fails for %s on %s"), hentry->key, file->localpath, arch);
                 params.severity = RESULT_VERIFY;
                 params.verb = VERB_CHANGED;
                 result = false;
             }
         } else if (after_out) {
             if (after_exit == 0) {
-                xasprintf(&params.msg, _("annocheck '%s' test passes for %s on %s"), entry->data, file->localpath, arch);
+                xasprintf(&params.msg, _("annocheck '%s' test passes for %s on %s"), hentry->key, file->localpath, arch);
             } else if (after_exit == 1) {
-                xasprintf(&params.msg, _("annocheck '%s' test fails for %s on %s"), entry->data, file->localpath, arch);
+                xasprintf(&params.msg, _("annocheck '%s' test fails for %s on %s"), hentry->key, file->localpath, arch);
                 params.severity = RESULT_VERIFY;
                 params.verb = VERB_CHANGED;
                 result = false;

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -91,7 +91,6 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
     char *before_product = NULL;
     char *after_product = NULL;
     char *needle = NULL;
-    string_entry_t *entry = NULL;
     string_map_t *hentry = NULL;
     string_map_t *tmp_hentry = NULL;
     regex_t product_regex;
@@ -197,7 +196,7 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
 
                 if (before_matches[0].rm_so > -1 && after_matches[0].rm_so > -1) {
                     matched = true;
-                    after_product = strdup(entry->data);
+                    after_product = strdup(hentry->key);
                 }
 
                 regfree(&product_regex);


### PR DESCRIPTION
I recently replaced the hsearch() usage with uthash.  There were two
places where I neglected to replace the 'entry->data' variable with
'hentry->key' to match the new variables and types.  This patch fixes
the SIGSEGV caused by that problem.

Signed-off-by: David Cantrell <dcantrell@redhat.com>