### PR TITLE
Normalize copyright boilerplates in source files

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2018 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/include/output.h
+++ b/include/output.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019  Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/include/queue.h
+++ b/include/queue.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/include/readelf.h
+++ b/include/readelf.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Red Hat Author(s):  David Shea <dshea@redhat.com>
- *                     David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/include/results.h
+++ b/include/results.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/include/types.h
+++ b/include/types.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/abi.c
+++ b/lib/abi.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/abspath.c
+++ b/lib/abspath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Red Hat, Inc.
+ * Copyright © 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/arches.c
+++ b/lib/arches.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/badwords.c
+++ b/lib/badwords.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/bytes.c
+++ b/lib/bytes.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/filecmp.c
+++ b/lib/filecmp.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/files.c
+++ b/lib/files.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Red Hat Author(s):  David Shea <dshea@redhat.com>
- *                     David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/flags.c
+++ b/lib/flags.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/free.c
+++ b/lib/free.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/ignore.c
+++ b/lib/ignore.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Red Hat Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/init.c
+++ b/lib/init.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2021  Red Hat, Inc.
- * Author(s):  David Shea <dshea@redhat.com>
- *             David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2021 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Shea <dshea@redhat.com>
- *             David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_files.c
+++ b/lib/inspect_files.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2018 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Shea <dshea@redhat.com>
- *             David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_metadata.c
+++ b/lib/inspect_metadata.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2021 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_specname.c
+++ b/lib/inspect_specname.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Shea <dshea@redhat.com>
- *             David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Shea <dshea@redhat.com>
- *             David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Shea <dshea@redhat.com>
- *             David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/local.c
+++ b/lib/local.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2018 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Red Hat Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/magic.c
+++ b/lib/magic.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/output.c
+++ b/lib/output.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/output_json.c
+++ b/lib/output_json.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/output_text.c
+++ b/lib/output_text.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/output_xunit.c
+++ b/lib/output_xunit.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2021 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/pairfuncs.c
+++ b/lib/pairfuncs.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Red Hat Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Red Hat Author(s):  David Shea <dshea@redhat.com>
- *                     David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/pic_bits.sh
+++ b/lib/pic_bits.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Shea <dshea@redhat.com>
-#             David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Shea <dshea@redhat.com>
+#            David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public License

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
- *             David Shea <dshea@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
+ *            David Shea <dshea@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/readfile.c
+++ b/lib/readfile.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/rebase.c
+++ b/lib/rebase.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/release.c
+++ b/lib/release.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/results.c
+++ b/lib/results.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Red Hat Author(s):  David Shea <dshea@redhat.com>
- *                     David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2018 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/tty.c
+++ b/lib/tty.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/lib/uncompress.c
+++ b/lib/uncompress.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/regress/all-inspections-kernel.sh
+++ b/regress/all-inspections-kernel.sh
@@ -6,7 +6,7 @@
 # give a general idea of expected runtime on the inspections and
 # downloading.
 #
-# Copyright (C) 2020 David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/regress/indiv-inspections-kernel.sh
+++ b/regress/indiv-inspections-kernel.sh
@@ -6,7 +6,7 @@
 # well. The purpose of this script is to give a general idea of
 # expected runtime on the inspections and downloading.
 #
-# Copyright (C) 2020 David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/rpminspect.1
+++ b/src/rpminspect.1
@@ -1,5 +1,5 @@
-.\" Copyright (C) 2018-2020  Red Hat, Inc.
-.\" Author(s):  David Cantrell <dcantrell@redhat.com>
+.\" Copyright © 2018 Red Hat, Inc.
+.\" Author(s): David Cantrell <dcantrell@redhat.com>
 .\"
 .\" This program is free software: you can redistribute it and/or modify
 .\" it under the terms of the GNU General Public License as published by

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2021  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/data/derp-kmod/derp.c
+++ b/test/data/derp-kmod/derp.c
@@ -1,6 +1,6 @@
 /*
  * derp kernel module
- * Copyright (C) 2020 David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2020 David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/test/lib/elftest.c
+++ b/test/lib/elftest.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/lib/test-abspath.c
+++ b/test/lib/test-abspath.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2021 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/lib/test-badwords.c
+++ b/test/lib/test-badwords.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/lib/test-init.c
+++ b/test/lib/test-init.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/lib/test-inspect_elf.c
+++ b/test/lib/test-inspect_elf.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/lib/test-koji.c
+++ b/test/lib/test-koji.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/lib/test-main.c
+++ b/test/lib/test-main.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019  Red Hat, Inc.
- * Author(s):  David Shea <dshea@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/lib/test-main.h
+++ b/test/lib/test-main.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Shea <dshea@redhat.com>
- *             David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Shea <dshea@redhat.com>
+ *            David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/lib/test-strfuncs.c
+++ b/test/lib/test-strfuncs.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2021  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/lib/test-tty.c
+++ b/test/lib/test-tty.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019  Red Hat, Inc.
- * Author(s):  David Cantrell <dcantrell@redhat.com>
+ * Copyright © 2019 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/test_abidiff.py
+++ b/test/test_abidiff.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_addedfiles.py
+++ b/test/test_addedfiles.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_badfuncs.py
+++ b/test/test_badfuncs.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2021  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2021 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_changedfiles.py
+++ b/test/test_changedfiles.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_default.py
+++ b/test/test_default.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_desktop.py
+++ b/test/test_desktop.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_elf.py
+++ b/test/test_elf.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2021  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_emptyrpm.py
+++ b/test/test_emptyrpm.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_filesize.py
+++ b/test/test_filesize.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  Jeremy Cline <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): Jeremy Cline <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_kmod.py
+++ b/test/test_kmod.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_lostpayload.py
+++ b/test/test_lostpayload.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_lto.py
+++ b/test/test_lto.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020-2021  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_manpage.py
+++ b/test/test_manpage.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2021  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_ownership.py
+++ b/test/test_ownership.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
-#             Jim Bair <jbair@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
+#            Jim Bair <jbair@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020-2021  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_pathmigration.py
+++ b/test/test_pathmigration.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_politics.py
+++ b/test/test_politics.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_runpath.py
+++ b/test/test_runpath.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2021  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2021 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_shellsyntax.py
+++ b/test/test_shellsyntax.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_specname.py
+++ b/test/test_specname.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_symlinks.py
+++ b/test/test_symlinks.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_virus.py
+++ b/test/test_virus.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2020 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2019-2020  Red Hat, Inc.
-# Author(s):  David Cantrell <dcantrell@redhat.com>
+# Copyright © 2019 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/utils/mkannounce.sh
+++ b/utils/mkannounce.sh
@@ -4,7 +4,7 @@
 # blog post.  Groups git log summaries by category and only includes
 # those log entries that have a category marking.
 #
-# Copyright (C) 2021 David Cantrell <david.l.cantrell@gmail.com>
+# Copyright © 2021 David Cantrell <david.l.cantrell@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/utils/mkrpmchangelog.sh
+++ b/utils/mkrpmchangelog.sh
@@ -4,7 +4,7 @@
 # git commits for the project.  Requires consistent usage of
 # tagging for releases.
 #
-# Copyright (C) 2019-2020 David Cantrell <david.l.cantrell@gmail.com>
+# Copyright © 2019 David Cantrell <david.l.cantrell@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -4,7 +4,7 @@
 # use Copr for automated builds and that carry template RPM spec
 # files.  See README for more information.
 #
-# Copyright (C) 2019-2020 David Cantrell <david.l.cantrell@gmail.com>
+# Copyright © 2019 David Cantrell <david.l.cantrell@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/utils/srpm.sh
+++ b/utils/srpm.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2019-2020 David Cantrell <david.l.cantrell@gmail.com>
+# Copyright © 2019 David Cantrell <david.l.cantrell@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/utils/submit-koji-builds.sh
+++ b/utils/submit-koji-builds.sh
@@ -2,7 +2,7 @@
 #
 # Build new releases in Koji
 #
-# Copyright (C) 2019-2020 David Cantrell <david.l.cantrell@gmail.com>
+# Copyright © 2019 David Cantrell <david.l.cantrell@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
As part of an effort to make these more correct, I have normalized
copyright statements that I can within the project.  The general
format I am following is:

    Copyright © [YEAR] [COPYRIGHT OWNER]

The YEAR is the year of first publication, so I am eliminating the
year ranges that are common in open source copyright boilerplates.
The copyright owner in most cases for rpminspect is Red Hat, Inc. but
in some cases it is one or more individuals.

The copyright symbol (©) replaces the "(C)" since the latter has no
legal significance.  At least under US copyright law you can use the
word "Copyright", "Copr.", or "©" to indicate a copyright followed by
the year of first publication and the copyright owner.  I am leaving
the word "Copyright" before the copyright symbol to deal with file
encoding problems if someone reads the source on a system where the
copyright symbol does not display correctly.  By using the copyright
symbol, all of the source files are now UTF-8 encoded.  So you will
need a system that supports that and an editor that supports UTF-8
encoded files.

For more information about this change, see:
https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code

Signed-off-by: David Cantrell <dcantrell@redhat.com>