### PR TITLE
[ci] Add armv7, aarch64, and s390x to the other_arches job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - arch: ppc64le
+                    - arch: [armv7, aarch64, ppc64le, s390x]
                     - distro: fedora_latest
 
         # All of these steps run from within the main source


### PR DESCRIPTION
For fedora_latest.  Trying out the other architectures.

Signed-off-by: David Cantrell <dcantrell@redhat.com>