### PR TITLE
[fix] In read_cfgfile(), keep track of block depth correctly (#329)

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -445,10 +445,9 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     level--;
                 }
 
-                /* At the top?  Reset all block indicators. */
+                /* At the top?  Reset block indicator. */
                 if (level == 1) {
                     block = BLOCK_NULL;
-                    group = BLOCK_NULL;
                 }
 
                 break;
@@ -478,8 +477,8 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         block = BLOCK_INSPECTIONS;
                         group = BLOCK_NULL;
                     } else if (!strcmp(key, "products")) {
-                        block = BLOCK_PRODUCTS;
-                        group = BLOCK_NULL;
+                        block = BLOCK_NULL;
+                        group = BLOCK_PRODUCTS;
                     } else if (!strcmp(key, "ignore")) {
                         block = BLOCK_IGNORE;
                         group = BLOCK_NULL;
@@ -561,11 +560,11 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     key = strdup(t);
 
                     /* handle group subsection blocks here rather than above */
-                    if (group == BLOCK_PATHMIGRATION) {
+                    if (group == BLOCK_PATHMIGRATION || group == BLOCK_MIGRATED_PATHS || group == BLOCK_PATHMIGRATION_EXCLUDED_PATHS) {
                         if (!strcmp(key, "migrated_paths")) {
-                            block = BLOCK_MIGRATED_PATHS;
+                            group = BLOCK_MIGRATED_PATHS;
                         } else if (!strcmp(key, "excluded_paths")) {
-                            block = BLOCK_PATHMIGRATION_EXCLUDED_PATHS;
+                            group = BLOCK_PATHMIGRATION_EXCLUDED_PATHS;
                         }
                     } else if (group == BLOCK_METADATA) {
                         if (!strcmp(key, "buildhost_subdomain")) {
@@ -797,9 +796,9 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         process_table(key, t, &ri->annocheck);
                     } else if (block == BLOCK_JAVABYTECODE) {
                         process_table(key, t, &ri->jvm);
-                    } else if (block == BLOCK_MIGRATED_PATHS) {
+                    } else if (group == BLOCK_MIGRATED_PATHS) {
                         process_table(key, t, &ri->pathmigration);
-                    } else if (block == BLOCK_PRODUCTS) {
+                    } else if (group == BLOCK_PRODUCTS) {
                         process_table(key, t, &ri->products);
                     } else if (block == BLOCK_INSPECTIONS) {
                         if (!strcasecmp(t, "on")) {
@@ -904,7 +903,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         add_entry(&ri->kernel_filenames, t);
                     } else if (block == BLOCK_PATCH_FILENAMES) {
                         add_entry(&ri->patch_ignore_list, t);
-                    } else if (block == BLOCK_PATHMIGRATION_EXCLUDED_PATHS) {
+                    } else if (group == BLOCK_PATHMIGRATION_EXCLUDED_PATHS) {
                         add_entry(&ri->pathmigration_excluded_paths, t);
                     } else if (block == BLOCK_RUNPATH_ALLOWED_PATHS) {
                         add_entry(&ri->runpath_allowed_paths, t);

--- a/lib/init.c
+++ b/lib/init.c
@@ -378,6 +378,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
     int symbol = SYMBOL_NULL;
     int block = BLOCK_NULL;
     int group = BLOCK_NULL;
+    unsigned int level = 0;
     char *key = NULL;
     char *t = NULL;
     bool exclude = false;
@@ -432,8 +433,28 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     read_list = false;
                 }
 
+                /*
+                 * Go back up a level until we are at level 1.  The
+                 * variable is initialized to 0 though we don't really
+                 * use that level.  libyaml throws out two
+                 * YAML_BLOCK_END_TOKENs when reading a stream.  The
+                 * first one can be ignored so level 1 becomes our
+                 * effective top level.
+                 */
+                if (level > 1) {
+                    level--;
+                }
+
+                /* At the top?  Reset all block indicators. */
+                if (level == 1) {
+                    block = BLOCK_NULL;
+                    group = BLOCK_NULL;
+                }
+
                 break;
             case YAML_BLOCK_MAPPING_START_TOKEN:
+                /* YAML is all endless blocks */
+                level++;
                 break;
             case YAML_SCALAR_TOKEN:
                 /* convert the value to a string for comparison and copying */

--- a/osdeps/arch/post.sh
+++ b/osdeps/arch/post.sh
@@ -44,7 +44,7 @@ make install
 cd ${CWD}
 rm -rf rc
 
-# Install libabigail from AUR
+# Install libabigail from git
 cd ${CWD}
 git clone git://sourceware.org/git/libabigail.git
 cd libabigail


### PR DESCRIPTION
I was not properly keeping track of where I was in the YAML configuration file.  Since I have block names that match inspection names, this is important when reading a subset configuration file (such as a profile).  What I've done is add a level counter and increment and decrement that based on the YAML tokens I get back from libyaml.  The stream technically starts at level 0, but you'll never get back to that before descending again so I let it count up to 1 and beyond but then only ever decrement back to 1 before the stream ends.  The result here is that when you return to level 1 then the block and group indicators are reset which allows reading a new section in the configuration file.
    
Signed-off-by: David Cantrell <dcantrell@redhat.com>