### PR TITLE
[lib] Finish normalizing all the error reporting statements

### DIFF
--- a/TODO
+++ b/TODO
@@ -28,9 +28,6 @@ Other:
       rebased but not on the rebaseable list.  This should be off by
       default but then enabled in a maintenance profile.  Maybe???
 
-    - Unify the error and debug reporting using consistent functions
-      and messaging.  (e.g., warn() and err())
-
 
 Test categories that have been migrated:
 ----------------------------------------

--- a/lib/checksums.c
+++ b/lib/checksums.c
@@ -36,6 +36,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <err.h>
 #include <assert.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
@@ -83,8 +84,7 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
     /* don't calculate the checksum of a device node */
     if (S_ISCHR(*mode) || S_ISBLK(*mode) ||
         S_ISFIFO(*mode) || S_ISSOCK(*mode)) {
-        fprintf(stderr, _("*** Cannot calculate checksum on devices or fifos: %s\n"), filename);
-        fflush(stderr);
+        warnx(_("%s is a FIFO"), filename);
         return NULL;
     }
 
@@ -108,14 +108,12 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
 
     /* read in the file to generate the requested checksum */
     if ((input = open(filename, O_RDONLY)) == -1) {
-        fprintf(stderr, _("*** Unable to open %s: %s\n"), filename, strerror(errno));
-        fflush(stderr);
+        warn("open()");
         return NULL;
     }
 
     if ((len = read(input, buf, sizeof(buf))) == -1) {
-        fprintf(stderr, "%s (%d): %s\n", __func__, __LINE__, strerror(errno));
-        fflush(stderr);
+        warn("read()");
         return NULL;
     }
 
@@ -132,15 +130,13 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
         }
 
         if ((len = read(input, buf, sizeof(buf))) == -1) {
-            fprintf(stderr, "%s (%d): %s\n", __func__, __LINE__, strerror(errno));
-            fflush(stderr);
+            warn("read()");
             return NULL;
         }
     }
 
     if (close(input) == -1) {
-        fprintf(stderr, "%s (%d): %s\n", __func__, __LINE__, strerror(errno));
-        fflush(stderr);
+        warn("close()");
         return NULL;
     }
 
@@ -171,8 +167,7 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
 
     /* this is our human readable digest, caller must free */
     if ((ret = calloc(len + 1, sizeof(char *))) == NULL) {
-        fprintf(stderr, "%s (%d): %s\n", __func__, __LINE__, strerror(errno));
-        fflush(stderr);
+        warn("calloc()");
         return NULL;
     }
 

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -141,10 +141,10 @@ void dump_cfg(const struct rpminspect *ri)
     }
 
     if (ri->products) {
-        fprintf(stderr, "products:\n");
+        printf("products:\n");
 
         HASH_ITER(hh, ri->products, hentry, tmp_hentry) {
-            fprintf(stderr, "    - %s: %s\n", hentry->key, hentry->value);
+            printf("    - %s: %s\n", hentry->key, hentry->value);
         }
     }
 
@@ -325,29 +325,29 @@ void dump_cfg(const struct rpminspect *ri)
     printf("    primary: %s\n", (ri->specprimary == PRIMARY_NAME) ? "name" : (ri->specprimary == PRIMARY_FILENAME) ? "filename" : "?");
 
     if (ri->annocheck) {
-        fprintf(stderr, "annocheck:\n");
+        printf("annocheck:\n");
 
         HASH_ITER(hh, ri->annocheck, hentry, tmp_hentry) {
-            fprintf(stderr, "    - %s: %s\n", hentry->key, hentry->value);
+            printf("    - %s: %s\n", hentry->key, hentry->value);
         }
     }
 
     if (ri->jvm) {
-        fprintf(stderr, "javabytecode:\n");
+        printf("javabytecode:\n");
 
         HASH_ITER(hh, ri->jvm, hentry, tmp_hentry) {
-            fprintf(stderr, "    - %s: %s\n", hentry->key, hentry->value);
+            printf("    - %s: %s\n", hentry->key, hentry->value);
         }
     }
 
     if (ri->pathmigration || (ri->pathmigration_excluded_paths && !TAILQ_EMPTY(ri->pathmigration_excluded_paths))) {
-        fprintf(stderr, "pathmigration:\n");
+        printf("pathmigration:\n");
 
         if (ri->pathmigration) {
-            fprintf(stderr, "    migrated_paths:\n");
+            printf("    migrated_paths:\n");
 
             HASH_ITER(hh, ri->pathmigration, hentry, tmp_hentry) {
-                fprintf(stderr, "        - %s: %s\n", hentry->key, hentry->value);
+                printf("        - %s: %s\n", hentry->key, hentry->value);
             }
         }
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -179,7 +179,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
     }
 
     if (mkdir(*output_dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == -1) {
-        warn(_("*** mkdir(%s)"), *output_dir);
+        warn("mkdir()");
         return NULL;
     }
 
@@ -208,7 +208,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
         rpm_path = rpmtdNextString(td);
 
         if (rpm_path == NULL) {
-            warn(_("*** error reading RPM metadata for %s"), pkg);
+            warn("rpmtdNextString()");
             goto cleanup;
         }
 
@@ -231,7 +231,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
     archive_read_support_format_all(archive);
 
     if (archive_read_open_filename(archive, pkg, 10240) != ARCHIVE_OK) {
-        warn(_("*** unable to open %s with libarchive: %s"), pkg, archive_error_string(archive));
+        warn("archive_read_open_filename()");
         goto cleanup;
     }
 
@@ -246,7 +246,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
         }
 
         if (archive_result != ARCHIVE_OK) {
-            warn(_("*** error reading from archive %s: %s"), pkg, archive_error_string(archive));
+            warn("archive_read_next_header()");
             free_files(file_list);
             file_list = NULL;
             goto cleanup;
@@ -315,7 +315,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
 
         /* Write the file to disk */
         if (archive_read_extract(archive, entry, archive_flags) != ARCHIVE_OK) {
-            warn(_("*** error extracting %s: %s"), pkg, archive_error_string(archive));
+            warn("archive_read_extract()");
             free_files(file_list);
             file_list = NULL;
             goto cleanup;
@@ -809,14 +809,14 @@ cap_t get_cap(rpmfile_entry_t *file)
 
     /* Gather capabilities(7) for the file we need */
     if ((fd = open(file->fullpath, O_RDONLY)) == -1) {
-        fprintf(stderr, _("*** unable to open() %s on %s: %s\n"), file->localpath, arch, strerror(errno));
+        warn("open()");
         return NULL;
     }
 
     file->cap = cap_get_fd(fd);
 
     if (close(fd) == -1) {
-        fprintf(stderr, _("*** unable to close() %s on %s: %s\n"), file->localpath, arch, strerror(errno));
+        warn("close()");
     }
 
     return file->cap;

--- a/lib/init.c
+++ b/lib/init.c
@@ -243,7 +243,7 @@ static mode_t parse_mode(const char *input) {
     assert(input != NULL);
 
     if (strlen(input) != 10) {
-        warn(_("*** Invalid input string `%s`"), input);
+        warn(_("invalid input string `%s`"), input);
         return mode;
     }
 
@@ -270,7 +270,7 @@ static mode_t parse_mode(const char *input) {
         mode |= S_IFWHT;
 #endif
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -279,7 +279,7 @@ static mode_t parse_mode(const char *input) {
     if (i == 'r') {
         mode |= S_IRUSR;
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -287,7 +287,7 @@ static mode_t parse_mode(const char *input) {
     if (i == 'w') {
         mode |= S_IWUSR;
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -299,7 +299,7 @@ static mode_t parse_mode(const char *input) {
     } else if (i == 's') {
         mode |= S_IXUSR | S_ISUID;
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -308,7 +308,7 @@ static mode_t parse_mode(const char *input) {
     if (i == 'r') {
         mode |= S_IRGRP;
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -316,7 +316,7 @@ static mode_t parse_mode(const char *input) {
     if (i == 'w') {
         mode |= S_IWGRP;
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -328,7 +328,7 @@ static mode_t parse_mode(const char *input) {
     } else if (i == 's') {
         mode |= S_IXGRP | S_ISGID;
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -337,7 +337,7 @@ static mode_t parse_mode(const char *input) {
     if (i == 'r') {
         mode |= S_IROTH;
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -345,7 +345,7 @@ static mode_t parse_mode(const char *input) {
     if (i == 'w') {
         mode |= S_IWOTH;
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -357,7 +357,7 @@ static mode_t parse_mode(const char *input) {
     } else if (i == 't') {
         mode |= S_IXOTH | S_ISVTX;
     } else if (i != '-') {
-        warnx(_("*** Invalid mode string: %s"), input);
+        warnx(_("*** invalid mode string: %s"), input);
         return mode;
     }
 
@@ -388,13 +388,13 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
 
     /* prepare a YAML parser */
     if (!yaml_parser_initialize(&parser)) {
-        warn(_("yaml_parser_initialize()"));
+        warn("yaml_parser_initialize()");
         return -1;
     }
 
     /* open the config file */
     if ((fp = fopen(filename, "r")) == NULL) {
-        warn(_("fopen()"));
+        warn("fopen()");
         return -1;
     }
 
@@ -718,7 +718,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             }
 
                             if (add_regex(t, &ri->elf_path_include) != 0) {
-                                warn(_("*** error reading elf include path"));
+                                warn(_("error reading elf include path"));
                             }
                         } else if (!strcmp(key, "exclude_path")) {
                             if (debug_mode) {
@@ -727,7 +727,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             }
 
                             if (add_regex(t, &ri->elf_path_exclude) != 0) {
-                                warn(_("*** error reading elf exclude path"));
+                                warn(_("error reading elf exclude path"));
                             }
                         }
                     } else if (block == BLOCK_MANPAGE) {
@@ -738,7 +738,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             }
 
                             if (add_regex(t, &ri->manpage_path_include) != 0) {
-                                warn(_("*** error reading man page include path"));
+                                warn(_("error reading man page include path"));
                             }
                         } else if (!strcmp(key, "exclude_path")) {
                             if (debug_mode) {
@@ -747,7 +747,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             }
 
                             if (add_regex(t, &ri->manpage_path_exclude) != 0) {
-                                warn(_("*** error reading man page exclude path"));
+                                warn(_("error reading man page exclude path"));
                             }
                         }
                     } else if (block == BLOCK_XML) {
@@ -758,7 +758,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             }
 
                             if (add_regex(t, &ri->xml_path_include) != 0) {
-                                warn(_("*** error reading xml include path"));
+                                warn(_("error reading xml include path"));
                             }
                         } else if (!strcmp(key, "exclude_path")) {
                             if (debug_mode) {
@@ -767,7 +767,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             }
 
                             if (add_regex(t, &ri->xml_path_exclude) != 0) {
-                                warn(_("*** error reading xml exclude path"));
+                                warn(_("error reading xml exclude path"));
                             }
                         }
                     } else if (block == BLOCK_DESKTOP) {
@@ -929,7 +929,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
     yaml_parser_delete(&parser);
 
     if (fclose(fp) != 0) {
-        warn(_("fclose(%s)"), filename);
+        warn("fclose()");
         return -1;
     }
 
@@ -1416,7 +1416,7 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         filename = realpath(tmp, NULL);
 
         if ((filename == NULL) || (access(filename, F_OK|R_OK) == -1)) {
-            warn(_("*** Unable to read profile '%s' from %s\n"), profile, filename);
+            warn(_("*** unable to read profile '%s' from %s\n"), profile, filename);
         } else {
             i = read_cfgfile(ri, filename);
 

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -74,12 +74,12 @@ static char *run_and_capture(const char *where, char **output, char *cmd, const 
     fd = mkstemp(*output);
 
     if (fd == -1) {
-        warn(_("mkstemp()"));
+        warn("mkstemp()");
         return false;
     }
 
     if (close(fd) == -1) {
-        warn(_("close()"));
+        warn("close()");
         return false;
     }
 
@@ -188,17 +188,17 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         fd = open(file->fullpath, O_RDONLY | O_CLOEXEC | O_LARGEFILE);
 
         if (fd == -1) {
-            warn(_("open()"));
+            warn("open()");
             return true;
         }
 
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
-            warn(_("read()"));
+            warn("read()");
             return true;
         }
 
         if (close(fd) == -1) {
-            warn(_("close()"));
+            warn("close()");
             return true;
         }
 
@@ -305,11 +305,11 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         /* Remove the temporary files */
         if (unlink(before_tmp) == -1) {
-            warn(_("unlink(%s)"), before_tmp);
+            warn("unlink()");
         }
 
         if (unlink(after_tmp) == -1) {
-            warn(_("unlink(%s)"), after_tmp);
+            warn("unlink()");
         }
 
         if (exitcode) {

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <time.h>
 #include <errno.h>
+#include <err.h>
 #include <string.h>
 #include <rpm/header.h>
 
@@ -132,7 +133,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     fd = mkstemp(output);
 
     if (fd == -1) {
-        fprintf(stderr, "*** unable to create temporary file %s: %s\n", output, strerror(errno));
+        warn("mkstemp()");
         free(output);
         return NULL;
     }
@@ -140,7 +141,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     logfp = fdopen(fd, "w");
 
     if (logfp == NULL) {
-        fprintf(stderr, "*** unable to open temporary file %s for writing: %s\n", output, strerror(errno));
+        warn("fdopen()");
         close(fd);
         free(output);
         return NULL;
@@ -151,7 +152,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     }
 
     if (fclose(logfp) != 0) {
-        fprintf(stderr, "*** unable to close writing to temporary file %s: %s\n", output, strerror(errno));
+        warn("fclose()");
         close(fd);
         free(output);
         return NULL;

--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -30,8 +30,6 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <archive.h>
-#include <archive_entry.h>
 #include "rpminspect.h"
 
 /**

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -63,17 +63,17 @@ static short get_jvm_major(const char *filename, const char *localpath,
         fd = open(filename, O_RDONLY | O_CLOEXEC | O_LARGEFILE);
 
         if (fd == -1) {
-            fprintf(stderr, _("unable to open(2) %s from %s for reading: %s\n"), localpath, container, strerror(errno));
+            warn("open()");
             return -1;
         }
 
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
-            fprintf(stderr, _("unable to read(2) %s from %s: %s\n"), localpath, container, strerror(errno));
+            warn("read()");
             return -1;
         }
 
         if (close(fd) == -1) {
-            fprintf(stderr, _("unable to close(2) %s from %s: %s\n"), localpath, container, strerror(errno));
+            warn("close()");
             return -1;
         }
 
@@ -180,9 +180,11 @@ static bool javabytecode_driver(struct rpminspect *ri, rpmfile_entry_t *file, co
 
         /* create a temporary directory to unpack this file */
         xasprintf(&tmppath, "%s/jar.XXXXXX", ri->workdir);
+        tmppath = mkdtemp(tmppath);
 
-        if ((tmppath = mkdtemp(tmppath)) == NULL) {
-            fprintf(stderr, _("*** unable to create a temporary directory for %s: %s\n"), file->fullpath, strerror(errno));
+        if (tmppath == NULL) {
+            warn("mkdtemp()");
+            free(tmppath);
             return false;
         }
 
@@ -201,7 +203,7 @@ static bool javabytecode_driver(struct rpminspect *ri, rpmfile_entry_t *file, co
 
         if (jarstatus != 0) {
             /* we errored somewhere, just report it */
-            fprintf(stderr, _("*** error walking the unpacked directory tree for %s\n"), file->fullpath);
+            warn("nftw()");
         }
 
         /* clean up */

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <libgen.h>
 #include <errno.h>
+#include <err.h>
 #include <assert.h>
 
 #include "rpminspect.h"
@@ -145,7 +146,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     kctx = kmod_new(NULL, NULL);
 
     if (kctx == NULL) {
-        fprintf(stderr, _("*** kmod_new() failure\n"));
+        warn("kmod_new()");
         return false;
     }
 
@@ -162,7 +163,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     kctx = kmod_new(NULL, NULL);
 
     if (kctx == NULL) {
-        fprintf(stderr, _("*** kmod_new() failure\n"));
+        warn("kmod_new()");
         return false;
     }
 
@@ -179,7 +180,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Gather module parameters */
     err = kmod_module_get_info(beforekmod, &beforeinfo);
     if (err < 0) {
-        fprintf(stderr, _("*** error reading before kernel module %s\n"), file->peer_file->fullpath);
+        warn("kmod_module_get_info()");
         kmod_module_unref(beforekmod);
         kmod_module_unref(afterkmod);
         kmod_unref(kctx);
@@ -188,7 +189,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     err = kmod_module_get_info(afterkmod, &afterinfo);
     if (err < 0) {
-        fprintf(stderr, _("*** error reading after kernel module %s\n"), file->peer_file->fullpath);
+        warn("kmod_module_get_info()");
         kmod_module_info_free_list(beforeinfo);
         kmod_module_unref(beforekmod);
         kmod_module_unref(afterkmod);

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -29,6 +29,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <err.h>
 #include <stdbool.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -54,8 +55,7 @@ static struct json_object *read_licensedb(const char *licensedb)
     fd = open(licensedb, O_RDONLY);
 
     if (fd == -1) {
-        fprintf(stderr, _("*** Unable to open license db %s: %s\n"), licensedb, strerror(errno));
-        fflush(stderr);
+        warn(_("unable to open license db %s"), licensedb);
         return NULL;
     }
 

--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -30,8 +30,6 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <archive.h>
-#include <archive_entry.h>
 #include "rpminspect.h"
 
 /**

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -55,9 +55,7 @@ static regex_t sections_regex;
 static void error_handler(enum mandocerr errtype, enum mandoclevel level,
                           const char *file, int line, int col, const char *msg)
 {
-    fprintf(error_stream, _("Error parsing %s:%d:%d: %s: %s: %s\n"),
-            basename(file), line, col, mparse_strlevel(level),
-            mparse_strerror(errtype), msg);
+    fprintf(error_stream, _("Error parsing %s:%d:%d: %s: %s: %s\n"), basename(file), line, col, mparse_strlevel(level), mparse_strerror(errtype), msg);
 }
 #endif
 
@@ -86,7 +84,7 @@ static bool inspect_manpage_alloc(void)
     free(tmp);
     if (reg_result != 0) {
         regerror(reg_result, &sections_regex, reg_error, sizeof(reg_error));
-        fprintf(stderr, _("Unable to compile man page path regular expression: %s\n"), reg_error);
+        warnx(_("unable to compile man page path regular expression: %s"), reg_error);
         inspect_manpage_free();
         return false;
     }
@@ -307,7 +305,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             result = false;
             free(params.msg);
         } else if (r == -1) {
-            warn(_("stat()"));
+            warn("stat()");
         }
 
         free(uncompressed_man_page);

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -199,7 +199,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
 
                 if (cap) {
                     if (cap_get_flag(cap, CAP_SETUID, CAP_EFFECTIVE, &have_setuid) == -1) {
-                        fprintf(stderr, _("*** unable to get capabilities for %s\n"), file->localpath);
+                        warnx("cap_get_flag()");
                         have_setuid = CAP_CLEAR;
                     }
                 }

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -144,7 +144,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
 
                         if (reg_result != 0) {
                             regerror(reg_result, &origin_root, reg_error, sizeof(reg_error));
-                            warn(_("regexec(): %s"), reg_error);
+                            warn("regexec(): %s", reg_error);
                             regfree(&origin_root);
                             continue;
                         }

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <err.h>
 #include <assert.h>
 
 #include "rpminspect.h"
@@ -50,8 +51,7 @@ static char *get_shell(const struct rpminspect *ri, const char *fullpath)
     fp = fopen(fullpath, "r");
 
     if (fp == NULL) {
-        fprintf(stderr, _("error opening %s for reading: %s\n"), fullpath, strerror(errno));
-        fflush(stderr);
+        warn("fopen()");
         return NULL;
     }
 
@@ -59,13 +59,11 @@ static char *get_shell(const struct rpminspect *ri, const char *fullpath)
     start = buf;
 
     if (fclose(fp) == -1) {
-        fprintf(stderr, _("error closing %s: %s\n"), fullpath, strerror(errno));
-        fflush(stderr);
+        warn("fclose()");
     }
 
     if (r == -1) {
-        fprintf(stderr, _("error reading first line from %s: %s\n"), fullpath, strerror(errno));
-        fflush(stderr);
+        warn("getline()");
     } else if (!strncmp(buf, "#!", 2)) {
         /* trim newlines */
         buf[strcspn(buf, "\n")] = '\0';

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -261,8 +261,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     TAILQ_FOREACH(peer, ri->peers, items) {
         /* move to the subpackage root */
         if (chdir(peer->after_root) == -1) {
-            fprintf(stderr, "*** unable to chdir to %s: %s\n", peer->after_root, strerror(errno));
-            fflush(stderr);
+            warn("chdir()");
             continue;
         }
 

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -103,7 +103,7 @@ static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         result = false;
     } else if (r != CL_CLEAN) {
-        warnx(_("cl_scanfile(%s): %s"), file->localpath, cl_strerror(r));
+        warnx("cl_scanfile(%s): %s", file->localpath, cl_strerror(r));
     }
 
     return result;
@@ -118,7 +118,7 @@ bool inspect_virus(struct rpminspect *ri)
     r = cl_init(CL_INIT_DEFAULT);
 
     if (r != CL_SUCCESS) {
-        warnx(_("cl_init(): %s"), cl_strerror(r));
+        warnx("cl_init(): %s", cl_strerror(r));
         return false;
     }
 

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <err.h>
 #include <limits.h>
 #include <xmlrpc-c/client.h>
 #include <xmlrpc-c/client_global.h>
@@ -35,9 +36,7 @@
 static void xmlrpc_abort_on_fault(xmlrpc_env *env)
 {
     if (env->fault_occurred) {
-        fprintf(stderr, _("XML-RPC Fault: %s (%d)\n"), env->fault_string, env->fault_code);
-        fflush(stderr);
-        abort();
+        errx(RI_PROGRAM_ERROR, _("XML-RPC Fault: %s (%d)"), env->fault_string, env->fault_code);
     }
 }
 

--- a/lib/local.c
+++ b/lib/local.c
@@ -51,8 +51,7 @@ bool is_local_build(const char *build) {
     }
 
     if (stat(build, &sb) == -1) {
-        fprintf(stderr, "%s (%d): %s\n", __func__, __LINE__, strerror(errno));
-        fflush(stderr);
+        warn("stat()");
         return false;
     }
 
@@ -67,14 +66,12 @@ bool is_local_build(const char *build) {
     }
 
     if (chdir(build) == -1) {
-        fprintf(stderr, "%s (%d): %s\n", __func__, __LINE__, strerror(errno));
-        fflush(stderr);
+        warn("chdir()");
         return false;
     }
 
     if (chdir(cwd) == -1) {
-        fprintf(stderr, "%s (%d): %s\n", __func__, __LINE__, strerror(errno));
-        fflush(stderr);
+        warn("chdir()");
         return false;
     }
 

--- a/lib/output_json.c
+++ b/lib/output_json.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <err.h>
 #include <assert.h>
 #include <json.h>
 
@@ -95,8 +96,7 @@ void output_json(const results_t *results, const char *dest, __attribute__((unus
         fp = fopen(dest, "w");
 
         if (fp == NULL) {
-            fprintf(stderr, _("*** Error opening %s for writing: %s\n"), dest, strerror(errno));
-            fflush(stderr);
+            warn(_("error opening %s for writing"), dest);
             return;
         }
     }

--- a/lib/output_text.c
+++ b/lib/output_text.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <err.h>
 #include <assert.h>
 
 #include "rpminspect.h"
@@ -48,8 +49,7 @@ void output_text(const results_t *results, const char *dest, __attribute__((unus
         fp = fopen(dest, "w");
 
         if (fp == NULL) {
-            fprintf(stderr, _("*** Error opening %s for writing: %s\n"), dest, strerror(errno));
-            fflush(stderr);
+            warn(_("error opening %s for writing"), dest);
             return;
         }
     }

--- a/lib/pic_bits.sh
+++ b/lib/pic_bits.sh
@@ -64,7 +64,9 @@ echo " * See pic_bits.sh to modify." >> $1
 echo " */" >> $1
 echo "#include <stdbool.h>" >> $1
 echo "#include <stdio.h>" >> $1
+echo "#include <err.h>" >> $1
 echo "#include <elf.h>" >> $1
+echo "#include \"rpminspect.h\"" >> $1
 echo "bool is_pic_reloc(Elf64_Half machine, Elf64_Xword rel_type)" >> $1
 echo "{" >> $1
 echo "    switch (machine) {" >> $1
@@ -96,8 +98,8 @@ echo "$cpp_output" | sed -n -E 's/^#define[[:space:]]+(EM_[^[:space:]]+).*/\1/p'
 
 echo "        default:" >> $1
 # use printf to avoid a non-bash /bin/sh's echo messing up the \'s.
-printf '            fprintf(stderr, "WARNING: Unknown machine type %%u\\n", machine);\n' >> $1
-printf '            fprintf(stderr, "Recompile librpminspect with a newer elf.h, or make necessary modifications to pic_bits.sh\\n");\n' >> $1
+printf '            warnx(_("unknown machine type %%u\\n"), machine);\n' >> $1
+printf '            warnx(_("Recompile librpminspect with a newer elf.h, or make necessary modifications to pic_bits.sh\\n"));\n' >> $1
 echo "            return false;" >> $1
 echo "    }" >> $1
 echo "}" >> $1

--- a/lib/uncompress.c
+++ b/lib/uncompress.c
@@ -192,14 +192,14 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     r = archive_read_open_filename(input, infile, 16384);
 
     if (r != ARCHIVE_OK) {
-        warn("archive_read_open_filename()");
+        warn("archive_read_open_filename(): %s", archive_error_string(input));
         goto error2;
     }
 
     r = archive_read_next_header(input, &entry);
 
     if (r == ARCHIVE_WARN || r == ARCHIVE_FAILED || r == ARCHIVE_FATAL) {
-        warn("archive_read_next_header()");
+        warn("archive_read_next_header(): %s", archive_error_string(input));
         goto error2;
     }
 

--- a/lib/unpack.c
+++ b/lib/unpack.c
@@ -52,7 +52,7 @@ static int copy_data(struct archive *ar, struct archive *aw) {
         r = archive_write_data_block(aw, buf, s, o);
 
         if (r != ARCHIVE_OK) {
-            warnx("%s", archive_error_string(aw));
+            warnx("archive_write_data_block(): %s", archive_error_string(aw));
             return r;
         }
     }
@@ -68,7 +68,7 @@ static int extract_entry(struct archive *input, struct archive *output, struct a
     r = archive_write_header(output, entry);
 
     if (r != ARCHIVE_OK) {
-        warnx("%s", archive_error_string(output));
+        warnx("archive_write_header(): %s", archive_error_string(output));
         ret = -1;
     } else if (archive_entry_size(entry) > 0) {
         if (copy_data(input, output) != ARCHIVE_OK) {
@@ -76,7 +76,7 @@ static int extract_entry(struct archive *input, struct archive *output, struct a
         }
 
         if (r != ARCHIVE_OK) {
-            warnx("%s", archive_error_string(output));
+            warnx("archive_write_header(): %s", archive_error_string(output));
         } else if (r < ARCHIVE_WARN) {
             ret = -1;
         }
@@ -85,7 +85,7 @@ static int extract_entry(struct archive *input, struct archive *output, struct a
     r = archive_write_finish_entry(output);
 
     if (r != ARCHIVE_OK) {
-        warnx("%s", archive_error_string(output));
+        warnx("archive_write_finish_entry(): %s", archive_error_string(output));
     } else if (r < ARCHIVE_WARN) {
         ret = -1;
     }
@@ -125,7 +125,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force) {
         if (errno == ENOENT) {
             return 0;
         } else {
-            warn(_("realpath(%s)"), archive);
+            warn("realpath()");
             return -1;
         }
     }
@@ -141,7 +141,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force) {
     r = archive_read_open_filename(input, archive, 16384);
 
     if (r != ARCHIVE_OK) {
-        warnx(_("error opening %s"), archive);
+        warn("archive_read_open_filename(): %s", archive_error_string(input));
         return -1;
     }
 
@@ -151,7 +151,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force) {
     }
 
     if (chdir(dest) != 0) {
-        warn(_("chdir(%s)"), dest);
+        warn("chdir()");
         return -1;
     }
 
@@ -163,7 +163,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force) {
     /* extract each archive member */
     while ((r = archive_read_next_header(input, &entry)) != ARCHIVE_EOF) {
         if (r != ARCHIVE_OK) {
-            warnx("%s", archive_error_string(input));
+            warnx("archive_read_next_header(): %s", archive_error_string(input));
         } else if (r < ARCHIVE_WARN) {
             ret = -1;
         }
@@ -182,7 +182,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force) {
 
     /* change back to original directory */
     if (chdir(cwd) != 0) {
-        warn(_("chdir(%s)"), cwd);
+        warn("chdir()");
         return -1;
     }
 


### PR DESCRIPTION
Migrate most of the error reporting to warn(), warnx(), err(), and
errx().  This drops the use of fprintf, fflush, and sometimes abort in
cases where I wanted to stop execution.  The err.h functions will
handle strerror() for me and in cases where that doesn't happen I use
the called library's error string function if available.

Signed-off-by: David Cantrell <dcantrell@redhat.com>