### PR TITLE
[lib] Add inspection_id() to librpminspect

### DIFF
--- a/include/inspect.h
+++ b/include/inspect.h
@@ -71,6 +71,13 @@
 bool foreach_peer_file(struct rpminspect *ri, foreach_peer_file_func callback, bool use_ignore);
 
 /**
+ * @brief Return inspection ID given its name string.
+ *
+ * @param name Inspection name.
+ */
+uint64_t inspection_id(const char *name);
+
+/**
  * @brief Return inspection description string given its ID.
  *
  * Return the long description for the specified inspection.
@@ -510,6 +517,7 @@ bool inspect_runpath(struct rpminspect *ri);
  * command line.
  */
 
+#define INSPECT_NULL                        ((uint64_t) 0)
 #define INSPECT_LICENSE                     (((uint64_t) 1) << 1)
 #define INSPECT_EMPTYRPM                    (((uint64_t) 1) << 2)
 #define INSPECT_METADATA                    (((uint64_t) 1) << 3)
@@ -552,6 +560,50 @@ bool inspect_runpath(struct rpminspect *ri);
 #define INSPECT_POLITICS                    (((uint64_t) 1) << 40)
 #define INSPECT_BADFUNCS                    (((uint64_t) 1) << 41)
 #define INSPECT_RUNPATH                     (((uint64_t) 1) << 42)
+
+/* Inspection names */
+#define NAME_LICENSE                        "license"
+#define NAME_EMPTYRPM                       "emptyrpm"
+#define NAME_METADATA                       "metadata"
+#define NAME_MANPAGE                        "manpage"
+#define NAME_XML                            "xml"
+#define NAME_ELF                            "elf"
+#define NAME_DESKTOP                        "desktop"
+#define NAME_DISTTAG                        "disttag"
+#define NAME_SPECNAME                       "specname"
+#define NAME_MODULARITY                     "modularity"
+#define NAME_JAVABYTECODE                   "javabytecode"
+#define NAME_CHANGEDFILES                   "changedfiles"
+#define NAME_MOVEDFILES                     "movedfiles"
+#define NAME_REMOVEDFILES                   "removedfiles"
+#define NAME_ADDEDFILES                     "addedfiles"
+#define NAME_UPSTREAM                       "upstream"
+#define NAME_OWNERSHIP                      "ownership"
+#define NAME_SHELLSYNTAX                    "shellsyntax"
+#define NAME_ANNOCHECK                      "annocheck"
+#define NAME_DSODEPS                        "dsodeps"
+#define NAME_FILESIZE                       "filesize"
+#define NAME_PERMISSIONS                    "permissions"
+#define NAME_CAPABILITIES                   "capabilities"
+#define NAME_KMOD                           "kmod"
+#define NAME_ARCH                           "arch"
+#define NAME_SUBPACKAGES                    "subpackages"
+#define NAME_CHANGELOG                      "changelog"
+#define NAME_PATHMIGRATION                  "pathmigration"
+#define NAME_LTO                            "lto"
+#define NAME_SYMLINKS                       "symlinks"
+#define NAME_LOSTPAYLOAD                    "lostpayload"
+#define NAME_FILES                          "files"
+#define NAME_TYPES                          "types"
+#define NAME_ABIDIFF                        "abidiff"
+#define NAME_KMIDIFF                        "kmidiff"
+#define NAME_CONFIG                         "config"
+#define NAME_DOC                            "doc"
+#define NAME_PATCHES                        "patches"
+#define NAME_VIRUS                          "virus"
+#define NAME_POLITICS                       "politics"
+#define NAME_BADFUNCS                       "badfuncs"
+#define NAME_RUNPATH                        "runpath"
 
 /* Long descriptions for the inspections */
 #define DESC_LICENSE _("Verify the string specified in the License tag of the RPM metadata describes permissible software licenses as defined by the license database. Also checks to see if the License tag contains any unprofessional words as defined in the configuration file.")

--- a/lib/init.c
+++ b/lib/init.c
@@ -485,70 +485,70 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     } else if (!strcmp(key, "security_path_prefix")) {
                         block = BLOCK_SECURITY_PATH_PREFIX;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "badfuncs")) {
+                    } else if (!strcmp(key, NAME_BADFUNCS)) {
                         block = BLOCK_BADFUNCS;
                         group = BLOCK_NULL;
                     } else if (!strcmp(key, "badwords")) {
                         block = BLOCK_BADWORDS;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "metadata")) {
+                    } else if (!strcmp(key, NAME_METADATA)) {
                         block = BLOCK_NULL;
                         group = BLOCK_METADATA;
-                    } else if (!strcmp(key, "elf")) {
+                    } else if (!strcmp(key, NAME_ELF)) {
                         block = BLOCK_NULL;
                         group = BLOCK_ELF;
-                    } else if (!strcmp(key, "manpage")) {
+                    } else if (!strcmp(key, NAME_MANPAGE)) {
                         block = BLOCK_MANPAGE;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "xml")) {
+                    } else if (!strcmp(key, NAME_XML)) {
                         block = BLOCK_XML;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "desktop")) {
+                    } else if (!strcmp(key, NAME_DESKTOP)) {
                         block = BLOCK_DESKTOP;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "changedfiles")) {
+                    } else if (!strcmp(key, NAME_CHANGEDFILES)) {
                         block = BLOCK_NULL;
                         group = BLOCK_CHANGEDFILES;
-                    } else if (!strcmp(key, "addedfiles")) {
+                    } else if (!strcmp(key, NAME_ADDEDFILES)) {
                         block = BLOCK_NULL;
                         group = BLOCK_ADDEDFILES;
-                    } else if (!strcmp(key, "ownership")) {
+                    } else if (!strcmp(key, NAME_OWNERSHIP)) {
                         block = BLOCK_NULL;
                         group = BLOCK_OWNERSHIP;
-                    } else if (!strcmp(key, "shellsyntax")) {
+                    } else if (!strcmp(key, NAME_SHELLSYNTAX)) {
                         block = BLOCK_NULL;
                         group = BLOCK_SHELLSYNTAX;
-                    } else if (!strcmp(key, "filesize")) {
+                    } else if (!strcmp(key, NAME_FILESIZE)) {
                         block = BLOCK_FILESIZE;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "lto")) {
+                    } else if (!strcmp(key, NAME_LTO)) {
                         block = BLOCK_NULL;
                         group = BLOCK_LTO;
-                    } else if (!strcmp(key, "specname")) {
+                    } else if (!strcmp(key, NAME_SPECNAME)) {
                         block = BLOCK_SPECNAME;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "annocheck")) {
+                    } else if (!strcmp(key, NAME_ANNOCHECK)) {
                         block = BLOCK_ANNOCHECK;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "javabytecode")) {
+                    } else if (!strcmp(key, NAME_JAVABYTECODE)) {
                         block = BLOCK_JAVABYTECODE;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "pathmigration")) {
+                    } else if (!strcmp(key, NAME_PATHMIGRATION)) {
                         block = BLOCK_NULL;
                         group = BLOCK_PATHMIGRATION;
-                    } else if (!strcmp(key, "files")) {
+                    } else if (!strcmp(key, NAME_FILES)) {
                         block = BLOCK_NULL;
                         group = BLOCK_FILES;
-                    } else if (!strcmp(key, "abidiff")) {
+                    } else if (!strcmp(key, NAME_ABIDIFF)) {
                         block = BLOCK_ABIDIFF;
                         group = BLOCK_NULL;
-                    } else if (!strcmp(key, "kmidiff")) {
+                    } else if (!strcmp(key, NAME_KMIDIFF)) {
                         block = BLOCK_NULL;
                         group = BLOCK_KMIDIFF;
-                    } else if (!strcmp(key, "patches")) {
+                    } else if (!strcmp(key, NAME_PATCHES)) {
                         block = BLOCK_NULL;
                         group = BLOCK_PATCHES;
-                    } else if (!strcmp(key, "runpath")) {
+                    } else if (!strcmp(key, NAME_RUNPATH)) {
                         block = BLOCK_NULL;
                         group = BLOCK_RUNPATH;
                     }

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -135,6 +135,104 @@ bool foreach_peer_file(struct rpminspect *ri, foreach_peer_file_func check_fn, b
 }
 
 /**
+ * @brief Return inspection ID given its name string.
+ *
+ * @param name Inspection name.
+ */
+uint64_t inspection_id(const char *name)
+{
+    if (name == NULL) {
+        return INSPECT_NULL;
+    } else if (!strcmp(name, NAME_LICENSE)) {
+        return INSPECT_LICENSE;
+    } else if (!strcmp(name, NAME_EMPTYRPM)) {
+        return INSPECT_EMPTYRPM;
+    } else if (!strcmp(name, NAME_LOSTPAYLOAD)) {
+        return INSPECT_LOSTPAYLOAD;
+    } else if (!strcmp(name, NAME_METADATA)) {
+        return INSPECT_METADATA;
+    } else if (!strcmp(name, NAME_MANPAGE)) {
+        return INSPECT_MANPAGE;
+    } else if (!strcmp(name, NAME_XML)) {
+        return INSPECT_XML;
+    } else if (!strcmp(name, NAME_ELF)) {
+        return INSPECT_ELF;
+    } else if (!strcmp(name, NAME_DESKTOP)) {
+        return INSPECT_DESKTOP;
+    } else if (!strcmp(name, NAME_DISTTAG)) {
+        return INSPECT_DISTTAG;
+    } else if (!strcmp(name, NAME_SPECNAME)) {
+        return INSPECT_SPECNAME;
+    } else if (!strcmp(name, NAME_MODULARITY)) {
+        return INSPECT_MODULARITY;
+    } else if (!strcmp(name, NAME_JAVABYTECODE)) {
+        return INSPECT_JAVABYTECODE;
+    } else if (!strcmp(name, NAME_CHANGEDFILES)) {
+        return INSPECT_CHANGEDFILES;
+    } else if (!strcmp(name, NAME_MOVEDFILES)) {
+        return INSPECT_MOVEDFILES;
+    } else if (!strcmp(name, NAME_REMOVEDFILES)) {
+        return INSPECT_REMOVEDFILES;
+    } else if (!strcmp(name, NAME_ADDEDFILES)) {
+        return INSPECT_ADDEDFILES;
+    } else if (!strcmp(name, NAME_UPSTREAM)) {
+        return INSPECT_UPSTREAM;
+    } else if (!strcmp(name, NAME_OWNERSHIP)) {
+        return INSPECT_OWNERSHIP;
+    } else if (!strcmp(name, NAME_SHELLSYNTAX)) {
+        return INSPECT_SHELLSYNTAX;
+    } else if (!strcmp(name, NAME_ANNOCHECK)) {
+        return INSPECT_ANNOCHECK;
+    } else if (!strcmp(name, NAME_DSODEPS)) {
+        return INSPECT_DSODEPS;
+    } else if (!strcmp(name, NAME_FILESIZE)) {
+        return INSPECT_FILESIZE;
+    } else if (!strcmp(name, NAME_PERMISSIONS)) {
+        return INSPECT_PERMISSIONS;
+    } else if (!strcmp(name, NAME_CAPABILITIES)) {
+        return INSPECT_CAPABILITIES;
+    } else if (!strcmp(name, NAME_KMOD)) {
+        return INSPECT_KMOD;
+    } else if (!strcmp(name, NAME_ARCH)) {
+        return INSPECT_ARCH;
+    } else if (!strcmp(name, NAME_SUBPACKAGES)) {
+        return INSPECT_SUBPACKAGES;
+    } else if (!strcmp(name, NAME_CHANGELOG)) {
+        return INSPECT_CHANGELOG;
+    } else if (!strcmp(name, NAME_PATHMIGRATION)) {
+        return INSPECT_PATHMIGRATION;
+    } else if (!strcmp(name, NAME_LTO)) {
+        return INSPECT_LTO;
+    } else if (!strcmp(name, NAME_SYMLINKS)) {
+        return INSPECT_SYMLINKS;
+    } else if (!strcmp(name, NAME_FILES)) {
+        return INSPECT_FILES;
+    } else if (!strcmp(name, NAME_TYPES)) {
+        return INSPECT_TYPES;
+    } else if (!strcmp(name, NAME_ABIDIFF)) {
+        return INSPECT_ABIDIFF;
+    } else if (!strcmp(name, NAME_KMIDIFF)) {
+        return INSPECT_KMIDIFF;
+    } else if (!strcmp(name, NAME_CONFIG)) {
+        return INSPECT_CONFIG;
+    } else if (!strcmp(name, NAME_DOC)) {
+        return INSPECT_DOC;
+    } else if (!strcmp(name, NAME_PATCHES)) {
+        return INSPECT_PATCHES;
+    } else if (!strcmp(name, NAME_VIRUS)) {
+        return INSPECT_VIRUS;
+    } else if (!strcmp(name, NAME_POLITICS)) {
+        return INSPECT_POLITICS;
+    } else if (!strcmp(name, NAME_BADFUNCS)) {
+        return INSPECT_BADFUNCS;
+    } else if (!strcmp(name, NAME_RUNPATH)) {
+        return INSPECT_RUNPATH;
+    } else {
+        return INSPECT_NULL;
+    }
+}
+
+/**
  * @brief Return inspection description string given its ID.
  *
  * Return the long description for the specified inspection.


### PR DESCRIPTION
Given an inspection name, return its ID number as used in
librpminspect.  This is part of a larger coming that will track
per-inspection includes and excludes.

Signed-off-by: David Cantrell <dcantrell@redhat.com>