### PR TITLE
[tst] Make sure abidiff test cases add a DT_SONAME to the test lib

### DIFF
--- a/test/test_abidiff.py
+++ b/test/test_abidiff.py
@@ -142,10 +142,10 @@ class AbidiffNoRebaseWithABIChangeRPMs(TestCompareRPMs):
         super().setUp()
 
         self.before_rpm.add_simple_library(
-            sourceContent=old_library_source, compileFlags="-g"
+            sourceContent=old_library_source, compileFlags="-g -Wl,-soname,libcrashy.so.1"
         )
         self.after_rpm.add_simple_library(
-            sourceContent=new_library_source, compileFlags="-g"
+            sourceContent=new_library_source, compileFlags="-g -Wl,-soname,libcrashy.so.1"
         )
 
         self.inspection = "abidiff"
@@ -159,10 +159,10 @@ class AbidiffNoRebaseWithABIChangeKoji(TestCompareKoji):
         super().setUp()
 
         self.before_rpm.add_simple_library(
-            sourceContent=old_library_source, compileFlags="-g"
+            sourceContent=old_library_source, compileFlags="-g -Wl,-soname,libcrashy.so.1"
         )
         self.after_rpm.add_simple_library(
-            sourceContent=new_library_source, compileFlags="-g"
+            sourceContent=new_library_source, compileFlags="-g -Wl,-soname,libcrashy.so.1"
         )
 
         self.inspection = "abidiff"


### PR DESCRIPTION
Using rpmfluff, make sure the test libraries set a DT_SONAME since
is_elf_shared_library() now requires that in order for the abidiff
inspection to run on the file.

Signed-off-by: David Cantrell <dcantrell@redhat.com>