### PR TITLE
[fix] Handle old or broken versions of libmagic in 'changedfiles'

### DIFF
--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -230,7 +230,10 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
      */
     if (!strcmp(type, "application/x-gzip") || !strcmp(type, "application/gzip") ||
         !strcmp(type, "application/x-bzip2") || !strcmp(type, "application/bzip2") ||
-        !strcmp(type, "application/x-xz") || !strcmp(type, "application/xz")) {
+        !strcmp(type, "application/x-xz") || !strcmp(type, "application/xz") ||
+        (!strcmp(type, "application/octet-stream") && (strsuffix(file->localpath, ".gz") ||        /* this is a workaround for bad/old versions of libmagic */
+                                                       strsuffix(file->localpath, ".bz2") ||
+                                                       strsuffix(file->localpath, ".xz")))) {
         /* uncompress the files to temporary files for comparison */
         before_uncompressed_file = uncompress_file(ri, file->peer_file->fullpath, HEADER_CHANGEDFILES);
         assert(before_uncompressed_file != NULL);


### PR DESCRIPTION
Some systems have versions of libmagic (and the magic database) that
do not register all compression file types.  In this case I noticed an
Arch Linux system will report "application/octet-stream" for
xz-compressed files.  So as a fail safe, add an additional check that
looks for application/octet-stream and the filename ending.  Not
perfect.

Signed-off-by: David Cantrell <dcantrell@redhat.com>