### PR TITLE
[lib] Change strappend() to work as a variadic function

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -188,7 +188,7 @@ severity_t getseverity(const char *);
 char *strwaiverauth(const waiverauth_t);
 char *strreplace(const char *, const char *, const char *);
 char *strxmlescape(const char *);
-char *strappend(char *, const char *);
+char *strappend(char *, ...);
 string_list_t *strsplit(const char *, const char *);
 const char *strtype(const mode_t mode);
 

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -342,7 +342,7 @@ static int download_build(const struct rpminspect *ri, const struct koji_build *
             }
 
             /* Get the main metadata file */
-            dst = strappend(dst, "/modulemd.txt");
+            dst = strappend(dst, "/modulemd.txt", NULL);
             xasprintf(&src, "%s/packages/%s/%s/%s/files/module/modulemd.txt", workri->kojimbs, build->package_name, build->version, build->release);
             curl_helper(workri->verbose, src, dst);
             free(src);

--- a/lib/files.c
+++ b/lib/files.c
@@ -485,7 +485,7 @@ static char *comparable_version_substrings(const char *s, const char *ignore)
         if (result == NULL) {
             result = strdup("/");
         } else {
-            result = strappend(result, "/");
+            result = strappend(result, "/", NULL);
         }
 
         /* the outer tokens are directory parts, see if there's a versioned one */
@@ -505,7 +505,7 @@ static char *comparable_version_substrings(const char *s, const char *ignore)
                 if (first) {
                     first = false;
                 } else {
-                    result = strappend(result, ".");
+                    result = strappend(result, ".", NULL);
                 }
 
                 /* make the version substring generic */
@@ -525,16 +525,16 @@ static char *comparable_version_substrings(const char *s, const char *ignore)
 
                 /* append the inner token */
                 if (same) {
-                    result = strappend(result, "?");
+                    result = strappend(result, "?", NULL);
                 } else {
-                    result = strappend(result, inner_token);
+                    result = strappend(result, inner_token, NULL);
                 }
             }
 
             free(inner_orig);
         } else {
             /* nothing special, just append the outer token */
-            result = strappend(result, outer_token);
+            result = strappend(result, outer_token, NULL);
         }
     }
 

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -43,7 +43,7 @@ static void add_changedfiles_result(struct rpminspect *ri, struct result_params 
     assert(params != NULL);
 
     if (params->waiverauth == WAIVABLE_BY_SECURITY) {
-        params->msg = strappend(params->msg, _("  Changes to security policy related files require inspection by the Security Response Team."));
+        params->msg = strappend(params->msg, _("  Changes to security policy related files require inspection by the Security Response Team."), NULL);
         assert(params->msg != NULL);
     }
 

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -36,7 +36,7 @@ static void add_removedfiles_result(struct rpminspect *ri, struct result_params 
     assert(params != NULL);
 
     if (params->waiverauth == WAIVABLE_BY_SECURITY) {
-        params->msg = strappend(params->msg, _("; Removing security policy related files requires inspection by the Security Response Team."));
+        params->msg = strappend(params->msg, _("; Removing security policy related files requires inspection by the Security Response Team."), NULL);
     }
 
     add_result(ri, params);

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -195,7 +195,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("%s became a valid %s script on %s"), file->localpath, shell, arch);
 
             if (extglob) {
-                params.msg = strappend(params.msg, _(". The script fails with '-n' but passes with '-O extglob'; be sure 'shopt extglob' is set in the script."));
+                params.msg = strappend(params.msg, _(". The script fails with '-n' but passes with '-O extglob'; be sure 'shopt extglob' is set in the script."), NULL);
             }
 
             params.severity = RESULT_INFO;

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -157,16 +157,14 @@ bool inspect_virus(struct rpminspect *ri)
             continue;
         }
 
-        params.details = strappend(params.details, "\n");
-        assert(params.details != NULL);
-
         xasprintf(&cvdpath, "%s/%s", dbpath, de->d_name);
         assert(cvdpath != NULL);
         cvd = cl_cvdhead(cvdpath);
 
         xasprintf(&dbver, _("%s version %u (%s)"), cvdpath, cvd->version, cvd->time);
         assert(dbver != NULL);
-        params.details = strappend(params.details, dbver);
+
+        params.details = strappend(params.details, "\n", dbver, NULL);
         assert(params.details != NULL);
 
         cl_cvdfree(cvd);

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -55,12 +55,15 @@ char *list_to_string(const string_list_t *list, const char *delimiter)
         return NULL;
     }
 
+    s = strdup("");
+    assert(s != NULL);
+
     TAILQ_FOREACH(entry, list, items) {
         if (pos > 0 && delimiter != NULL) {
-            s = strappend(s, delimiter);
+            s = strappend(s, delimiter, NULL);
         }
 
-        s = strappend(s, entry->data);
+        s = strappend(s, entry->data, NULL);
         pos++;
     }
 

--- a/lib/output_xunit.c
+++ b/lib/output_xunit.c
@@ -88,18 +88,18 @@ void output_xunit(const results_t *results, const char *dest, const severity_t t
         }
 
         xasprintf(&rawcdata, _("Result: %s\nWaiver Authorization: %s\n\n"), strseverity(result->severity), strwaiverauth(result->waiverauth));
-        msg = strappend(msg, rawcdata);
+        msg = strappend(msg, rawcdata, NULL);
         free(rawcdata);
 
         if (result->details != NULL) {
             xasprintf(&rawcdata, _("Details:\n%s\n\n"), result->details);
-            msg = strappend(msg, rawcdata);
+            msg = strappend(msg, rawcdata, NULL);
             free(rawcdata);
         }
 
         if (result->remedy != NULL) {
             xasprintf(&rawcdata, _("Suggested Remedy:\n%s"), result->remedy);
-            msg = strappend(msg, rawcdata);
+            msg = strappend(msg, rawcdata, NULL);
             free(rawcdata);
         }
 


### PR DESCRIPTION
When I originally wrote this it was just to append single strings on
to another.  But I find I might want to append more than one.  Change
it to work as a variadic function.  Everything still has to be a
string to append.  I'm not doing a format string or anything.
Terminate the list of strings to append with NULL.  Also, the first
argument must be an allocated char *.  strappend() will realloc this
string.  You can't start it with NULL.  If you want to start it with
an empty string, then pass it a strdup("").  The caller still has to
free what strappend returns, but that was always the case.

Signed-off-by: David Cantrell <dcantrell@redhat.com>