### PR TITLE
[fix] Fix reading of the javabytecode block in the config file

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -528,11 +528,11 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         block = BLOCK_SPECNAME;
                         group = BLOCK_NULL;
                     } else if (!strcmp(key, NAME_ANNOCHECK)) {
-                        block = BLOCK_ANNOCHECK;
-                        group = BLOCK_NULL;
+                        block = BLOCK_NULL;
+                        group = BLOCK_ANNOCHECK;
                     } else if (!strcmp(key, NAME_JAVABYTECODE)) {
-                        block = BLOCK_JAVABYTECODE;
-                        group = BLOCK_NULL;
+                        block = BLOCK_NULL;
+                        group = BLOCK_JAVABYTECODE;
                     } else if (!strcmp(key, NAME_PATHMIGRATION)) {
                         block = BLOCK_NULL;
                         group = BLOCK_PATHMIGRATION;
@@ -792,9 +792,9 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                                 ri->size_threshold = 0;
                             }
                         }
-                    } else if (block == BLOCK_ANNOCHECK) {
+                    } else if (group == BLOCK_ANNOCHECK) {
                         process_table(key, t, &ri->annocheck);
-                    } else if (block == BLOCK_JAVABYTECODE) {
+                    } else if (group == BLOCK_JAVABYTECODE) {
                         process_table(key, t, &ri->jvm);
                     } else if (group == BLOCK_MIGRATED_PATHS) {
                         process_table(key, t, &ri->pathmigration);

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -241,7 +241,7 @@ bool inspect_javabytecode(struct rpminspect *ri)
      * Get the major JVM version for this product release.
      */
     if (ri->jvm == NULL) {
-        warn(_("*** missing JVM version to product release mapping"));
+        warnx(_("*** missing JVM version to product release mapping"));
         return false;
     }
 
@@ -253,14 +253,14 @@ bool inspect_javabytecode(struct rpminspect *ri)
     }
 
     if (hentry == NULL) {
-        warn(_("*** missing JVM version to product release mapping"));
+        warnx(_("*** missing JVM version to product release mapping"));
         return false;
     }
 
     supported_major = strtol(hentry->value, NULL, 10);
 
     if (errno == ERANGE) {
-        warn(_("*** invalid JVM major version"));
+        warn(_("strtol"));
         return false;
     }
 


### PR DESCRIPTION
init.c was not reading the javabytecode block correctly, so the
javabytecode inspection failed to run since ri->jvm was then NULL.

Signed-off-by: David Cantrell <dcantrell@redhat.com>