### PR TITLE
[fix] Catch missing/losing -fPIC correctly on .a ELF objects (#352)

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -302,6 +302,9 @@ bool has_executable_program(Elf *elf);
 bool has_relro(Elf *elf);
 uint64_t get_execstack_flags(Elf *elf);
 bool has_textrel(Elf *elf);
+bool find_no_pic(Elf *elf, string_list_t **user_data);
+bool find_pic(Elf *elf, string_list_t **user_data);
+bool find_all(Elf *elf, string_list_t **user_data);
 
 /* bytes.c */
 /**

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -744,9 +744,8 @@ cleanup:
  * @param elf ELF object to check
  * @param user_data List of ELF archives compiled without -fPIC
  */
-bool find_no_pic(Elf *elf, string_list_t **user_data)
+bool find_no_pic(Elf *elf, string_list_t **no_pic_list)
 {
-    string_list_t *no_pic_list = *user_data;
     string_entry_t *entry = NULL;
     Elf_Arhdr *arhdr = NULL;
 
@@ -766,13 +765,13 @@ bool find_no_pic(Elf *elf, string_list_t **user_data)
         assert(entry != NULL);
         entry->data = strdup(arhdr->ar_name);
 
-        if (no_pic_list == NULL) {
-            no_pic_list = calloc(1, sizeof(*no_pic_list));
-            assert(no_pic_list != NULL);
-            TAILQ_INIT(no_pic_list);
+        if (*no_pic_list == NULL) {
+            *no_pic_list = calloc(1, sizeof(**no_pic_list));
+            assert(*no_pic_list != NULL);
+            TAILQ_INIT(*no_pic_list);
         }
 
-        TAILQ_INSERT_TAIL(no_pic_list, entry, items);
+        TAILQ_INSERT_TAIL(*no_pic_list, entry, items);
     }
 
     return true;
@@ -785,9 +784,8 @@ bool find_no_pic(Elf *elf, string_list_t **user_data)
  * @param elf ELF object to check
  * @param user_data List of ELF archives compiled with -fPIC
  */
-bool find_pic(Elf *elf, string_list_t **user_data)
+bool find_pic(Elf *elf, string_list_t **pic_list)
 {
-    string_list_t *pic_list = *user_data;
     string_entry_t *entry = NULL;
     Elf_Arhdr *arhdr = NULL;
 
@@ -807,13 +805,13 @@ bool find_pic(Elf *elf, string_list_t **user_data)
         assert(entry != NULL);
         entry->data = strdup(arhdr->ar_name);
 
-        if (pic_list == NULL) {
-            pic_list = calloc(1, sizeof(*pic_list));
-            assert(pic_list != NULL);
-            TAILQ_INIT(pic_list);
+        if (*pic_list == NULL) {
+            *pic_list = calloc(1, sizeof(**pic_list));
+            assert(*pic_list != NULL);
+            TAILQ_INIT(*pic_list);
         }
 
-        TAILQ_INSERT_TAIL(pic_list, entry, items);
+        TAILQ_INSERT_TAIL(*pic_list, entry, items);
     }
 
     return true;
@@ -825,9 +823,8 @@ bool find_pic(Elf *elf, string_list_t **user_data)
  * @param elf ELF object to check
  * @param user_data List of ELF archives
  */
-bool find_all(Elf *elf, string_list_t **user_data)
+bool find_all(Elf *elf, string_list_t **all_list)
 {
-    string_list_t *all_list = *user_data;
     string_entry_t *entry = NULL;
     Elf_Arhdr *arhdr = NULL;
 
@@ -846,13 +843,13 @@ bool find_all(Elf *elf, string_list_t **user_data)
     assert(entry != NULL);
     entry->data = strdup(arhdr->ar_name);
 
-    if (all_list == NULL) {
-        all_list = calloc(1, sizeof(*all_list));
-        assert(all_list != NULL);
-        TAILQ_INIT(all_list);
+    if (*all_list == NULL) {
+        *all_list = calloc(1, sizeof(**all_list));
+        assert(*all_list != NULL);
+        TAILQ_INIT(*all_list);
     }
 
-    TAILQ_INSERT_TAIL(all_list, entry, items);
+    TAILQ_INSERT_TAIL(*all_list, entry, items);
 
     return true;
 }
@@ -884,9 +881,6 @@ static bool elf_archive_tests(struct rpminspect *ri, Elf *after_elf, int after_e
     elf_archive_iterate(after_elf_fd, after_elf, find_no_pic, &after_no_pic);
 
     /* initialize the list of objects in the before build with PIC */
-    before_pic = calloc(1, sizeof(*before_pic));
-    assert(before_pic != NULL);
-    TAILQ_INIT(before_pic);
     elf_archive_iterate(before_elf_fd, before_elf, find_pic, &before_pic);
 
     if (after_no_pic == NULL || before_pic == NULL) {

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -140,9 +140,6 @@ string_list_t *list_difference(const string_list_t *a, const string_list_t *b)
 
     /* Copy list b into a hash table */
     b_table = list_to_table(b);
-    ret = calloc(1, sizeof(*ret));
-    assert(ret != NULL);
-    TAILQ_INIT(ret);
 
     /* Iterate through list a looking for things not in list b */
     TAILQ_FOREACH(iter, a, items) {
@@ -152,6 +149,13 @@ string_list_t *list_difference(const string_list_t *a, const string_list_t *b)
             entry = calloc(1, sizeof(*entry));
             assert(entry != NULL);
             entry->data = strdup(iter->data);
+
+            if (ret == NULL) {
+                ret = calloc(1, sizeof(*ret));
+                assert(ret != NULL);
+                TAILQ_INIT(ret);
+            }
+
             TAILQ_INSERT_TAIL(ret, entry, items);
         }
     }
@@ -178,10 +182,6 @@ string_list_t *list_intersection(const string_list_t *a, const string_list_t *b)
         return NULL;
     }
 
-    ret = calloc(1, sizeof(*ret));
-    assert(ret != NULL);
-    TAILQ_INIT(ret);
-
     /* Iterate through list a looking for things in list b */
     TAILQ_FOREACH(iter, a, items) {
         HASH_FIND_STR(b_table, iter->data, hentry);
@@ -190,6 +190,13 @@ string_list_t *list_intersection(const string_list_t *a, const string_list_t *b)
             entry = calloc(1, sizeof(*entry));
             assert(entry != NULL);
             entry->data = strdup(iter->data);
+
+            if (ret == NULL) {
+                ret = calloc(1, sizeof(*ret));
+                assert(ret != NULL);
+                TAILQ_INIT(ret);
+            }
+
             TAILQ_INSERT_TAIL(ret, entry, items);
         }
     }
@@ -209,10 +216,6 @@ string_list_t *list_union(const string_list_t *a, const string_list_t *b)
     string_list_t *ret = NULL;
     string_entry_t *entry = NULL;
 
-    ret = calloc(1, sizeof(*ret));
-    assert(ret != NULL);
-    TAILQ_INIT(ret);
-
     /*
      * Iterate over both lists, adding each entry to u_table. If it's not already in
      * u_table, add it to the list to be returned.
@@ -229,6 +232,13 @@ string_list_t *list_union(const string_list_t *a, const string_list_t *b)
             entry = calloc(1, sizeof(*entry));
             assert(entry != NULL);
             entry->data = strdup(iter->data);
+
+            if (ret == NULL) {
+                ret = calloc(1, sizeof(*ret));
+                assert(ret != NULL);
+                TAILQ_INIT(ret);
+            }
+
             TAILQ_INSERT_TAIL(ret, entry, items);
         }
     }
@@ -245,6 +255,13 @@ string_list_t *list_union(const string_list_t *a, const string_list_t *b)
             entry = calloc(1, sizeof(*entry));
             assert(entry != NULL);
             entry->data = strdup(iter->data);
+
+            if (ret == NULL) {
+                ret = calloc(1, sizeof(*ret));
+                assert(ret != NULL);
+                TAILQ_INIT(ret);
+            }
+
             TAILQ_INSERT_TAIL(ret, entry, items);
         }
     }
@@ -257,9 +274,9 @@ string_list_t *list_union(const string_list_t *a, const string_list_t *b)
 /* Return a new list of entries that in either list a or list b, but not both */
 string_list_t * list_symmetric_difference(const string_list_t *a, const string_list_t *b)
 {
-    string_list_t *a_minus_b;
-    string_list_t *b_minus_a;
-    string_list_t *combination;
+    string_list_t *a_minus_b = NULL;
+    string_list_t *b_minus_a = NULL;
+    string_list_t *combination = NULL;
 
     a_minus_b = list_difference(a, b);
 
@@ -288,7 +305,7 @@ string_list_t * list_symmetric_difference(const string_list_t *a, const string_l
  */
 void list_free(string_list_t *list, list_entry_data_free_func free_func)
 {
-    string_entry_t *entry;
+    string_entry_t *entry = NULL;
 
     if (list == NULL) {
         return;
@@ -338,10 +355,6 @@ string_list_t *list_sort(const string_list_t *list)
     }
 
     /* build a new string_list_t from the sorted hash table */
-    sorted_list = calloc(1, sizeof(*sorted_list));
-    assert(sorted_list != NULL);
-    TAILQ_INIT(sorted_list);
-
     HASH_ITER(hh, map, entry, tmp_entry) {
         HASH_DEL(map, entry);
 
@@ -349,6 +362,13 @@ string_list_t *list_sort(const string_list_t *list)
         assert(iter != NULL);
         iter->data = strdup(entry->key);
         assert(iter->data != NULL);
+
+        if (sorted_list == NULL) {
+            sorted_list = calloc(1, sizeof(*sorted_list));
+            assert(sorted_list != NULL);
+            TAILQ_INIT(sorted_list);
+        }
+
         TAILQ_INSERT_TAIL(sorted_list, iter, items);
 
         free(entry->key);
@@ -362,7 +382,7 @@ string_list_t *list_sort(const string_list_t *list)
 /* Returns the number of entries in the list */
 size_t list_len(const string_list_t *list)
 {
-    string_entry_t *iter;
+    string_entry_t *iter = NULL;
     size_t len = 0;
 
     if (list == NULL || TAILQ_EMPTY(list)) {
@@ -382,17 +402,13 @@ size_t list_len(const string_list_t *list)
  */
 string_list_t * list_copy(const string_list_t *list)
 {
-    const string_entry_t *iter;
-    string_list_t *result;
-    string_entry_t *entry;
+    const string_entry_t *iter = NULL;
+    string_list_t *result = NULL;
+    string_entry_t *entry = NULL;
 
     if (list == NULL) {
         return NULL;
     }
-
-    result = malloc(sizeof(*result));
-    assert(result != NULL);
-    TAILQ_INIT(result);
 
     TAILQ_FOREACH(iter, list, items) {
         entry = calloc(1, sizeof(*entry));
@@ -400,6 +416,12 @@ string_list_t * list_copy(const string_list_t *list)
 
         entry->data = strdup(iter->data);
         assert(entry->data != NULL);
+
+        if (result == NULL) {
+            result = calloc(1, sizeof(*result));
+            assert(result != NULL);
+            TAILQ_INIT(result);
+        }
 
         TAILQ_INSERT_TAIL(result, entry, items);
     }
@@ -424,14 +446,17 @@ string_list_t *list_from_array(const char **array)
 
     assert(array != NULL);
 
-    list = calloc(1, sizeof(*list));
-    assert(list != NULL);
-    TAILQ_INIT(list);
-
     for (i = 0; array[i] != NULL; i++) {
         entry = calloc(1, sizeof(*entry));
         assert(entry != NULL);
         entry->data = strdup(array[i]);
+
+        if (list == NULL) {
+            list = calloc(1, sizeof(*list));
+            assert(list != NULL);
+            TAILQ_INIT(list);
+        }
+
         TAILQ_INSERT_TAIL(list, entry, items);
     }
 

--- a/lib/pic_bits.sh
+++ b/lib/pic_bits.sh
@@ -69,6 +69,8 @@ echo "#include <elf.h>" >> $1
 echo "#include \"rpminspect.h\"" >> $1
 echo "bool is_pic_reloc(Elf64_Half machine, Elf64_Xword rel_type)" >> $1
 echo "{" >> $1
+echo "    DEBUG_PRINT(\"machine=%d, rel_type=%ld\n\", machine, rel_type);" >> $1
+echo >> $1
 echo "    switch (machine) {" >> $1
 
 # get a list of the EM_* arch lines:


### PR DESCRIPTION
I initially thought the problem here was with the function generated
by our pic_bits.sh script.  It generates is_pic_reloc() based on the
contents of the build system's elf.h file.  But this function was
working correctly.  The issue came down to improper use of my own list
structures and always treating missing PIC data in the after build as
a loss of -fPIC at build time.

I have corrected inspect_elf.c so it makes better use of the list
functions in listfuncs.c.  The listfuncs.c functions have also been
modified to return NULL when there is no data rather than always
returning an empty list.  Likewise, in inspect_elf.c, the
elf_archive_iterate() calls can take a NULL list parameter and
initialize if necessary.

Signed-off-by: David Cantrell <dcantrell@redhat.com>