### PR TITLE
[lib] Read per-inspection ignore lists from the config file.

### DIFF
--- a/lib/ignore.c
+++ b/lib/ignore.c
@@ -62,6 +62,10 @@ bool ignore_path(const struct rpminspect *ri, const char *path, const char *root
         return true;
     }
 
+    if (ri->ignores == NULL || TAILQ_EMPTY(ri->ignores)) {
+        return false;
+    }
+
     if (root) {
         len = strlen(root);
     }


### PR DESCRIPTION
The following inspections all per-inspection ignore lists in the
configuration file:

    elf, manpage, xml, desktop, changedfiles, addedfiles, ownership,
    shellsyntax, filesize, lto, annocheck, javabytecode,
    pathmigration, files, abidiff, kmidiff, badfuncs, runpath

This patch enables reading in those blocks if they exist and adding
them to the ri->inspection_ignores hash table.  Note that we still
have global ignores.  This is just another refinement of specifying
glob(7)'s to ignore on a per-inspection basis.

Signed-off-by: David Cantrell <dcantrell@redhat.com>