### PR TITLE
[lib] Implement per-inspection path ignore support (#351)

### DIFF
--- a/include/inspect.h
+++ b/include/inspect.h
@@ -63,12 +63,13 @@
  * for a single inspection.
  *
  * @param ri Pointer to the struct rpminspect used for the program.
+ * @param inspection Name of the currently running inspection.
  * @param callback Callback function to iterate over each file.
  * @param use_ignore True to skip files that match entries in the
  *        ignore section of the configuration file, false otherwise.
  * @return True if the check_fn passed for each file, false otherwise.
  */
-bool foreach_peer_file(struct rpminspect *ri, foreach_peer_file_func callback, bool use_ignore);
+bool foreach_peer_file(struct rpminspect *ri, const char *inspection, foreach_peer_file_func check_fn, bool use_ignore);
 
 /**
  * @brief Return inspection ID given its name string.

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -330,7 +330,7 @@ char *bytes_to_str(unsigned char *array, size_t len);
  * directory, optional (pass NULL to use '/').  @return True if path
  * should be ignored, false otherwise.
  */
-bool ignore_path(const struct rpminspect *ri, const char *path, const char *root);
+bool ignore_path(const struct rpminspect *ri, const char *inspection, const char *path, const char *root);
 
 /* paths.c */
 /**

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -99,12 +99,13 @@ struct inspect inspections[] = {
  * for a single inspection.
  *
  * @param ri Pointer to the struct rpminspect used for the program.
+ * @param inspection Name of currently running inspection.
  * @param callback Callback function to iterate over each file.
  * @param use_ignore True to skip files that match entries in the
  *        ignore section of the configuration file, false otherwise.
  * @return True if the check_fn passed for each file, false otherwise.
  */
-bool foreach_peer_file(struct rpminspect *ri, foreach_peer_file_func check_fn, bool use_ignore)
+bool foreach_peer_file(struct rpminspect *ri, const char *inspection, foreach_peer_file_func check_fn, bool use_ignore)
 {
     rpmpeer_entry_t *peer;
     rpmfile_entry_t *file;
@@ -121,7 +122,7 @@ bool foreach_peer_file(struct rpminspect *ri, foreach_peer_file_func check_fn, b
 
         TAILQ_FOREACH(file, peer->after_files, items) {
             /* Ignore files we should be ignoring */
-            if (use_ignore && ignore_path(ri, file->localpath, peer->after_root)) {
+            if (use_ignore && ignore_path(ri, inspection, file->localpath, peer->after_root)) {
                 continue;
             }
 

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -336,7 +336,7 @@ bool inspect_abidiff(struct rpminspect *ri) {
     }
 
     /* run the main inspection */
-    result = foreach_peer_file(ri, abidiff_driver, true);
+    result = foreach_peer_file(ri, NAME_ABIDIFF, abidiff_driver, true);
 
     /* clean up */
     free_abi(abi);

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -197,7 +197,7 @@ bool inspect_addedfiles(struct rpminspect *ri)
     bool result;
     struct result_params params;
 
-    result = foreach_peer_file(ri, addedfiles_driver, false);
+    result = foreach_peer_file(ri, NAME_ADDEDFILES, addedfiles_driver, false);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -169,7 +169,7 @@ bool inspect_annocheck(struct rpminspect *ri) {
     }
 
     /* run the annocheck tests across all ELF files */
-    result = foreach_peer_file(ri, annocheck_driver, true);
+    result = foreach_peer_file(ri, NAME_ANNOCHECK, annocheck_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -167,7 +167,7 @@ bool inspect_badfuncs(struct rpminspect *ri)
 
     if (ri->bad_functions != NULL) {
         init_elf_data(ri);
-        result = foreach_peer_file(ri, badfuncs_driver, true);
+        result = foreach_peer_file(ri, NAME_BADFUNCS, badfuncs_driver, true);
     }
 
     if (result) {

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -151,7 +151,7 @@ bool inspect_capabilities(struct rpminspect *ri) {
     assert(ri != NULL);
 
     /* run the capabilities inspection across all RPM files */
-    result = foreach_peer_file(ri, capabilities_driver, true);
+    result = foreach_peer_file(ri, NAME_CAPABILITIES, capabilities_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -469,7 +469,7 @@ bool inspect_changedfiles(struct rpminspect *ri)
     bool result;
     struct result_params params;
 
-    result = foreach_peer_file(ri, changedfiles_driver, true);
+    result = foreach_peer_file(ri, NAME_CHANGEDFILES, changedfiles_driver, true);
 
     if (result && !reported) {
         init_result_params(&params);

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -205,7 +205,7 @@ bool inspect_config(struct rpminspect *ri) {
 
     assert(ri != NULL);
 
-    result = foreach_peer_file(ri, config_driver, true);
+    result = foreach_peer_file(ri, NAME_CONFIG, config_driver, true);
 
     if (result && !reported) {
         init_result_params(&params);

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -393,7 +393,7 @@ bool inspect_desktop(struct rpminspect *ri)
      * them.  The before and after peers are compared for these files.
      * For the after files, the Exec and Icon references are checked.
      */
-    result = foreach_peer_file(ri, desktop_driver, true);
+    result = foreach_peer_file(ri, NAME_DESKTOP, desktop_driver, true);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -144,7 +144,7 @@ bool inspect_doc(struct rpminspect *ri) {
 
     assert(ri != NULL);
 
-    result = foreach_peer_file(ri, doc_driver, true);
+    result = foreach_peer_file(ri, NAME_DOC, doc_driver, true);
 
     if (result && !reported) {
         init_result_params(&params);

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -226,7 +226,7 @@ bool inspect_dsodeps(struct rpminspect *ri) {
     assert(ri != NULL);
 
     /* run the dsodeps test across all ELF files */
-    result = foreach_peer_file(ri, dsodeps_driver, true);
+    result = foreach_peer_file(ri, NAME_DSODEPS, dsodeps_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -1091,7 +1091,7 @@ bool inspect_elf(struct rpminspect *ri)
 
     init_elf_data(ri);
     rip = ri;
-    result = foreach_peer_file(ri, elf_driver, true);
+    result = foreach_peer_file(ri, NAME_ELF, elf_driver, true);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -134,7 +134,7 @@ bool inspect_filesize(struct rpminspect *ri) {
     assert(ri != NULL);
 
     /* run the size inspection across all RPM files */
-    result = foreach_peer_file(ri, filesize_driver, true);
+    result = foreach_peer_file(ri, NAME_FILESIZE, filesize_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -406,7 +406,7 @@ bool inspect_kmidiff(struct rpminspect *ri) {
 
         TAILQ_FOREACH(file, peer->after_files, items) {
             /* Ignore files we should be ignoring */
-            if (ignore_path(ri, file->localpath, peer->after_root)) {
+            if (ignore_path(ri, NAME_KMIDIFF, file->localpath, peer->after_root)) {
                 continue;
             }
 

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -304,7 +304,7 @@ bool inspect_kmod(struct rpminspect *ri) {
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
     params.header = HEADER_KMOD;
-    result = foreach_peer_file(ri, kmod_driver, true);
+    result = foreach_peer_file(ri, NAME_KMOD, kmod_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -214,7 +214,7 @@ bool inspect_lto(struct rpminspect *ri) {
 
     if (ri->lto_symbol_name_prefixes != NULL) {
         lto_symbol_name_prefixes = ri->lto_symbol_name_prefixes;
-        result = foreach_peer_file(ri, lto_driver, true);
+        result = foreach_peer_file(ri, NAME_LTO, lto_driver, true);
     }
 
     if (result) {

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -341,7 +341,7 @@ bool inspect_manpage(struct rpminspect *ri)
     struct result_params params;
 
     inspect_manpage_alloc();
-    result = foreach_peer_file(ri, manpage_driver, true);
+    result = foreach_peer_file(ri, NAME_MANPAGE, manpage_driver, true);
     inspect_manpage_free();
 
     if (result) {

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -87,7 +87,7 @@ bool inspect_modularity(struct rpminspect *ri) {
         return true;
     }
 
-    result = foreach_peer_file(ri, modularity_driver, true);
+    result = foreach_peer_file(ri, NAME_MODULARITY, modularity_driver, true);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -68,7 +68,7 @@ bool inspect_movedfiles(struct rpminspect *ri) {
 
     assert(ri != NULL);
 
-    result = foreach_peer_file(ri, movedfiles_driver, true);
+    result = foreach_peer_file(ri, NAME_MOVEDFILES, movedfiles_driver, true);
 
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -290,7 +290,7 @@ bool inspect_ownership(struct rpminspect *ri) {
     struct result_params params;
 
     assert(ri != NULL);
-    result = foreach_peer_file(ri, ownership_driver, true);
+    result = foreach_peer_file(ri, NAME_OWNERSHIP, ownership_driver, true);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -119,7 +119,7 @@ bool inspect_pathmigration(struct rpminspect *ri) {
 
     /* Only run the inspection if path migrations are specified */
     if (ri->pathmigration) {
-        result = foreach_peer_file(ri, pathmigration_driver, true);
+        result = foreach_peer_file(ri, NAME_PATHMIGRATION, pathmigration_driver, true);
     }
 
     if (result) {

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -111,7 +111,7 @@ bool inspect_permissions(struct rpminspect *ri) {
     assert(ri != NULL);
 
     /* run the permissions inspection across all RPM files */
-    result = foreach_peer_file(ri, permissions_driver, true);
+    result = foreach_peer_file(ri, NAME_PERMISSIONS, permissions_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -162,7 +162,7 @@ bool inspect_politics(struct rpminspect *ri)
 
     /* run the politics check on each file */
     if (init_politics(ri)) {
-        result = foreach_peer_file(ri, politics_driver, false);
+        result = foreach_peer_file(ri, NAME_POLITICS, politics_driver, false);
     }
 
     /* hope the result is always this */

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -305,7 +305,7 @@ bool inspect_runpath(struct rpminspect *ri) {
     assert(ri != NULL);
 
     /* run the runpath test across all ELF files */
-    result = foreach_peer_file(ri, runpath_driver, true);
+    result = foreach_peer_file(ri, NAME_RUNPATH, runpath_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -249,7 +249,7 @@ bool inspect_shellsyntax(struct rpminspect *ri) {
 
     assert(ri != NULL);
 
-    result = foreach_peer_file(ri, shellsyntax_driver, true);
+    result = foreach_peer_file(ri, NAME_SHELLSYNTAX, shellsyntax_driver, true);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_specname.c
+++ b/lib/inspect_specname.c
@@ -106,7 +106,7 @@ bool inspect_specname(struct rpminspect *ri) {
     struct result_params params;
 
     assert(ri != NULL);
-    foreach_peer_file(ri, specname_driver, false);
+    foreach_peer_file(ri, NAME_SPECNAME, specname_driver, false);
 
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -320,7 +320,7 @@ bool inspect_symlinks(struct rpminspect *ri) {
     struct result_params params;
 
     assert(ri != NULL);
-    result = foreach_peer_file(ri, symlinks_driver, true);
+    result = foreach_peer_file(ri, NAME_SYMLINKS, symlinks_driver, true);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -90,7 +90,7 @@ bool inspect_types(struct rpminspect *ri) {
     assert(ri != NULL);
 
     /* run the types inspection across all RPM files */
-    foreach_peer_file(ri, types_driver, true);
+    foreach_peer_file(ri, NAME_TYPES, types_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -189,7 +189,7 @@ bool inspect_virus(struct rpminspect *ri)
     params.header = HEADER_VIRUS;
     params.verb = VERB_FAILED;
     params.noun = _("virus or malware in ${FILE}");
-    result = foreach_peer_file(ri, virus_driver, false);
+    result = foreach_peer_file(ri, NAME_VIRUS, virus_driver, false);
 
     /* hope the result is always this */
     if (result) {

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -215,7 +215,7 @@ bool inspect_xml(struct rpminspect *ri)
     struct result_params params;
 
     assert(ri != NULL);
-    result = foreach_peer_file(ri, xml_driver, true);
+    result = foreach_peer_file(ri, NAME_XML, xml_driver, true);
 
     if (result) {
         init_result_params(&params);


### PR DESCRIPTION
For the following inspections:

    elf, manpage, xml, desktop, changedfiles, addedfiles, ownership,
    shellsyntax, filesize, lto, annocheck, javabytecode,
    pathmigration, files, abidiff, kmidiff, badfuncs, runpath

rpminspect now honors per-inspection ignore listings in the
configuration file.  Use this to specify glob(7) patterns to match
paths to ignore in a specific inspection.  The syntax of the ignore
list is the same as the global ignore list in the configuration file,
it just happens to be nested under the appropriate inspection
configuration block in the configuration file.

Signed-off-by: David Cantrell <dcantrell@redhat.com>