### PR TITLE
3 changes

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -160,10 +160,10 @@ vendor:
     # 2) Rely on the product release string regexps in rpminspect.yaml
     #
     # Some products may have a variety of dist tags, so you can
-    # construct a regular expression to match them.  For example,
-    # let's say your dist tags are ".fc31, .fc31server, .fc31laptop".
-    # You want to use "fc31" for all of these, so you can add a rule
-    # here that looks like:
+    # construct a regular expression (man 7 regex) to match them.  For
+    # example, let's say your dist tags are ".fc31, .fc31server,
+    # .fc31laptop".  You want to use "fc31" for all of these, so you
+    # can add a rule here that looks like:
     #
     #     - fc31: ^\.fc31.*$
     #
@@ -223,16 +223,17 @@ metadata:
 
 elf:
     # File paths to include in or exclude from specific tests. Each
-    # value is a POSIX extended regular expression. Individual tests
-    # may apply additional filters (e.g., ELF tests only run on ELF
-    # files)
+    # value is a POSIX extended regular expression (man 7
+    # regex). Individual tests may apply additional filters (e.g., ELF
+    # tests only run on ELF files)
     #
     # For ELF, skip the kernel, kernel modules, and two additional
     # paths for ppc/ppc64: crtsavres.o is linked against kernel
     # modules, and kernel-wrapper is a boot wrapper that should not be
     # inspected.
     #
-    # These are regular expressions used by regexp(3).
+    # These are regular expressions used by regex(3).  See regex(7)
+    # for more info.
     #include_path:
     exclude_path: (^(/boot/vmlinu|/lib/modules|/lib64/modules).*)|(.*/powerpc/lib/crtsavres.o$)|(^/usr/lib(64)?/kernel-wrapper$)
 
@@ -244,11 +245,12 @@ elf:
     #    - /usr/lib*/libexample.so*
 
 manpage:
-    # Regular expression matching man page installation directories.
+    # Regular expression (man 7 regex) matching man page installation
+    # directories.
     include_path: ^(/usr|/usr/local)/share/man/.*
 
-    # Regular expression matching directories to ignore during the
-    # man page inspection.
+    # Regular expression (man 7 regex) matching directories to ignore
+    # during the man page inspection.
     #exclude_path:
 
     # Optional list of glob(7) specifications to match files to ignore
@@ -259,13 +261,13 @@ manpage:
     #    - /usr/lib*/libexample.so*
 
 xml:
-    # Regular expression matching directories to include in the xml
-    # expression.
+    # Regular expression (man 7 regex) matching directories to include
+    # in the xml expression.
     #include_path:
 
-    # Regular expression matching directories to ignore during the xml
-    # inspection. Skip JSP and RHTML files, which contain a mix of XML
-    # and code.
+    # Regular expression (man 7 regex) matching directories to ignore
+    # during the xml inspection. Skip JSP and RHTML files, which
+    # contain a mix of XML and code.
     exclude_path: .*(\.jsp|\.rhtml)$
 
     # Optional list of glob(7) specifications to match files to ignore
@@ -688,11 +690,11 @@ runpath:
         - /lib
         - /lib64
 
-    # Optional list of regular expressions to trim after an $ORIGIN
-    # entry in DT_RPATH or DT_RUNPATH.  If any of these regular
-    # expressions match, the matching substring is trimmed after
-    # "$ORIGIN" is trimmed and the remaining substring is validated
-    # against the 'allowed_origin_paths' list.
+    # Optional list of regular expressions (man 7 regex) to trim after
+    # an $ORIGIN entry in DT_RPATH or DT_RUNPATH.  If any of these
+    # regular expressions match, the matching substring is trimmed
+    # after "$ORIGIN" is trimmed and the remaining substring is
+    # validated against the 'allowed_origin_paths' list.
     origin_prefix_trim:
         - ^(opt/rh/[^/]+/root/)
 

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -309,7 +309,15 @@ void dump_cfg(const struct rpminspect *ri)
     }
 
     if (ri->size_threshold) {
-        printf("filesize:\n    size_threshold: %ld\n", ri->size_threshold);
+        printf("filesize:\n    size_threshold: ");
+
+        if (ri->size_threshold == -1) {
+            printf("info");
+        } else {
+            printf("%ld", ri->size_threshold);
+        }
+
+        printf("\n");
     }
 
     if (ri->lto_symbol_name_prefixes && !TAILQ_EMPTY(ri->lto_symbol_name_prefixes)) {

--- a/lib/init.c
+++ b/lib/init.c
@@ -953,11 +953,15 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         }
                     } else if (group == BLOCK_FILESIZE) {
                         if (!strcmp(key, "size_threshold")) {
-                            ri->size_threshold = strtol(t, 0, 10);
+                            if (!strcasecmp(t, "info") || !strcasecmp(t, "info-only") || !strcasecmp(t, "info_only")) {
+                                ri->size_threshold = -1;
+                            } else {
+                                ri->size_threshold = strtol(t, 0, 10);
 
-                            if ((ri->size_threshold == LONG_MIN || ri->size_threshold == LONG_MAX) && errno == ERANGE) {
-                                warn("strtol()");
-                                ri->size_threshold = 0;
+                                if ((ri->size_threshold == LONG_MIN || ri->size_threshold == LONG_MAX) && errno == ERANGE) {
+                                    warn("strtol()");
+                                    ri->size_threshold = 0;
+                                }
                             }
                         }
                     } else if (group == BLOCK_ANNOCHECK) {

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -38,9 +38,9 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     size_t ll = 0;
     char *tmp_out = NULL;
     char *after_out = NULL;
-    int after_exit;
+    int after_exit = 0;
     char *before_out = NULL;
-    int before_exit;
+    int before_exit = 0;
     struct result_params params;
 
     assert(ri != NULL);
@@ -103,9 +103,9 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (before_out && after_out) {
             if (before_exit == 0 && after_exit == 0) {
                 xasprintf(&params.msg, _("annocheck '%s' test passes for %s on %s"), hentry->key, file->localpath, arch);
-            } else if (before_exit == 1 && after_exit == 0) {
+            } else if (before_exit && after_exit == 0) {
                 xasprintf(&params.msg, _("annocheck '%s' test now passes for %s on %s"), hentry->key, file->localpath, arch);
-            } else if (before_exit == 0 && after_exit == 1) {
+            } else if (before_exit == 0 && after_exit) {
                 xasprintf(&params.msg, _("annocheck '%s' test now fails for %s on %s"), hentry->key, file->localpath, arch);
                 params.severity = RESULT_VERIFY;
                 params.verb = VERB_CHANGED;
@@ -114,7 +114,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         } else if (after_out) {
             if (after_exit == 0) {
                 xasprintf(&params.msg, _("annocheck '%s' test passes for %s on %s"), hentry->key, file->localpath, arch);
-            } else if (after_exit == 1) {
+            } else if (after_exit) {
                 xasprintf(&params.msg, _("annocheck '%s' test fails for %s on %s"), hentry->key, file->localpath, arch);
                 params.severity = RESULT_VERIFY;
                 params.verb = VERB_CHANGED;

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -115,6 +115,11 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
     }
 
+    /* info reporting if user configured that */
+    if (ri->size_threshold == -1) {
+        params.severity = RESULT_INFO;
+    }
+
     /* Reporting */
     if (params.msg) {
         add_result(ri, &params);


### PR DESCRIPTION
[fix] Report annocheck failures correctly in librpminspect
[cfg] Note all regular expression settings use regex(7) syntax
[lib] Allow 'size_threshold: info' in the config file (#261)