### PR TITLE
[lib] Check ignore list in 'files' for path prefixes to ignore (#360)

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -523,12 +523,13 @@ files:
     forbidden_paths:
         - /usr/lib
 
-    # Optional list of glob(7) specifications to match files to ignore
-    # for this inspection.  The format of this list is the same as the
-    # global 'ignore' list.  The difference is the items specified
-    # here will only be used during this inspection.
+    # Optional list of path prefixes to ignore when checking for
+    # forbidden paths in the %files section.  For example, a package
+    # may need to provide files in /usr/lib/dracut but anything else
+    # in /usr/lib is forbidden.  In that case, list /usr/lib/dracut/
+    # in the ignore list here.
     #ignore:
-    #    - /usr/lib*/libexample.so*
+    #    - /usr/lib/dracut/
 
 abidiff:
     # The name of the optional ABI suppression file that SRPMs can


### PR DESCRIPTION
This one operates a little differently than the other ignore lists.
Since the 'files' inspection is reading the %files lists in spec
files, we need to treat the ignore list here as a list of path
prefixes to ignore rather than a list of glob(7) specifications to
match.  Adjust the comment to reflect that.  Modify the inspection
code to make use of the ignore list since this inspection does not use
foreach_peer_file().

Signed-off-by: David Cantrell <dcantrell@redhat.com>