### PR TITLE
[lib] Support a list of expected empty RPMs in the config file (#355)

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -244,6 +244,13 @@ elf:
     #ignore:
     #    - /usr/lib*/libexample.so*
 
+#emptyrpm:
+    # Optional list of packages in a build that will contain an empty
+    # payload.  Useful for SRPMs that build metapackages that will
+    # always have an empty payload.
+    #expected_empty:
+    #    - metapackagename
+
 manpage:
     # Regular expression (man 7 regex) matching man page installation
     # directories.

--- a/include/types.h
+++ b/include/types.h
@@ -508,6 +508,9 @@ struct rpminspect {
      */
     string_list_map_t *inspection_ignores;
 
+    /* Optional list of expected RPMs with empty payloads */
+    string_list_t *expected_empty_rpms;
+
     /* Options specified by the user */
     char *before;              /* before build ID arg given on cmdline */
     char *after;               /* after build ID arg given on cmdline */

--- a/lib/free.c
+++ b/lib/free.c
@@ -221,6 +221,7 @@ void free_rpminspect(struct rpminspect *ri) {
     list_free(ri->runpath_allowed_origin_paths, free);
     list_free(ri->runpath_origin_prefix_trim, free);
     free_string_list_map(ri->inspection_ignores);
+    list_free(ri->expected_empty_rpms, free);
 
     free_rpmpeer(ri->peers);
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -112,7 +112,9 @@ enum {
     BLOCK_SHELLSYNTAX,
     BLOCK_SPECNAME,
     BLOCK_VENDOR,
-    BLOCK_XML
+    BLOCK_XML,
+    BLOCK_EMPTYRPM,
+    BLOCK_EXPECTED_EMPTY_RPMS
 };
 
 static int add_regex(const char *pattern, regex_t **regex_out)
@@ -667,6 +669,9 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     } else if (!strcmp(key, NAME_RUNPATH)) {
                         block = BLOCK_NULL;
                         group = BLOCK_RUNPATH;
+                    } else if (!strcmp(key, NAME_EMPTYRPM)) {
+                        block = BLOCK_NULL;
+                        group = BLOCK_EMPTYRPM;
                     }
                 }
 
@@ -778,13 +783,18 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         if (!strcmp(key, "ignore")) {
                             block = BLOCK_IGNORE;
                         }
-                    } else if (group == BLOCK_BADFUNCS) {
+                    } else if (block == BLOCK_BADFUNCS) {
                         if (!strcmp(key, "ignore")) {
+                            group = BLOCK_BADFUNCS;
                             block = BLOCK_IGNORE;
                         }
                     } else if (group == BLOCK_RUNPATH) {
                         if (!strcmp(key, "ignore")) {
                             block = BLOCK_IGNORE;
+                        }
+                    } else if (group == BLOCK_EMPTYRPM) {
+                        if (!strcmp(key, "expected_empty")) {
+                            block = BLOCK_EXPECTED_EMPTY_RPMS;
                         }
                     }
                 } else if (symbol == SYMBOL_VALUE) {
@@ -1093,6 +1103,8 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         add_entry(&ri->runpath_allowed_origin_paths, t);
                     } else if (block == BLOCK_RUNPATH_ORIGIN_PREFIX_TRIM) {
                         add_entry(&ri->runpath_origin_prefix_trim, t);
+                    } else if (block == BLOCK_EXPECTED_EMPTY_RPMS) {
+                        add_entry(&ri->expected_empty_rpms, t);
                     }
                 }
 


### PR DESCRIPTION
Some packages build meta packages which have empty payloads but serve
as a way to control what packages are installed.  This patch adds a
way to list the expected empty RPMs so the emptyrpm inspection still
runs, but does not fail when it encounters expected empty packages.

Signed-off-by: David Cantrell <dcantrell@redhat.com>