### PR TITLE
[fix] Call mparse_reset() before mparse_readfd()

### DIFF
--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -193,7 +193,7 @@ static char *inspect_manpage_validity(const char *path, const char *localpath)
         fprintf(error_stream, _("Man page %s does not end in %s\n"), path, GZIPPED_FILENAME_EXTENSION);
     } else {
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
-            fprintf(error_stream, _("Unable to read man page %s\n"), path);
+            fprintf(error_stream, "read(): %s\n", strerror(errno));
             goto end;
         }
 
@@ -202,8 +202,13 @@ static char *inspect_manpage_validity(const char *path, const char *localpath)
         }
 
         /* Reset the fd and continue */
-        lseek(fd, 0, SEEK_SET);
+        if (lseek(fd, 0, SEEK_SET) == -1) {
+            fprintf(error_stream, "lseek(): %s\n", strerror(errno));
+            goto end;
+        }
     }
+
+    mparse_reset(parser);
 
     /* Parse the file */
 #ifdef NEWLIBMANDOC


### PR DESCRIPTION
A few packages were causing rpminspect to segfault in the manpage
inspection.  I was not calling mparse_reset() before mparse_readfd(),
which was the correct thing to do.  Some things were uninitialized as
a result and if needed during the read and parse could have led to a
segfault.  It did.  Call mparse_reset() to fix things up before
reading and parsing.

Signed-off-by: David Cantrell <dcantrell@redhat.com>