### PR TITLE
[fix] Ensure ctxt->lastError.message is not NULL before strdup (#382)

### DIFF
--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -79,7 +79,7 @@ static bool is_xml_well_formed(const char *path, char **errors)
         result = true;
     } else {
         if (!ctxt->valid) {
-            if (errors != NULL) {
+            if (errors != NULL && ctxt->lastError.message) {
                 *errors = strdup(ctxt->lastError.message);
             }
 


### PR DESCRIPTION
libxml does not always give an error string during validation, so
don't assume we have something we can strdup().

Signed-off-by: David Cantrell <dcantrell@redhat.com>