### PR TITLE
[lib] Disable debugging output for the ignore lists in init.c

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -1643,6 +1643,7 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
     ri->threshold = RESULT_VERIFY;
     ri->worst_result = RESULT_OK;
 
+#if 0
     /* debugging output only to make sure we captured ignores */
     if (ri->ignores && !TAILQ_EMPTY(ri->ignores)) {
         string_entry_t *se = NULL;
@@ -1675,6 +1676,7 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
     } else {
         DEBUG_PRINT("no per-inspection ignores defined\n");
     }
+#endif
 
     return ri;
 }


### PR DESCRIPTION
Leave the code block in place, but disable by default.  I am leaving
this here because the ignore list code is relatively new and I want to
have this handy in case bug reports come in where I need to dig in to
a per-inspection ignore list.

Signed-off-by: David Cantrell <dcantrell@redhat.com>