### PR TITLE
[cmd] Remove what working directories we can

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -834,9 +834,8 @@ int main(int argc, char **argv) {
         if (keep) {
             printf(_("\nKeeping working directory: %s\n"), ri->worksubdir);
         } else {
-            if (rmtree(ri->workdir, true, true)) {
-                warn(_("*** Error removing directory %s"), ri->workdir);
-            }
+            /* remove the working directories we can */
+            (void) rmtree(ri->workdir, true, true);
         }
     }
 


### PR DESCRIPTION
If rmtree() errors here, just proceed.  In most cases it means there's
another rpminspect job running and the working directory is in use.

Signed-off-by: David Cantrell <dcantrell@redhat.com>