### PR TITLE
[fix] Only look at RPMTAG_SOURCE entries for removed sources

### DIFF
--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -181,13 +181,6 @@ bool inspect_upstream(struct rpminspect *ri)
         before_source = get_rpm_header_string_array(peer->before_hdr, RPMTAG_SOURCE);
         source = get_rpm_header_string_array(peer->after_hdr, RPMTAG_SOURCE);
 
-        /* On the off chance the SRPM is empty, just ignore */
-        if ((before_source == NULL || TAILQ_EMPTY(before_source)) || (source == NULL || TAILQ_EMPTY(source))) {
-            list_free(before_source, free);
-            list_free(source, free);
-            continue;
-        }
-
         /* Iterate over the SRPM files */
         TAILQ_FOREACH(file, peer->after_files, items) {
             if (!upstream_driver(ri, file)) {


### PR DESCRIPTION
In the upstream inspection, be sure to only look at the list of
RPMTAG_SOURCE entries when looking for what source files have been
removed.  The foreach_peer_file() iterator is going over every file in
an SRPM, which includes patches.  So if patches disappear, that is
incorrectly reported as a disappearing SourceN file.

Signed-off-by: David Cantrell <dcantrell@redhat.com>