### PR TITLE
[lib] Add list_contains() to librpminspect

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -144,6 +144,7 @@ size_t list_len(const string_list_t *);
 string_list_t * list_sort(const string_list_t *);
 string_list_t * list_copy(const string_list_t *);
 string_list_t *list_from_array(const char **);
+bool list_contains(const string_list_t *, const char *);
 
 /* local.c */
 bool is_local_build(const char *);

--- a/lib/arches.c
+++ b/lib/arches.c
@@ -58,14 +58,7 @@ void init_arches(struct rpminspect *ri)
             continue;
         }
 
-        found = false;
-
-        TAILQ_FOREACH(entry, ri->arches, items) {
-            if (!strcmp(arch, entry->data)) {
-                found = true;
-                break;
-            }
-        }
+        found = list_contains(ri->arches, arch);
 
         if (!found) {
             entry = calloc(1, sizeof(*entry));
@@ -87,8 +80,6 @@ void init_arches(struct rpminspect *ri)
  */
 bool allowed_arch(const struct rpminspect *ri, const char *rpmarch)
 {
-    string_entry_t *arch = NULL;
-
     assert(ri != NULL);
     assert(rpmarch != NULL);
 
@@ -96,11 +87,5 @@ bool allowed_arch(const struct rpminspect *ri, const char *rpmarch)
         return true;
     }
 
-    TAILQ_FOREACH(arch, ri->arches, items) {
-        if (!strcmp(rpmarch, arch->data)) {
-            return true;
-        }
-    }
-
-    return false;
+    return list_contains(ri->arches, rpmarch);
 }

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -326,7 +326,6 @@ static int download_build(const struct rpminspect *ri, const struct koji_build *
     int in_filter = 0;
     string_list_t *filter = NULL;
     string_entry_t *filtered_rpm = NULL;
-    bool filtered = false;
 
     assert(build != NULL);
     assert(build->builds != NULL);
@@ -470,16 +469,7 @@ static int download_build(const struct rpminspect *ri, const struct koji_build *
 
             /* for module builds, filter out packages */
             if (workri->buildtype == KOJI_BUILD_MODULE && filter != NULL) {
-                filtered = false;
-
-                TAILQ_FOREACH(filtered_rpm, filter, items) {
-                    if (!strcmp(filtered_rpm->data, rpm->name)) {
-                        filtered = true;
-                        break;
-                    }
-                }
-
-                if (filtered) {
+                if (list_contains(filter, rpm->name)) {
                     continue;
                 }
             }

--- a/lib/init.c
+++ b/lib/init.c
@@ -172,10 +172,8 @@ static void add_entry(string_list_t **list, const char *s)
         TAILQ_INIT(*list);
     } else {
         /* do not add entry if it exists in the list */
-        TAILQ_FOREACH(entry, *list, items) {
-            if (!strcmp(entry->data, s)) {
-                return;
-            }
+        if (list_contains(*list, s)) {
+            return;
         }
     }
 

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -29,10 +29,8 @@
 
 static void append_macros(string_list_t **macros, const char *s)
 {
-    bool found = false;
     string_list_t *new_macros = NULL;
     string_entry_t *entry = NULL;
-    string_entry_t *macro = NULL;
 
     if (s == NULL) {
         return;
@@ -45,18 +43,8 @@ static void append_macros(string_list_t **macros, const char *s)
         entry = TAILQ_FIRST(new_macros);
         TAILQ_REMOVE(new_macros, entry, items);
 
-        /* look for this macro in the list */
-        found = false;
-
-        TAILQ_FOREACH(macro, *macros, items) {
-            if (!strcmp(macro->data, entry->data)) {
-                found = true;
-                break;
-            }
-        }
-
         /* add the macro to the list if not found */
-        if (found) {
+        if (list_contains(*macros, entry->data)) {
             free(entry->data);
             free(entry);
         } else {

--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -34,8 +34,6 @@
 
 static bool is_expected_empty(const struct rpminspect *ri, const char *p)
 {
-    string_entry_t *entry = NULL;
-
     assert(ri != NULL);
     assert(p != NULL);
 
@@ -43,13 +41,7 @@ static bool is_expected_empty(const struct rpminspect *ri, const char *p)
         return false;
     }
 
-    TAILQ_FOREACH(entry, ri->expected_empty_rpms, items) {
-        if (!strcmp(p, entry->data)) {
-            return true;
-        }
-    }
-
-    return false;
+    return list_contains(ri->expected_empty_rpms, p);
 }
 
 /**

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -79,10 +79,8 @@ static bool find_lto_symbols(Elf *elf, string_list_t **user_data)
 
                 if (strprefix(entry->data, prefix->data)) {
                     /* don't add the symbol if we already have it */
-                    TAILQ_FOREACH(found, specifics, items) {
-                        if (!strcmp(found->data, entry->data)) {
-                            break;
-                        }
+                    if (list_contains(specifics, entry->data)) {
+                        break;
                     }
 
                     /* add this symbol to the list */

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -120,35 +120,25 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
      */
 
     /* Report forbidden file owners */
-    if (ri->forbidden_owners) {
-        TAILQ_FOREACH(entry, ri->forbidden_owners, items) {
-            if (!strcmp(owner, entry->data)) {
-                xasprintf(&params.msg, _("File %s has forbidden owner `%s` on %s"), file->localpath, owner, arch);
-                params.severity = RESULT_BAD;
-                params.waiverauth = WAIVABLE_BY_ANYONE;
-                params.remedy = REMEDY_OWNERSHIP_DEFATTR;
-                add_result(ri, &params);
-                free(params.msg);
-                result = false;
-                break;
-            }
-        }
+    if (ri->forbidden_owners && list_contains(ri->forbidden_owners, owner)) {
+        xasprintf(&params.msg, _("File %s has forbidden owner `%s` on %s"), file->localpath, owner, arch);
+        params.severity = RESULT_BAD;
+        params.waiverauth = WAIVABLE_BY_ANYONE;
+        params.remedy = REMEDY_OWNERSHIP_DEFATTR;
+        add_result(ri, &params);
+        free(params.msg);
+        result = false;
     }
 
     /* Report forbidden file groups */
-    if (ri->forbidden_groups) {
-        TAILQ_FOREACH(entry, ri->forbidden_groups, items) {
-            if (!strcmp(group, entry->data)) {
-                xasprintf(&params.msg, _("File %s has forbidden group `%s` on %s"), file->localpath, owner, arch);
-                params.severity = RESULT_BAD;
-                params.waiverauth = WAIVABLE_BY_ANYONE;
-                params.remedy = REMEDY_OWNERSHIP_DEFATTR;
-                add_result(ri, &params);
-                free(params.msg);
-                result = false;
-                break;
-            }
-        }
+    if (ri->forbidden_groups && list_contains(ri->forbidden_groups, group)) {
+        xasprintf(&params.msg, _("File %s has forbidden group `%s` on %s"), file->localpath, owner, arch);
+        params.severity = RESULT_BAD;
+        params.waiverauth = WAIVABLE_BY_ANYONE;
+        params.remedy = REMEDY_OWNERSHIP_DEFATTR;
+        add_result(ri, &params);
+        free(params.msg);
+        result = false;
     }
 
     /* Report files in bin paths not under the bin owner or group */

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -44,9 +44,7 @@ static struct result_params params;
 /* Returns true if this file is a Patch file */
 static bool is_patch(const rpmfile_entry_t *file)
 {
-    bool ret = false;
     char *shortname = NULL;
-    string_entry_t *entry = NULL;
 
     assert(file != NULL);
 
@@ -65,13 +63,7 @@ static bool is_patch(const rpmfile_entry_t *file)
     shortname = rindex(file->fullpath, '/') + 1;
 
     /* See if this file is a Patch file */
-    TAILQ_FOREACH(entry, patches, items) {
-        if (!strcmp(shortname, entry->data)) {
-            return true;
-        }
-    }
-
-    return ret;
+    return list_contains(patches, shortname);
 }
 
 /*
@@ -158,7 +150,6 @@ static diffstat_t get_diffstat_counts(const char *summary)
 static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool result = true;
-    string_entry_t *entry = NULL;
     char *before_patch = NULL;
     char *after_patch = NULL;
     int exitcode;
@@ -177,12 +168,8 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.file = file->localpath;
 
     /* If this patch is on the ignore list, skip */
-    if (ri->patch_ignore_list != NULL && !TAILQ_EMPTY(ri->patch_ignore_list)) {
-        TAILQ_FOREACH(entry, ri->patch_ignore_list, items) {
-            if (!strcmp(file->localpath, entry->data)) {
-                return true;
-            }
-        }
+    if (list_contains(ri->patch_ignore_list, file->localpath)) {
+        return true;
     }
 
     /* patches may be compressed, so uncompress them here for diff(1) */

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -42,12 +42,12 @@ static bool pathmigration_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Skip files beginning with an excluded path */
     if (ri->pathmigration_excluded_paths && !TAILQ_EMPTY(ri->pathmigration_excluded_paths)) {
-        TAILQ_FOREACH(entry, ri->pathmigration_excluded_paths, items) {
-            /* check in case of an exact match */
-            if (!strcmp(file->localpath, entry->data)) {
-                return true;
-            }
+        /* check in case of an exact match */
+        if (list_contains(ri->pathmigration_excluded_paths, file->localpath)) {
+            return true;
+        }
 
+        TAILQ_FOREACH(entry, ri->pathmigration_excluded_paths, items) {
             /* ensure the path prefixes end with '/' */
             if (strsuffix(entry->data, "/")) {
                 old = strdup(entry->data);

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -175,12 +175,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
                 working_path = abspath(working_path);
 
                 /* check for the working path in the allowed paths */
-                TAILQ_FOREACH(prefix, allowed, items) {
-                    if (!strcmp(working_path, prefix->data)) {
-                        valid = true;
-                        break;
-                    }
-                }
+                valid = list_contains(allowed, working_path);
 
                 free(working_path);
             }

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -42,7 +42,6 @@ static char *get_shell(const struct rpminspect *ri, const char *fullpath)
     char *start = NULL;
     size_t len;
     int r = 0;
-    string_entry_t *entry = NULL;
 
     assert(ri != NULL);
     assert(ri->shells != NULL);
@@ -84,11 +83,8 @@ static char *get_shell(const struct rpminspect *ri, const char *fullpath)
         walk = basename(buf);
 
         /* is it a shell we care about? */
-        TAILQ_FOREACH(entry, ri->shells, items) {
-            if (!strcmp(walk, entry->data)) {
-                shell = strdup(walk);
-                break;
-            }
+        if (list_contains(ri->shells, walk)) {
+            shell = strdup(walk);
         }
     }
 

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -462,3 +462,25 @@ string_list_t *list_from_array(const char **array)
 
     return list;
 }
+
+/*
+ * Return true if the given string list contains the given string.  It
+ * compares string values, so the string in the list need not be the
+ * same string requested.
+ */
+bool list_contains(const string_list_t *list, const char *s)
+{
+    string_entry_t *entry = NULL;
+
+    if (list == NULL || TAILQ_EMPTY(list)) {
+        return false;
+    }
+
+    TAILQ_FOREACH(entry, list, items) {
+        if (!strcmp(entry->data, s)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/lib/rebase.c
+++ b/lib/rebase.c
@@ -51,7 +51,6 @@ bool is_rebase(struct rpminspect *ri)
     const char *an = NULL;
     const char *bv = NULL;
     const char *av = NULL;
-    string_entry_t *entry = NULL;
 
     assert(ri != NULL);
     assert(ri->peers != NULL);
@@ -91,12 +90,8 @@ bool is_rebase(struct rpminspect *ri)
     }
 
     /* if the package name is on the rebaseable list, it's valid */
-    if (init_rebaseable(ri)) {
-        TAILQ_FOREACH(entry, ri->rebaseable, items) {
-            if ((bn && !strcmp(entry->data, bn)) && (an && !strcmp(entry->data, an))) {
-                return true;
-            }
-        }
+    if (init_rebaseable(ri) && list_contains(ri->rebaseable, bn) && list_contains(ri->rebaseable, an)) {
+        return true;
     }
 
     /* is it a rebase or not or did an error occur? */


### PR DESCRIPTION
There is a regular thing I do in librpminspect which is "check this
list to see if the following string is in it".  I added a function to
do this so I don't have to remember how to construct the TAILQ_FOREACH
each time.  An added bonus is this deletes 62 lines of code.

Signed-off-by: David Cantrell <dcantrell@redhat.com>