### PR TITLE
[fix] Ignore noarch packages in the 'arch' inspection

### DIFF
--- a/include/inspect.h
+++ b/include/inspect.h
@@ -657,7 +657,7 @@ bool inspect_runpath(struct rpminspect *ri);
 
 #define DESC_KMOD _("Report kernel module parameter, dependency, PCI ID, or symbol differences between builds.  Added and removed parameters are reported and if the package version is unchanged, these messages are reported as failures.  The same is true module dependencies, PCI IDs, and symbols.")
 
-#define DESC_ARCH _("Report RPM architectures that appear and disappear between the before and after builds.")
+#define DESC_ARCH _("Report RPM architectures that appear and disappear between the before and after builds.  This inspection does not report the loss of noarch packages.  The purpose of this inspection is to report the loss of target machine architectures as provided in the before build and not seeing them in the after build.")
 
 #define DESC_SUBPACKAGES _("Report RPM subpackages that appear and disappear between the before and after builds.")
 

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -174,7 +174,7 @@ bool inspect_upstream(struct rpminspect *ri)
     /* Run the main inspection */
     TAILQ_FOREACH(peer, ri->peers, items) {
         /* Only look at the files in SRPMs */
-        if (!headerIsSource(peer->after_hdr)) {
+        if (peer->after_rpm == NULL || !headerIsSource(peer->after_hdr)) {
             continue;
         }
 

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -476,6 +476,10 @@ bool list_contains(const string_list_t *list, const char *s)
         return false;
     }
 
+    if (s == NULL) {
+        return false;
+    }
+
     TAILQ_FOREACH(entry, list, items) {
         if (!strcmp(entry->data, s)) {
             return true;

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -196,7 +196,9 @@ string_list_t *get_rpm_header_string_array(Header hdr, rpmTagVal tag)
     string_entry_t *entry = NULL;
     const char *val = NULL;
 
-    assert(hdr != NULL);
+    if (hdr == NULL) {
+        return NULL;
+    }
 
     td = rpmtdNew();
 


### PR DESCRIPTION
The arch inspection is meant to alert developers to lost target
architectures between one build and the next.  Usually in the context
of product maintenance.  Loss of a noarch package should not be
considered the same thing as those are not really architectures in the
context of this inspection.

Signed-off-by: David Cantrell <dcantrell@redhat.com>