### PR TITLE
[fix] Drop all HEADER_* defines, switch to NAME_* (#397)

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -43,6 +43,12 @@
  */
 
 /**
+ * @def COMMAND_NAME
+ * The standard name for the rpminspect command.
+ */
+#define COMMAND_NAME "rpminspect"
+
+/**
  * @def SOFTWARE_NAME
  * Software name.  Used in Koji XMLRPC calls and logging.
  */

--- a/include/results.h
+++ b/include/results.h
@@ -27,53 +27,6 @@
 #define _LIBRPMINSPECT_RESULTS_H
 
 /*
- * Inspection headers
- */
-#define HEADER_RPMINSPECT    "rpminspect"
-#define HEADER_METADATA      "header-metadata"
-#define HEADER_EMPTYRPM      "empty-payload"
-#define HEADER_LOSTPAYLOAD   "lost-payload"
-#define HEADER_LICENSE       "license"
-#define HEADER_ELF           "elf-object-properties"
-#define HEADER_MANPAGE       "man-pages"
-#define HEADER_XML           "xml-files"
-#define HEADER_DESKTOP       "desktop-entry-files"
-#define HEADER_DISTTAG       "dist-tag"
-#define HEADER_SPECNAME      "spec-file-name"
-#define HEADER_MODULARITY    "modularity"
-#define HEADER_JAVABYTECODE  "java-bytecode"
-#define HEADER_CHANGEDFILES  "changed-files"
-#define HEADER_MOVEDFILES    "moved-files"
-#define HEADER_REMOVEDFILES  "removed-files"
-#define HEADER_ADDEDFILES    "added-files"
-#define HEADER_UPSTREAM      "upstream"
-#define HEADER_OWNERSHIP     "ownership"
-#define HEADER_SHELLSYNTAX   "shell-syntax"
-#define HEADER_ANNOCHECK     "annocheck"
-#define HEADER_DSODEPS       "dso-deps"
-#define HEADER_FILESIZE      "filesize"
-#define HEADER_PERMISSIONS   "permissions"
-#define HEADER_CAPABILITIES  "capabilities"
-#define HEADER_KMOD          "kernel-modules"
-#define HEADER_ARCH          "architectures"
-#define HEADER_SUBPACKAGES   "subpackages"
-#define HEADER_CHANGELOG     "changelog"
-#define HEADER_PATHMIGRATION "path-migration"
-#define HEADER_LTO           "lto"
-#define HEADER_SYMLINKS      "symlinks"
-#define HEADER_FILES         "files"
-#define HEADER_TYPES         "types"
-#define HEADER_ABIDIFF       "abidiff"
-#define HEADER_KMIDIFF       "kmidiff"
-#define HEADER_CONFIG        "config"
-#define HEADER_DOC           "doc"
-#define HEADER_PATCHES       "patches"
-#define HEADER_VIRUS         "virus"
-#define HEADER_POLITICS      "politics"
-#define HEADER_BADFUNCS      "bad-functions"
-#define HEADER_RUNPATH       "runpath"
-
-/*
  * Inspection remedies
  */
 /* metadata */

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -344,87 +344,87 @@ const char *inspection_header_to_desc(const char *header)
 {
     uint64_t i = 0;
 
-    if (!strcmp(header, HEADER_METADATA)) {
+    if (!strcmp(header, NAME_METADATA)) {
         i = INSPECT_METADATA;
-    } else if (!strcmp(header, HEADER_EMPTYRPM)) {
+    } else if (!strcmp(header, NAME_EMPTYRPM)) {
         i = INSPECT_EMPTYRPM;
-    } else if (!strcmp(header, HEADER_LOSTPAYLOAD)) {
+    } else if (!strcmp(header, NAME_LOSTPAYLOAD)) {
         i = INSPECT_LOSTPAYLOAD;
-    } else if (!strcmp(header, HEADER_LICENSE)) {
+    } else if (!strcmp(header, NAME_LICENSE)) {
         i = INSPECT_LICENSE;
-    } else if (!strcmp(header, HEADER_ELF)) {
+    } else if (!strcmp(header, NAME_ELF)) {
         i = INSPECT_ELF;
-    } else if (!strcmp(header, HEADER_MANPAGE)) {
+    } else if (!strcmp(header, NAME_MANPAGE)) {
         i = INSPECT_MANPAGE;
-    } else if (!strcmp(header, HEADER_XML)) {
+    } else if (!strcmp(header, NAME_XML)) {
         i = INSPECT_XML;
-    } else if (!strcmp(header, HEADER_DESKTOP)) {
+    } else if (!strcmp(header, NAME_DESKTOP)) {
         i = INSPECT_DESKTOP;
-    } else if (!strcmp(header, HEADER_DISTTAG)) {
+    } else if (!strcmp(header, NAME_DISTTAG)) {
         i = INSPECT_DISTTAG;
-    } else if (!strcmp(header, HEADER_SPECNAME)) {
+    } else if (!strcmp(header, NAME_SPECNAME)) {
         i = INSPECT_SPECNAME;
-    } else if (!strcmp(header, HEADER_MODULARITY)) {
+    } else if (!strcmp(header, NAME_MODULARITY)) {
         i = INSPECT_MODULARITY;
-    } else if (!strcmp(header, HEADER_JAVABYTECODE)) {
+    } else if (!strcmp(header, NAME_JAVABYTECODE)) {
         i = INSPECT_JAVABYTECODE;
-    } else if (!strcmp(header, HEADER_CHANGEDFILES)) {
+    } else if (!strcmp(header, NAME_CHANGEDFILES)) {
         i = INSPECT_CHANGEDFILES;
-    } else if (!strcmp(header, HEADER_MOVEDFILES)) {
+    } else if (!strcmp(header, NAME_MOVEDFILES)) {
         i = INSPECT_MOVEDFILES;
-    } else if (!strcmp(header, HEADER_REMOVEDFILES)) {
+    } else if (!strcmp(header, NAME_REMOVEDFILES)) {
         i = INSPECT_REMOVEDFILES;
-    } else if (!strcmp(header, HEADER_ADDEDFILES)) {
+    } else if (!strcmp(header, NAME_ADDEDFILES)) {
         i = INSPECT_ADDEDFILES;
-    } else if (!strcmp(header, HEADER_UPSTREAM)) {
+    } else if (!strcmp(header, NAME_UPSTREAM)) {
         i = INSPECT_UPSTREAM;
-    } else if (!strcmp(header, HEADER_OWNERSHIP)) {
+    } else if (!strcmp(header, NAME_OWNERSHIP)) {
         i = INSPECT_OWNERSHIP;
-    } else if (!strcmp(header, HEADER_SHELLSYNTAX)) {
+    } else if (!strcmp(header, NAME_SHELLSYNTAX)) {
         i = INSPECT_SHELLSYNTAX;
-    } else if (!strcmp(header, HEADER_DSODEPS)) {
+    } else if (!strcmp(header, NAME_DSODEPS)) {
         i = INSPECT_DSODEPS;
-    } else if (!strcmp(header, HEADER_FILESIZE)) {
+    } else if (!strcmp(header, NAME_FILESIZE)) {
         i = INSPECT_FILESIZE;
-    } else if (!strcmp(header, HEADER_PERMISSIONS)) {
+    } else if (!strcmp(header, NAME_PERMISSIONS)) {
         i = INSPECT_PERMISSIONS;
-    } else if (!strcmp(header, HEADER_CAPABILITIES)) {
+    } else if (!strcmp(header, NAME_CAPABILITIES)) {
         i = INSPECT_CAPABILITIES;
-    } else if (!strcmp(header, HEADER_KMOD)) {
+    } else if (!strcmp(header, NAME_KMOD)) {
         i = INSPECT_KMOD;
-    } else if (!strcmp(header, HEADER_ARCH)) {
+    } else if (!strcmp(header, NAME_ARCH)) {
         i = INSPECT_ARCH;
-    } else if (!strcmp(header, HEADER_SUBPACKAGES)) {
+    } else if (!strcmp(header, NAME_SUBPACKAGES)) {
         i = INSPECT_SUBPACKAGES;
-    } else if (!strcmp(header, HEADER_CHANGELOG)) {
+    } else if (!strcmp(header, NAME_CHANGELOG)) {
         i = INSPECT_CHANGELOG;
-    } else if (!strcmp(header, HEADER_PATHMIGRATION)) {
+    } else if (!strcmp(header, NAME_PATHMIGRATION)) {
         i = INSPECT_PATHMIGRATION;
-    } else if (!strcmp(header, HEADER_LTO)) {
+    } else if (!strcmp(header, NAME_LTO)) {
         i = INSPECT_LTO;
-    } else if (!strcmp(header, HEADER_SYMLINKS)) {
+    } else if (!strcmp(header, NAME_SYMLINKS)) {
         i = INSPECT_SYMLINKS;
-    } else if (!strcmp(header, HEADER_FILES)) {
+    } else if (!strcmp(header, NAME_FILES)) {
         i = INSPECT_FILES;
-    } else if (!strcmp(header, HEADER_TYPES)) {
+    } else if (!strcmp(header, NAME_TYPES)) {
         i = INSPECT_TYPES;
-    } else if (!strcmp(header, HEADER_ABIDIFF)) {
+    } else if (!strcmp(header, NAME_ABIDIFF)) {
         i = INSPECT_ABIDIFF;
-    } else if (!strcmp(header, HEADER_KMIDIFF)) {
+    } else if (!strcmp(header, NAME_KMIDIFF)) {
         i = INSPECT_KMIDIFF;
-    } else if (!strcmp(header, HEADER_CONFIG)) {
+    } else if (!strcmp(header, NAME_CONFIG)) {
         i = INSPECT_CONFIG;
-    } else if (!strcmp(header, HEADER_DOC)) {
+    } else if (!strcmp(header, NAME_DOC)) {
         i = INSPECT_DOC;
-    } else if (!strcmp(header, HEADER_PATCHES)) {
+    } else if (!strcmp(header, NAME_PATCHES)) {
         i = INSPECT_PATCHES;
-    } else if (!strcmp(header, HEADER_VIRUS)) {
+    } else if (!strcmp(header, NAME_VIRUS)) {
         i = INSPECT_VIRUS;
-    } else if (!strcmp(header, HEADER_POLITICS)) {
+    } else if (!strcmp(header, NAME_POLITICS)) {
         i = INSPECT_POLITICS;
-    } else if (!strcmp(header, HEADER_BADFUNCS)) {
+    } else if (!strcmp(header, NAME_BADFUNCS)) {
         i = INSPECT_BADFUNCS;
-    } else if (!strcmp(header, HEADER_RUNPATH)) {
+    } else if (!strcmp(header, NAME_RUNPATH)) {
         i = INSPECT_RUNPATH;
     }
 

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -211,7 +211,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
 
     /* report the results */
     init_result_params(&params);
-    params.header = HEADER_ABIDIFF;
+    params.header = NAME_ABIDIFF;
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.remedy = REMEDY_ABIDIFF;
     params.arch = arch;
@@ -351,7 +351,7 @@ bool inspect_abidiff(struct rpminspect *ri) {
     if (result) {
         init_result_params(&params);
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_ABIDIFF;
+        params.header = NAME_ABIDIFF;
         params.severity = RESULT_OK;
         add_result(ri, &params);
     }

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -90,7 +90,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.severity = RESULT_BAD;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_ADDEDFILES;
+    params.header = NAME_ADDEDFILES;
     params.remedy = REMEDY_ADDEDFILES;
     params.arch = arch;
     params.file = file->localpath;
@@ -169,7 +169,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Check for any new setuid or setgid files */
     if (!S_ISDIR(file->st.st_mode) && (file->st.st_mode & (S_ISUID|S_ISGID))) {
-        match_fileinfo_mode(ri, file, HEADER_ADDEDFILES, REMEDY_ADDEDFILES);
+        match_fileinfo_mode(ri, file, NAME_ADDEDFILES, REMEDY_ADDEDFILES);
         goto done;
     }
 
@@ -203,7 +203,7 @@ bool inspect_addedfiles(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_ADDEDFILES;
+        params.header = NAME_ADDEDFILES;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -68,7 +68,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_ANNOCHECK;
+    params.header = NAME_ANNOCHECK;
     params.remedy = REMEDY_ANNOCHECK;
     params.arch = arch;
     params.file = file->localpath;
@@ -176,7 +176,7 @@ bool inspect_annocheck(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_ANNOCHECK;
+        params.header = NAME_ANNOCHECK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -52,7 +52,7 @@ bool inspect_arch(struct rpminspect *ri) {
 
     init_result_params(&params);
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_ARCH;
+    params.header = NAME_ARCH;
 
     /* Gather up all the architectures */
     TAILQ_FOREACH(peer, ri->peers, items) {

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -127,7 +127,7 @@ static bool badfuncs_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     xasprintf(&params.msg, _("%s may use forbidden functions on %s"), after->localpath, arch);
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_BADFUNCS;
+    params.header = NAME_BADFUNCS;
     params.remedy = REMEDY_BADFUNCS;
     params.details = output_buffer;
     params.verb = VERB_FAILED;
@@ -174,7 +174,7 @@ bool inspect_badfuncs(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_BADFUNCS;
+        params.header = NAME_BADFUNCS;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -67,7 +67,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Set up result parameters */
     init_result_params(&params);
-    params.header = HEADER_CAPABILITIES;
+    params.header = NAME_CAPABILITIES;
     params.arch = arch;
     params.file = file->localpath;
 
@@ -158,7 +158,7 @@ bool inspect_capabilities(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_CAPABILITIES;
+        params.header = NAME_CAPABILITIES;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -156,7 +156,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_CHANGEDFILES;
+    params.header = NAME_CHANGEDFILES;
     params.arch = arch;
     params.file = file->localpath;
 
@@ -234,8 +234,8 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                                                        strsuffix(file->localpath, ".bz2") ||
                                                        strsuffix(file->localpath, ".xz")))) {
         /* uncompress the files to temporary files for comparison */
-        before_uncompressed_file = uncompress_file(ri, file->peer_file->fullpath, HEADER_CHANGEDFILES);
-        after_uncompressed_file = uncompress_file(ri, file->fullpath, HEADER_CHANGEDFILES);
+        before_uncompressed_file = uncompress_file(ri, file->peer_file->fullpath, NAME_CHANGEDFILES);
+        after_uncompressed_file = uncompress_file(ri, file->fullpath, NAME_CHANGEDFILES);
 
         /* we may not have been able to uncompress */
         if (before_uncompressed_file == NULL || after_uncompressed_file == NULL) {
@@ -478,7 +478,7 @@ bool inspect_changedfiles(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_CHANGEDFILES;
+        params.header = NAME_CHANGEDFILES;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -244,7 +244,7 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     /* Set up result parameters */
     init_result_params(&params);
-    params.header = HEADER_CHANGELOG;
+    params.header = NAME_CHANGELOG;
     params.severity = RESULT_OK;
     params.waiverauth = NOT_WAIVABLE;
     params.noun = _("%%changelog");
@@ -368,7 +368,7 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
     init_result_params(&params);
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_CHANGELOG;
+    params.header = NAME_CHANGELOG;
     params.verb = VERB_CHANGED;
     params.noun = _("%%changelog");
 
@@ -459,7 +459,7 @@ bool inspect_changelog(struct rpminspect *ri)
             init_result_params(&params);
             params.severity = RESULT_OK;
             params.waiverauth = NOT_WAIVABLE;
-            params.header = HEADER_CHANGELOG;
+            params.header = NAME_CHANGELOG;
             add_result(ri, &params);
         }
 

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -73,7 +73,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* set up result parameters */
     init_result_params(&params);
-    params.header = HEADER_CONFIG;
+    params.header = NAME_CONFIG;
     params.arch = arch;
     params.file = file->localpath;
     params.remedy = REMEDY_CONFIG;
@@ -211,7 +211,7 @@ bool inspect_config(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_CONFIG;
+        params.header = NAME_CONFIG;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -188,7 +188,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
     init_result_params(&params);
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_DESKTOP;
+    params.header = NAME_DESKTOP;
     params.remedy = REMEDY_DESKTOP;
     params.arch = arch;
     params.file = file->localpath;
@@ -359,7 +359,7 @@ static bool desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.waiverauth = WAIVABLE_BY_ANYONE;
     }
 
-    params.header = HEADER_DESKTOP;
+    params.header = NAME_DESKTOP;
     params.remedy = REMEDY_DESKTOP;
     params.arch = arch;
     params.file = file->localpath;
@@ -413,7 +413,7 @@ bool inspect_desktop(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_DESKTOP;
+        params.header = NAME_DESKTOP;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -184,7 +184,7 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     init_result_params(&params);
     params.severity = RESULT_BAD;
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_DISTTAG;
+    params.header = NAME_DISTTAG;
     params.remedy = REMEDY_DISTTAG;
     params.details = release;
     params.arch = get_rpm_header_arch(file->rpm_header);
@@ -252,7 +252,7 @@ bool inspect_disttag(struct rpminspect *ri) {
     /* Set up result parameters */
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_DISTTAG;
+    params.header = NAME_DISTTAG;
 
     /* If we never saw an SRPM, tell the user. */
     if (result && src) {

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -79,7 +79,7 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* set up result parameters */
     init_result_params(&params);
-    params.header = HEADER_DOC;
+    params.header = NAME_DOC;
     params.arch = arch;
     params.file = file->localpath;
     params.remedy = REMEDY_DOC;
@@ -150,7 +150,7 @@ bool inspect_doc(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_DOC;
+        params.header = NAME_DOC;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -102,7 +102,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_DSODEPS;
+    params.header = NAME_DSODEPS;
     params.remedy = REMEDY_DSODEPS;
     params.arch = arch;
     params.file = file->localpath;
@@ -233,7 +233,7 @@ bool inspect_dsodeps(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_DSODEPS;
+        params.header = NAME_DSODEPS;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -457,7 +457,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
     /* Set up result parameters */
     init_result_params(&params);
     params.waiverauth = WAIVABLE_BY_SECURITY;
-    params.header = HEADER_ELF;
+    params.header = NAME_ELF;
     params.arch = arch;
     params.file = localpath;
 
@@ -599,7 +599,7 @@ static bool check_relro(struct rpminspect *ri, Elf *before_elf, Elf *after_elf, 
     if (params.msg != NULL) {
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_SECURITY;
-        params.header = HEADER_ELF;
+        params.header = NAME_ELF;
         params.remedy = REMEDY_ELF_GNU_RELRO;
         params.arch = arch;
         params.file = localpath;
@@ -714,7 +714,7 @@ static bool check_fortified(struct rpminspect *ri, Elf *before_elf, Elf *after_e
 
     init_result_params(&params);
     xasprintf(&params.msg, _("%s may have lost -D_FORTIFY_SOURCE on %s"), localpath, arch);
-    params.header = HEADER_ELF;
+    params.header = NAME_ELF;
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_SECURITY;
     params.details = output_buffer;
@@ -938,7 +938,7 @@ static bool elf_archive_tests(struct rpminspect *ri, Elf *after_elf, int after_e
         xasprintf(&params.msg, _("%s in %s has objects built without -fPIC on %s"), localpath, name, arch);
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_SECURITY;
-        params.header = HEADER_ELF;
+        params.header = NAME_ELF;
         params.remedy = REMEDY_ELF_FPIC;
         params.details = screendump;
         params.arch = arch;
@@ -968,7 +968,7 @@ static bool elf_regular_tests(struct rpminspect *ri, Elf *after_elf, Elf *before
 
     init_result_params(&params);
     params.severity = RESULT_BAD;
-    params.header = HEADER_ELF;
+    params.header = NAME_ELF;
     params.waiverauth = WAIVABLE_BY_SECURITY;
     params.remedy = REMEDY_ELF_TEXTREL;
     params.arch = arch;
@@ -1097,7 +1097,7 @@ bool inspect_elf(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_ELF;
+        params.header = NAME_ELF;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -64,7 +64,7 @@ bool inspect_emptyrpm(struct rpminspect *ri) {
     assert(ri->peers != NULL);
 
     init_result_params(&params);
-    params.header = HEADER_EMPTYRPM;
+    params.header = NAME_EMPTYRPM;
 
     /*
      * The emptyrpm inspection looks for any packages missing

--- a/lib/inspect_files.c
+++ b/lib/inspect_files.c
@@ -72,7 +72,7 @@ static bool files_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     init_result_params(&params);
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_FILES;
+    params.header = NAME_FILES;
     params.remedy = REMEDY_FILES;
     params.file = file->localpath;
 
@@ -169,7 +169,7 @@ bool inspect_files(struct rpminspect *ri) {
 
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_FILES;
+    params.header = NAME_FILES;
 
     if (result && src) {
         params.severity = RESULT_OK;

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -70,7 +70,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_FILESIZE;
+    params.header = NAME_FILESIZE;
     params.arch = arch;
     params.file = file->localpath;
 
@@ -146,7 +146,7 @@ bool inspect_filesize(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_FILESIZE;
+        params.header = NAME_FILESIZE;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -111,7 +111,7 @@ static bool check_class_file(struct rpminspect *ri, const char *fullpath,
     init_result_params(&params);
     params.severity = RESULT_BAD;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_JAVABYTECODE;
+    params.header = NAME_JAVABYTECODE;
 
     /* try to see if this is just a .class file */
     major = get_jvm_major(fullpath, localpath, container);
@@ -292,7 +292,7 @@ bool inspect_javabytecode(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_JAVABYTECODE;
+        params.header = NAME_JAVABYTECODE;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -286,7 +286,7 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* report the results */
     init_result_params(&params);
-    params.header = HEADER_KMIDIFF;
+    params.header = NAME_KMIDIFF;
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.remedy = REMEDY_KMIDIFF;
     params.arch = arch;
@@ -438,7 +438,7 @@ bool inspect_kmidiff(struct rpminspect *ri) {
     if (result) {
         init_result_params(&params);
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_KMIDIFF;
+        params.header = NAME_KMIDIFF;
         params.severity = RESULT_OK;
         add_result(ri, &params);
     }

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -303,7 +303,7 @@ bool inspect_kmod(struct rpminspect *ri) {
     init_result_params(&params);
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_KMOD;
+    params.header = NAME_KMOD;
     result = foreach_peer_file(ri, NAME_KMOD, kmod_driver, true);
 
     /* if everything was fine, just say so */

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -451,7 +451,7 @@ bool inspect_license(struct rpminspect *ri)
     assert(ri->peers != NULL);
 
     init_result_params(&params);
-    params.header = HEADER_LICENSE;
+    params.header = NAME_LICENSE;
     params.waiverauth = NOT_WAIVABLE;
 
     xasprintf(&actual_licensedb, "%s/%s/%s", ri->vendor_data_dir, LICENSES_DIR, ri->licensedb);

--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -51,7 +51,7 @@ bool inspect_lostpayload(struct rpminspect *ri) {
     assert(ri->peers != NULL);
 
     init_result_params(&params);
-    params.header = HEADER_LOSTPAYLOAD;
+    params.header = NAME_LOSTPAYLOAD;
 
     /*
      * The lostpayload inspection looks for any packages missing payloads.

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -145,7 +145,7 @@ static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     init_result_params(&params);
     params.severity = RESULT_BAD;
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_LTO;
+    params.header = NAME_LTO;
     params.remedy = REMEDY_LTO;
     params.verb = VERB_FAILED;
     params.arch = arch;
@@ -218,7 +218,7 @@ bool inspect_lto(struct rpminspect *ri) {
     if (result) {
         init_result_params(&params);
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_LTO;
+        params.header = NAME_LTO;
         params.severity = RESULT_OK;
         add_result(ri, &params);
     }

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -291,14 +291,14 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_MANPAGE;
+    params.header = NAME_MANPAGE;
     params.arch = get_rpm_header_arch(file->rpm_header);
     params.file = file->localpath;
     params.verb = VERB_FAILED;
     params.noun = _("${FILE}");
 
     /* check for empty man pages */
-    uncompressed_man_page = uncompress_file(ri, file->fullpath, HEADER_MANPAGE);
+    uncompressed_man_page = uncompress_file(ri, file->fullpath, NAME_MANPAGE);
     if (uncompressed_man_page != NULL) {
         r = stat(uncompressed_man_page, &sb);
 
@@ -353,7 +353,7 @@ bool inspect_manpage(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_MANPAGE;
+        params.header = NAME_MANPAGE;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_metadata.c
+++ b/lib/inspect_metadata.c
@@ -48,7 +48,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
 
     /* Set up result parameters */
     init_result_params(&params);
-    params.header = HEADER_METADATA;
+    params.header = NAME_METADATA;
 
     after_vendor = headerGetString(after_hdr, RPMTAG_VENDOR);
     if (ri->vendor == NULL) {
@@ -207,7 +207,7 @@ bool inspect_metadata(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_METADATA;
+        params.header = NAME_METADATA;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -40,7 +40,7 @@ static bool modularity_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     init_result_params(&params);
     params.severity = RESULT_BAD;
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_MODULARITY;
+    params.header = NAME_MODULARITY;
     params.remedy = REMEDY_MODULARITY;
 
     /* Build the message we'll use for errors */
@@ -93,7 +93,7 @@ bool inspect_modularity(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.header = HEADER_MODULARITY;
+        params.header = NAME_MODULARITY;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -43,7 +43,7 @@ static bool movedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     rebase = is_rebase(ri);
 
     init_result_params(&params);
-    params.header = HEADER_MOVEDFILES;
+    params.header = NAME_MOVEDFILES;
 
     if (rebase) {
         params.severity = RESULT_INFO;
@@ -72,7 +72,7 @@ bool inspect_movedfiles(struct rpminspect *ri) {
 
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_MOVEDFILES;
+    params.header = NAME_MOVEDFILES;
 
     if (result) {
         params.severity = RESULT_OK;

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -111,7 +111,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
 
     /* Set up result parameters */
     init_result_params(&params);
-    params.header = HEADER_OWNERSHIP;
+    params.header = NAME_OWNERSHIP;
     params.arch = arch;
     params.file = file->localpath;
 
@@ -147,7 +147,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
             bin = true;
 
             /* Check the owner */
-            if (strcmp(owner, ri->bin_owner) && !match_fileinfo_owner(ri, file, owner, HEADER_OWNERSHIP, NULL)) {
+            if (strcmp(owner, ri->bin_owner) && !match_fileinfo_owner(ri, file, owner, NAME_OWNERSHIP, NULL)) {
                 xasprintf(&params.msg, _("File %s has owner `%s` on %s, but should be `%s`"), file->localpath, owner, arch, ri->bin_owner);
                 params.severity = RESULT_BAD;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
@@ -190,7 +190,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
                         free(params.msg);
                         result = false;
                     }
-                } else if (!match_fileinfo_group(ri, file, group, HEADER_OWNERSHIP, NULL)) {
+                } else if (!match_fileinfo_group(ri, file, group, NAME_OWNERSHIP, NULL)) {
                     xasprintf(&params.msg, _("File %s has group `%s` on %s, but should be `%s`"), file->localpath, group, arch, ri->bin_group);
                     params.severity = RESULT_BAD;
                     params.waiverauth = WAIVABLE_BY_ANYONE;
@@ -286,7 +286,7 @@ bool inspect_ownership(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_OWNERSHIP;
+        params.header = NAME_OWNERSHIP;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -174,7 +174,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* patches may be compressed, so uncompress them here for diff(1) */
     if (file->peer_file) {
-        before_patch = uncompress_file(ri, file->peer_file->fullpath, HEADER_PATCHES);
+        before_patch = uncompress_file(ri, file->peer_file->fullpath, NAME_PATCHES);
 
         if (before_patch == NULL) {
             warn("unable to prepare patch: %s", file->peer_file->localpath);
@@ -182,7 +182,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
     }
 
-    after_patch = uncompress_file(ri, file->fullpath, HEADER_PATCHES);
+    after_patch = uncompress_file(ri, file->fullpath, NAME_PATCHES);
 
     if (after_patch == NULL) {
         warn("unable to prepare patch: %s", file->localpath);
@@ -330,7 +330,7 @@ bool inspect_patches(struct rpminspect *ri)
     assert(ri != NULL);
 
     init_result_params(&params);
-    params.header = HEADER_PATCHES;
+    params.header = NAME_PATCHES;
 
     /* Check for source package */
     TAILQ_FOREACH(peer, ri->peers, items) {
@@ -397,7 +397,7 @@ bool inspect_patches(struct rpminspect *ri)
     /* Sound the everything-is-ok alarm if everything is, in fact, ok */
     if (result && !reported) {
         init_result_params(&params);
-        params.header = HEADER_PATCHES;
+        params.header = NAME_PATCHES;
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         add_result(ri, &params);

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -72,7 +72,7 @@ static bool pathmigration_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_PATHMIGRATION;
+    params.header = NAME_PATHMIGRATION;
     params.remedy = REMEDY_PATHMIGRATION;
     params.arch = arch;
 
@@ -126,7 +126,7 @@ bool inspect_pathmigration(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_PATHMIGRATION;
+        params.header = NAME_PATHMIGRATION;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -51,7 +51,7 @@ static bool permissions_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Set up result parameters */
     init_result_params(&params);
     params.severity = RESULT_VERIFY;
-    params.header = HEADER_PERMISSIONS;
+    params.header = NAME_PERMISSIONS;
     params.arch = arch;
 
     /* Local working copies for display */
@@ -65,7 +65,7 @@ static bool permissions_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     mode_diff = before_mode ^ after_mode;
-    allowed = match_fileinfo_mode(ri, file, HEADER_PERMISSIONS, NULL);
+    allowed = match_fileinfo_mode(ri, file, NAME_PERMISSIONS, NULL);
 
     /* if setuid/setgid or new mode is more open */
     if (mode_diff && file->peer_file && !allowed) {
@@ -118,7 +118,7 @@ bool inspect_permissions(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_PERMISSIONS;
+        params.header = NAME_PERMISSIONS;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -130,7 +130,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         init_result_params(&params);
         params.arch = get_rpm_header_arch(file->rpm_header);
         params.file = file->localpath;
-        params.header = HEADER_POLITICS;
+        params.header = NAME_POLITICS;
         params.remedy = REMEDY_POLITICS;
 
         if (allowed) {
@@ -170,7 +170,7 @@ bool inspect_politics(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_POLITICS;
+        params.header = NAME_POLITICS;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -89,7 +89,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Set up result parameters */
     init_result_params(&params);
-    params.header = HEADER_REMOVEDFILES;
+    params.header = NAME_REMOVEDFILES;
     params.arch = arch;
     params.file = file->localpath;
 
@@ -190,7 +190,7 @@ bool inspect_removedfiles(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_REMOVEDFILES;
+        params.header = NAME_REMOVEDFILES;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -99,7 +99,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
     init_result_params(&params);
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_RUNPATH;
+    params.header = NAME_RUNPATH;
     params.remedy = REMEDY_RUNPATH;
     params.arch = arch;
     params.file = file->localpath;
@@ -307,7 +307,7 @@ bool inspect_runpath(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_RUNPATH;
+        params.header = NAME_RUNPATH;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -132,7 +132,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Set up the result parameters */
     init_result_params(&params);
-    params.header = HEADER_SHELLSYNTAX;
+    params.header = NAME_SHELLSYNTAX;
     params.arch = arch;
     params.file = file->localpath;
 
@@ -251,7 +251,7 @@ bool inspect_shellsyntax(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_SHELLSYNTAX;
+        params.header = NAME_SHELLSYNTAX;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_specname.c
+++ b/lib/inspect_specname.c
@@ -76,7 +76,7 @@ static bool specname_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
         init_result_params(&params);
         params.severity = RESULT_BAD;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_SPECNAME;
+        params.header = NAME_SPECNAME;
         params.remedy = REMEDY_SPECNAME;
         params.file = file->localpath;
 
@@ -110,7 +110,7 @@ bool inspect_specname(struct rpminspect *ri) {
 
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_SPECNAME;
+    params.header = NAME_SPECNAME;
 
     if (specgood) {
         params.severity = RESULT_OK;

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -70,7 +70,7 @@ bool inspect_subpackages(struct rpminspect *ri) {
 
     /* Set up result parameters */
     init_result_params(&params);
-    params.header = HEADER_SUBPACKAGES;
+    params.header = NAME_SUBPACKAGES;
 
     /* Report results */
     if (lost != NULL && !TAILQ_EMPTY(lost)) {

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -96,7 +96,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
 
     /* initialize the result parameters */
     init_result_params(&params);
-    params.header = HEADER_SYMLINKS;
+    params.header = NAME_SYMLINKS;
     params.remedy = REMEDY_SYMLINKS;
     params.verb = VERB_FAILED;
     params.arch = get_rpm_header_arch(file->rpm_header);
@@ -325,7 +325,7 @@ bool inspect_symlinks(struct rpminspect *ri) {
     if (result) {
         init_result_params(&params);
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_SYMLINKS;
+        params.header = NAME_SYMLINKS;
         params.severity = RESULT_OK;
         add_result(ri, &params);
     }

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -65,7 +65,7 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         init_result_params(&params);
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.header = HEADER_TYPES;
+        params.header = NAME_TYPES;
         params.remedy = REMEDY_TYPES;
         params.arch = arch;
         params.file = file->localpath;
@@ -97,7 +97,7 @@ bool inspect_types(struct rpminspect *ri) {
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_TYPES;
+        params.header = NAME_TYPES;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -135,7 +135,7 @@ bool inspect_upstream(struct rpminspect *ri)
     assert(ri != NULL);
 
     init_result_params(&params);
-    params.header = HEADER_UPSTREAM;
+    params.header = NAME_UPSTREAM;
 
     /* Check for source package */
     TAILQ_FOREACH(peer, ri->peers, items) {

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -136,7 +136,7 @@ bool inspect_virus(struct rpminspect *ri)
     /* display version information about clamav */
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
-    params.header = HEADER_VIRUS;
+    params.header = NAME_VIRUS;
     xasprintf(&params.msg, _("clamav version information"));
 
     dbpath = cl_retdbdir();
@@ -186,7 +186,7 @@ bool inspect_virus(struct rpminspect *ri)
     /* run the virus check on each file */
     params.severity = RESULT_BAD;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_VIRUS;
+    params.header = NAME_VIRUS;
     params.verb = VERB_FAILED;
     params.noun = _("virus or malware in ${FILE}");
     result = foreach_peer_file(ri, NAME_VIRUS, virus_driver, false);
@@ -196,7 +196,7 @@ bool inspect_virus(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_VIRUS;
+        params.header = NAME_VIRUS;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -190,7 +190,7 @@ static bool xml_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.header = HEADER_XML;
+    params.header = NAME_XML;
     params.remedy = REMEDY_XML;
     params.arch = get_rpm_header_arch(file->rpm_header);
     params.file = file->localpath;
@@ -219,7 +219,7 @@ bool inspect_xml(struct rpminspect *ri)
         init_result_params(&params);
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
-        params.header = HEADER_XML;
+        params.header = NAME_XML;
         add_result(ri, &params);
     }
 

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -721,7 +721,7 @@ int main(int argc, char **argv) {
     /* general information in the results */
     init_result_params(&params);
     params.severity = RESULT_INFO;
-    params.header = HEADER_RPMINSPECT;
+    params.header = COMMAND_NAME;
 
     /* add version information to the results output */
     params.msg = _("version");

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -58,7 +58,9 @@ def check_results(results, inspection, result, waiver_auth, message=None):
         raise AssertionError("JSON test result is empty")
 
     if inspection not in results:
-        raise AssertionError(f'The inspection "{inspection}" is missing from results "{results}"')
+        raise AssertionError(
+            f'The inspection "{inspection}" is missing from results "{results}"'
+        )
 
     for r in results[inspection]:
         if "result" in r and "waiver authorization" in r:
@@ -251,7 +253,9 @@ class TestSRPM(RequiresRpminspect):
             self.dumpResults()
 
         self.assertEqual(self.p.returncode, self.exitcode)
-        check_results(self.results, self.result_inspection, self.result, self.waiver_auth)
+        check_results(
+            self.results, self.result_inspection, self.result, self.waiver_auth
+        )
 
     def tearDown(self):
         self.rpm.clean()
@@ -411,9 +415,12 @@ class TestRPMs(TestSRPM):
                 self.dumpResults()
 
             self.assertEqual(self.p.returncode, self.exitcode)
-            self.assertEqual(self.results[self.result_inspection][0]["result"], self.result)
             self.assertEqual(
-                self.results[self.result_inspection][0]["waiver authorization"], self.waiver_auth
+                self.results[self.result_inspection][0]["result"], self.result
+            )
+            self.assertEqual(
+                self.results[self.result_inspection][0]["waiver authorization"],
+                self.waiver_auth,
             )
 
     def tearDown(self):

--- a/test/test_abidiff.py
+++ b/test/test_abidiff.py
@@ -46,7 +46,6 @@ class AbidiffNoRebaseNoABIChangeRPMs(TestCompareRPMs):
         self.after_rpm.add_simple_library()
 
         self.inspection = "abidiff"
-        self.label = "abidiff"
         self.result = "OK"
 
 
@@ -58,7 +57,6 @@ class AbidiffNoRebaseNoABIChangeKoji(TestCompareKoji):
         self.after_rpm.add_simple_library()
 
         self.inspection = "abidiff"
-        self.label = "abidiff"
         self.result = "OK"
 
 
@@ -75,7 +73,6 @@ class AbidiffRebaseNoABIChangeRPMs(TestCompareRPMs):
         self.after_rpm.add_simple_library()
 
         self.inspection = "abidiff"
-        self.label = "abidiff"
         self.exitcode = 0
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
@@ -93,7 +90,6 @@ class AbidiffRebaseNoABIChangeKoji(TestCompareKoji):
         self.after_rpm.header += "\n%global __os_install_post %{nil}\n"
 
         self.inspection = "abidiff"
-        self.label = "abidiff"
         self.exitcode = 0
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
@@ -112,7 +108,6 @@ class AbidiffRebaseWithABIChangeRPMs(TestCompareRPMs):
         self.after_rpm.add_simple_library(sourceContent=new_library_source)
 
         self.inspection = "abidiff"
-        self.label = "abidiff"
         self.exitcode = 0
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
@@ -130,7 +125,6 @@ class AbidiffRebaseWithABIChangeKoji(TestCompareKoji):
         self.after_rpm.add_simple_library(sourceContent=new_library_source)
 
         self.inspection = "abidiff"
-        self.label = "abidiff"
         self.exitcode = 0
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
@@ -151,7 +145,6 @@ class AbidiffNoRebaseWithABIChangeRPMs(TestCompareRPMs):
         )
 
         self.inspection = "abidiff"
-        self.label = "abidiff"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -170,6 +163,5 @@ class AbidiffNoRebaseWithABIChangeKoji(TestCompareKoji):
         )
 
         self.inspection = "abidiff"
-        self.label = "abidiff"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_addedfiles.py
+++ b/test/test_addedfiles.py
@@ -36,7 +36,6 @@ class FileSizeGrowsAtThreshold(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -56,7 +55,6 @@ class FileSizeGrowsAboveThreshold(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -75,6 +73,5 @@ class FileSizeGrowsBelowThreshold(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"

--- a/test/test_badfuncs.py
+++ b/test/test_badfuncs.py
@@ -31,7 +31,6 @@ class ForbiddenIPv6FunctionRPM(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.inspection = "badfuncs"
-        self.label = "bad-functions"
         self.waiver_auth = "Anyone"
         self.result = "VERIFY"
 
@@ -41,7 +40,6 @@ class ForbiddenIPv6FunctionKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.inspection = "badfuncs"
-        self.label = "bad-functions"
         self.waiver_auth = "Anyone"
         self.result = "VERIFY"
 
@@ -52,7 +50,6 @@ class ForbiddenIPv6FunctionCompareRPMs(TestCompareRPMs):
         self.before_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.after_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.inspection = "badfuncs"
-        self.label = "bad-functions"
         self.waiver_auth = "Anyone"
         self.result = "VERIFY"
 
@@ -63,6 +60,5 @@ class ForbiddenIPv6FunctionCompareKoji(TestCompareKoji):
         self.before_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.after_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.inspection = "badfuncs"
-        self.label = "bad-functions"
         self.waiver_auth = "Anyone"
         self.result = "VERIFY"

--- a/test/test_changedfiles.py
+++ b/test/test_changedfiles.py
@@ -46,7 +46,6 @@ class GzipFileNoChangeRPMs(TestCompareRPMs):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -71,7 +70,6 @@ class GzipFileNoChangeKoji(TestCompareKoji):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -97,7 +95,6 @@ class GzipFileChangesRPMs(TestCompareRPMs):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -122,7 +119,6 @@ class GzipFileChangesKoji(TestCompareKoji):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -149,7 +145,6 @@ class Bzip2FileNoChangeRPMs(TestCompareRPMs):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -174,7 +169,6 @@ class Bzip2FileNoChangeKoji(TestCompareKoji):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -200,7 +194,6 @@ class Bzip2FileChangesRPMs(TestCompareRPMs):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -225,7 +218,6 @@ class Bzip2FileChangesKoji(TestCompareKoji):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -252,7 +244,6 @@ class XzFileNoChangeRPMs(TestCompareRPMs):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -277,7 +268,6 @@ class XzFileNoChangeKoji(TestCompareKoji):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -303,7 +293,6 @@ class XzFileChangesRPMs(TestCompareRPMs):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -328,6 +317,5 @@ class XzFileChangesKoji(TestCompareKoji):
         )
 
         self.inspection = "changedfiles"
-        self.label = "changed-files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -43,7 +43,6 @@ class LostChangeLogCompareSRPM(TestCompareSRPM):
         self.after_rpm.section_changelog = None
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -64,7 +63,6 @@ class LostChangeLogCompareRPMs(TestCompareRPMs):
         self.after_rpm.section_changelog = None
 
         self.inspection = "changelog"
-        self.label = "changelog"
         # this is INFO because it's only comapring the binary RPMs,
         # the other checks are for SRPMs
         self.result = "INFO"
@@ -87,7 +85,6 @@ class LostChangeLogCompareKoji(TestCompareKoji):
         self.after_rpm.section_changelog = None
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -110,7 +107,6 @@ class GainedChangeLogCompareSRPM(TestCompareSRPM):
         self.after_rpm.section_changelog = clog
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -131,7 +127,6 @@ class GainedChangeLogCompareRPMs(TestCompareRPMs):
         self.after_rpm.section_changelog = clog
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -152,7 +147,6 @@ class GainedChangeLogCompareKoji(TestCompareKoji):
         self.after_rpm.section_changelog = clog
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -175,7 +169,6 @@ class SameChangeLogCompareSRPM(TestCompareSRPM):
         self.after_rpm.section_changelog = clog
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -196,7 +189,6 @@ class SameChangeLogCompareKoji(TestCompareKoji):
         self.after_rpm.section_changelog = clog
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -228,7 +220,6 @@ class BalancedChangeLogEditCompareKoji(TestCompareKoji):
         self.after_rpm.section_changelog = after_prefix + suffix
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -257,7 +248,6 @@ class UnbalancedChangeLogEditCompareKoji(TestCompareKoji):
         self.after_rpm.section_changelog = prefix + suffix
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -290,7 +280,6 @@ class AddChangeLogEntryCompareSRPM(TestCompareSRPM):
         # We want to check here for OK anyway because any other return
         # indicates a failure in the SRPM only changelog inspection.
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -315,7 +304,6 @@ class AddChangeLogEntryCompareRPMs(TestCompareRPMs):
         self.after_rpm.section_changelog = after_prefix + suffix
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -340,7 +328,6 @@ class AddChangeLogEntryCompareKoji(TestCompareKoji):
         self.after_rpm.section_changelog = after_prefix + suffix
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -367,6 +354,5 @@ class UnprofessinalChangeLogEntryCompareKoji(TestCompareKoji):
         self.after_rpm.section_changelog = after_prefix + suffix
 
         self.inspection = "changelog"
-        self.label = "changelog"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -90,7 +90,6 @@ class ConfigBecomesNonConfigCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -112,7 +111,6 @@ class ConfigBecomesNonConfigCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -135,7 +133,6 @@ class ConfigBecomesNonConfigRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -157,7 +154,6 @@ class ConfigBecomesNonConfigRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -180,7 +176,6 @@ class NonConfigBecomesConfigCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -202,7 +197,6 @@ class NonConfigBecomesConfigCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -225,7 +219,6 @@ class NonConfigBecomesConfigRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -247,7 +240,6 @@ class NonConfigBecomesConfigRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -270,7 +262,6 @@ class ConfigChangesWhitespaceCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -292,7 +283,6 @@ class ConfigChangesWhitespaceCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -314,7 +304,6 @@ class ConfigChangesWhitespaceRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -336,7 +325,6 @@ class ConfigChangesWhitespaceRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -359,7 +347,6 @@ class ConfigChangesContentCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -381,7 +368,6 @@ class ConfigChangesContentCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -403,7 +389,6 @@ class ConfigChangesContentRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -425,7 +410,6 @@ class ConfigChangesContentRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -453,7 +437,6 @@ class ConfigChangeFromFileToSymlinkCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -480,7 +463,6 @@ class ConfigChangeFromFileToSymlinkCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -507,7 +489,6 @@ class ConfigChangeFromSymlinkToFileCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -534,7 +515,6 @@ class ConfigChangeFromSymlinkToFileCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -562,7 +542,6 @@ class ConfigChangeFromFileToSymlinkRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -589,7 +568,6 @@ class ConfigChangeFromFileToSymlinkRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -616,7 +594,6 @@ class ConfigChangeFromSymlinkToFileRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -643,7 +620,6 @@ class ConfigChangeFromSymlinkToFileRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -676,7 +652,6 @@ class ConfigSymlinkChangedValueCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -708,7 +683,6 @@ class ConfigSymlinkChangedValueCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -741,7 +715,6 @@ class ConfigSymlinkChangedValueRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -771,6 +744,5 @@ class ConfigSymlinkChangedValueRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.label = "config"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"

--- a/test/test_desktop.py
+++ b/test/test_desktop.py
@@ -96,7 +96,6 @@ class ValidDesktopFileRPM(TestRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "OK"
 
 
@@ -121,7 +120,6 @@ class ValidDesktopFileKoji(TestKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "OK"
 
 
@@ -155,7 +153,6 @@ class ValidDesktopFileCompareRPM(TestCompareRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "OK"
 
 
@@ -189,7 +186,6 @@ class ValidDesktopFileCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "OK"
 
 
@@ -208,7 +204,6 @@ class DesktopFileMissingIconRPM(TestRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -233,7 +228,6 @@ class DesktopFileMissingIconCompareRPM(TestCompareRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -253,7 +247,6 @@ class DesktopFileMissingIconKoji(TestKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -278,7 +271,6 @@ class DesktopFileMissingIconCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -304,7 +296,6 @@ class DesktopFileValidateFailsRPM(TestRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -330,7 +321,6 @@ class DesktopFileValidateFailsKoji(TestKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -365,7 +355,6 @@ class DesktopFileValidateFailsCompareRPM(TestCompareRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -400,7 +389,6 @@ class DesktopFileValidateFailsCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -426,7 +414,6 @@ class DesktopFileExecArgsRPM(TestRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "OK"
 
 
@@ -451,7 +438,6 @@ class DesktopFileExecArgsKoji(TestKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "OK"
 
 
@@ -485,7 +471,6 @@ class DesktopFileExecArgsCompareRPM(TestCompareRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "OK"
 
 
@@ -519,7 +504,6 @@ class DesktopFileExecArgsCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "OK"
 
 
@@ -545,7 +529,6 @@ class DesktopFileNotWorldReadableIconRPM(TestRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -572,7 +555,6 @@ class DesktopFileNotWorldReadableIconKoji(TestKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -609,7 +591,6 @@ class DesktopFileNotWorldReadableIconCompareRPM(TestCompareRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -646,7 +627,6 @@ class DesktopFileNotWorldReadableIconCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -669,7 +649,6 @@ class DesktopFileInvalidExecRPM(TestRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -692,7 +671,6 @@ class DesktopFileInvalidExecRPMs(TestKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -723,7 +701,6 @@ class DesktopFileInvalidExecCompareRPM(TestCompareRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -754,7 +731,6 @@ class DesktopFileInvalidExecCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -781,7 +757,6 @@ class DesktopFileWithoutWorldExecutableExecRPM(TestRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -808,7 +783,6 @@ class DesktopFileWithoutWorldExecutableExecKoji(TestKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -845,7 +819,6 @@ class DesktopFileWithoutWorldExecutableExecCompareRPM(TestCompareRPMs):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -882,6 +855,5 @@ class DesktopFileWithoutWorldExecutableExecCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "desktop"
-        self.label = "desktop-entry-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -38,7 +38,6 @@ class MissingDistTagSRPM(TestSRPM):
     def setUp(self):
         TestSRPM.setUp(self)
         self.inspection = "disttag"
-        self.label = "dist-tag"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -48,7 +47,6 @@ class MissingDistTagKojiBuild(TestKoji):
     def setUp(self):
         TestKoji.setUp(self)
         self.inspection = "disttag"
-        self.label = "dist-tag"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -59,7 +57,6 @@ class DistTagOnNonSRPM(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.release = "1%{?dist}"
         self.inspection = "disttag"
-        self.label = "dist-tag"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -70,7 +67,6 @@ class MalformedDistTagSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.release = "1dist"
         self.inspection = "disttag"
-        self.label = "dist-tag"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -81,7 +77,6 @@ class MalformedDistTagKojiBuild(TestKoji):
         TestKoji.setUp(self)
         self.rpm.release = "1dist"
         self.inspection = "disttag"
-        self.label = "dist-tag"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -92,7 +87,6 @@ class DistTagSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.release = "1%{?dist}"
         self.inspection = "disttag"
-        self.label = "dist-tag"
 
 
 # Verify correct %{?dist} usage passes on Koji build (OK)
@@ -101,7 +95,6 @@ class DistTagKojiBuild(TestKoji):
         TestKoji.setUp(self)
         self.rpm.release = "1%{?dist}"
         self.inspection = "disttag"
-        self.label = "dist-tag"
 
 
 ########################################################################
@@ -159,7 +152,6 @@ class DistTagInMacroSRPM(RequiresRpminspect):
         # the inspection we are checking
         self.exitcode = 0
         self.inspection = "disttag"
-        self.label = "dist-tag"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -199,7 +191,7 @@ class DistTagInMacroSRPM(RequiresRpminspect):
             self.dumpResults()
 
         self.assertEqual(self.p.returncode, self.exitcode)
-        check_results(self.results, self.label, self.result, self.waiver_auth)
+        check_results(self.results, self.inspection, self.result, self.waiver_auth)
 
     def tearDown(self):
         self.tmpdir.cleanup()
@@ -251,7 +243,6 @@ class TabbedDistTagInMacroSRPM(RequiresRpminspect):
         # the inspection we are checking
         self.exitcode = 0
         self.inspection = "disttag"
-        self.label = "dist-tag"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -291,7 +282,7 @@ class TabbedDistTagInMacroSRPM(RequiresRpminspect):
             self.dumpResults()
 
         self.assertEqual(self.p.returncode, self.exitcode)
-        check_results(self.results, self.label, self.result, self.waiver_auth)
+        check_results(self.results, self.inspection, self.result, self.waiver_auth)
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -56,7 +56,6 @@ class DocBecomesNonDocCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -78,7 +77,6 @@ class DocBecomesNonDocCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -101,7 +99,6 @@ class DocBecomesNonDocRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -123,7 +120,6 @@ class DocBecomesNonDocRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -146,7 +142,6 @@ class NonDocBecomesDocCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -168,7 +163,6 @@ class NonDocBecomesDocCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -191,7 +185,6 @@ class NonDocBecomesDocRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -213,7 +206,6 @@ class NonDocBecomesDocRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -236,7 +228,6 @@ class DocChangesWhitespaceCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -258,7 +249,6 @@ class DocChangesWhitespaceCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -280,7 +270,6 @@ class DocChangesWhitespaceRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -302,7 +291,6 @@ class DocChangesWhitespaceRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -325,7 +313,6 @@ class DocChangesContentCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -347,7 +334,6 @@ class DocChangesContentCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -369,7 +355,6 @@ class DocChangesContentRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -391,6 +376,5 @@ class DocChangesContentRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "doc"
-        self.label = "doc"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"

--- a/test/test_elf.py
+++ b/test/test_elf.py
@@ -69,7 +69,6 @@ class WithoutExecStackRPM(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
@@ -79,7 +78,6 @@ class WithoutExecStackKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
@@ -90,7 +88,6 @@ class WithoutExecStackCompareRPM(TestCompareRPMs):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
@@ -101,7 +98,6 @@ class WithoutExecStackCompareKoji(TestCompareKoji):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
@@ -112,7 +108,6 @@ class WithExecStackRPM(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.add_simple_compilation(compileFlags="-Wl,-z,execstack")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -122,7 +117,6 @@ class WithExecStackKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.add_simple_compilation(compileFlags="-Wl,-z,execstack")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -133,7 +127,6 @@ class WithExecStackCompareRPMs(TestCompareRPMs):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,execstack")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,execstack")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "VERIFY"
 
@@ -144,7 +137,6 @@ class WithExecStackCompare(TestCompareKoji):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,execstack")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,execstack")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "VERIFY"
 
@@ -156,7 +148,6 @@ class LostFullRELROCompareRPMs(TestCompareRPMs):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,now")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,norelro")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -167,7 +158,6 @@ class LostFullRELROCompareKoji(TestCompareKoji):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,now")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,norelro")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -179,7 +169,6 @@ class FulltoPartialRELROCompareRPMs(TestCompareRPMs):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,now")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,lazy")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -190,7 +179,6 @@ class FulltoPartialRELROCompareKoji(TestCompareKoji):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,now")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,lazy")
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -211,7 +199,6 @@ class LostFortifySourceCompareRPMs(TestCompareRPMs):
             compileFlags="-fno-stack-protector -O2 -D_FORTIFY_SOURCE=0",
         )
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "VERIFY"
 
@@ -231,7 +218,6 @@ class LostFortifySourceCompareKoji(TestCompareKoji):
             compileFlags="-fno-stack-protector -O2 -D_FORTIFY_SOURCE=0",
         )
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "VERIFY"
 
@@ -267,7 +253,6 @@ class LostPICCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_payload_check(installPath, None)
 
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -302,7 +287,6 @@ class LostPICCompareKoji(TestCompareKoji):
         self.after_rpm.add_payload_check(installPath, None)
 
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -327,7 +311,6 @@ class HasTEXTRELRPMs(TestRPMs):
         self.rpm.add_payload_check(installPath, None)
 
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -369,7 +352,6 @@ class HasTEXTRELCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_payload_check(installPath, None)
 
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
@@ -411,6 +393,5 @@ class HasTEXTRELCompareKoji(TestCompareKoji):
         self.after_rpm.add_payload_check(installPath, None)
 
         self.inspection = "elf"
-        self.label = "elf-object-properties"
         self.waiver_auth = "Security"
         self.result = "BAD"

--- a/test/test_emptyrpm.py
+++ b/test/test_emptyrpm.py
@@ -25,7 +25,6 @@ class HasPayloadSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.add_simple_payload_file()
         self.inspection = "emptyrpm"
-        self.label = "empty-payload"
         self.result = "OK"
 
 
@@ -35,7 +34,6 @@ class HasPayloadRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.add_simple_payload_file()
         self.inspection = "emptyrpm"
-        self.label = "empty-payload"
         self.result = "OK"
 
 
@@ -45,7 +43,6 @@ class HasPayloadKojiBuild(TestKoji):
         TestKoji.setUp(self)
         self.rpm.add_simple_payload_file()
         self.inspection = "emptyrpm"
-        self.label = "empty-payload"
         self.result = "OK"
 
 
@@ -54,7 +51,6 @@ class PkgHasEmptyPayload(TestRPMs):
     def setUp(self):
         TestRPMs.setUp(self)
         self.inspection = "emptyrpm"
-        self.label = "empty-payload"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -64,6 +60,5 @@ class KojiBuildHaveEmptyPayloads(TestKoji):
     def setUp(self):
         TestKoji.setUp(self)
         self.inspection = "emptyrpm"
-        self.label = "empty-payload"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -48,7 +48,6 @@ class ValidFilesSectionSRPM(TestSRPM):
 
         # the inspection results expected
         self.inspection = "files"
-        self.label = "files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -75,7 +74,6 @@ class ValidFilesSectionKoji(TestKoji):
 
         # the inspection results expected
         self.inspection = "files"
-        self.label = "files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -104,7 +102,6 @@ class ValidFilesSectionCompareSRPM(TestCompareSRPM):
 
         # the inspection results expected
         self.inspection = "files"
-        self.label = "files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -133,7 +130,6 @@ class ValidFilesSectionCompareKoji(TestCompareKoji):
 
         # the inspection results expected
         self.inspection = "files"
-        self.label = "files"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -144,7 +140,6 @@ class InvalidFilesSectionSRPM(TestSRPM):
         self.rpm.add_simple_library()
 
         self.inspection = "files"
-        self.label = "files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -155,7 +150,6 @@ class InvalidFilesSectionKoji(TestKoji):
         self.rpm.add_simple_library()
 
         self.inspection = "files"
-        self.label = "files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -166,7 +160,6 @@ class InvalidFilesSectionCompareSRPM(TestCompareSRPM):
         self.after_rpm.add_simple_library()
 
         self.inspection = "files"
-        self.label = "files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -177,6 +170,5 @@ class InvalidFilesSectionCompareKoji(TestCompareKoji):
         self.after_rpm.add_simple_library()
 
         self.inspection = "files"
-        self.label = "files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_filesize.py
+++ b/test/test_filesize.py
@@ -37,7 +37,6 @@ class FileSizeGrowsAtThreshold(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
         self.message = f"/some/file grew by 20% on {platform.machine()}"
@@ -58,7 +57,6 @@ class FileSizeGrowsAboveThreshold(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
         self.message = f"/some/file grew by 100% on {platform.machine()}"
@@ -78,7 +76,6 @@ class FileSizeGrowsBelowThreshold(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
         self.message = f"/some/file grew by 10% on {platform.machine()}"
@@ -98,7 +95,6 @@ class EmptyFileSizeGrows(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
         self.message = f"/some/file became a non-empty file on {platform.machine()}"
@@ -118,7 +114,6 @@ class FileSizeShrinksAtThreshold(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
         self.message = f"/some/file shrank by 20% on {platform.machine()}"
@@ -138,7 +133,6 @@ class FileSizeShrinksAboveThreshold(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
         self.message = f"/some/file shrank by 80% on {platform.machine()}"
@@ -158,7 +152,6 @@ class FileSizeShrinksBelowThreshold(TestCompareRPMs):
         )
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
         self.message = f"/some/file shrank by 10% on {platform.machine()}"
@@ -176,7 +169,6 @@ class FileSizeShrinksToEmpty(TestCompareRPMs):
         self.after_rpm.add_installed_file("/some/file", rpmfluff.SourceFile("file", ""))
 
         self.inspection = "filesize"
-        self.label = "filesize"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
         self.message = f"/some/file became an empty file on {platform.machine()}"

--- a/test/test_kmod.py
+++ b/test/test_kmod.py
@@ -152,7 +152,6 @@ class GoodKmodParamsRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -173,7 +172,6 @@ class LostKmodParmsRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -194,7 +192,6 @@ class GoodKmodParamsKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -215,7 +212,6 @@ class LostKmodParamsKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -240,7 +236,6 @@ class GoodKmodDependsRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -261,7 +256,6 @@ class LostKmodDependsRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -282,7 +276,6 @@ class GoodKmodDependsKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -303,7 +296,6 @@ class LostKmodDependsKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -328,7 +320,6 @@ class GoodKmodAliasesRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -349,7 +340,6 @@ class LostKmodAliasesRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -370,7 +360,6 @@ class GoodKmodAliasesKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -391,7 +380,6 @@ class LostKmodAliasesKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -412,7 +400,6 @@ class KmodChangingPathCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -432,6 +419,5 @@ class KmodChangingPathCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.label = "kernel-modules"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -30,7 +30,6 @@ class EmptyLicenseTagSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.license = ""
         self.inspection = "license"
-        self.label = "license"
         self.result = "BAD"
 
 
@@ -43,7 +42,6 @@ class EmptyLicenseTagRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.license = ""
         self.inspection = "license"
-        self.label = "license"
         self.result = "BAD"
 
 
@@ -56,7 +54,6 @@ class EmptyLicenseTagKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.license = ""
         self.inspection = "license"
-        self.label = "license"
         self.result = "BAD"
 
 
@@ -66,7 +63,6 @@ class ForbiddenLicenseTagSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addLicense("APSL-1.2")
         self.inspection = "license"
-        self.label = "license"
         self.result = "BAD"
 
 
@@ -76,7 +72,6 @@ class ForbiddenLicenseTagRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.addLicense("APSL-1.2")
         self.inspection = "license"
-        self.label = "license"
         self.result = "BAD"
 
 
@@ -86,7 +81,6 @@ class ForbiddenLicenseTagKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addLicense("APSL-1.2")
         self.inspection = "license"
-        self.label = "license"
         self.result = "BAD"
 
 
@@ -96,7 +90,6 @@ class BadWordLicenseTagSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
         self.inspection = "license"
-        self.label = "license"
         self.result = "BAD"
 
 
@@ -106,7 +99,6 @@ class BadWordLicenseTagRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
         self.inspection = "license"
-        self.label = "license"
         self.result = "BAD"
 
 
@@ -116,7 +108,6 @@ class BadWordLicenseTagKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
         self.inspection = "license"
-        self.label = "license"
         self.result = "BAD"
 
 
@@ -126,7 +117,6 @@ class ValidLicenseTagSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addLicense("GPLv3+")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -136,7 +126,6 @@ class ValidLicenseTagRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.addLicense("GPLv3+")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -146,7 +135,6 @@ class ValidLicenseTagKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addLicense("GPLv3+")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -156,7 +144,6 @@ class ValidLicenseTagWithSpacesSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addLicense("ASL 2.0")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -166,7 +153,6 @@ class ValidLicenseTagWithSpacesRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.addLicense("ASL 2.0")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -176,7 +162,6 @@ class ValidLicenseTagWithSpacesKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addLicense("ASL 2.0")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -186,7 +171,6 @@ class ValidLicenseTagWithBooleanSpacesSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addLicense("GPLv3+ and ASL 2.0")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -196,7 +180,6 @@ class ValidLicenseTagWithBooleanSpacesRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.addLicense("ASL 2.0 and GPLv3+")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -206,7 +189,6 @@ class ValidLicenseTagWithBooleanSpacesKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addLicense("GPLv3+ or ASL 2.0")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -216,7 +198,6 @@ class ValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addLicense("Artistic 2.0 and (GPL+ or Artistic)")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -226,7 +207,6 @@ class ValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.addLicense("Artistic 2.0 and (GPL+ or Artistic)")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -236,7 +216,6 @@ class ValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addLicense("Artistic 2.0 and (GPL+ or Artistic)")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -246,7 +225,6 @@ class AnotherValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -256,7 +234,6 @@ class AnotherValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -266,7 +243,6 @@ class AnotherValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -279,7 +255,6 @@ class ValidGlibcLicenseTagKoji(TestKoji):
             "and BSD and Inner-Net and ISC and Public Domain and GFDL"
         )
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"
 
 
@@ -289,5 +264,4 @@ class ValidPerlHTTPMessageLicenseTagKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addLicense("(GPL+ or Artistic) and CC0")
         self.inspection = "license"
-        self.label = "license"
         self.result = "INFO"

--- a/test/test_lostpayload.py
+++ b/test/test_lostpayload.py
@@ -26,7 +26,6 @@ class NewPkgHasEmptyPayload(TestCompareKoji):
         self.before_rpm.add_simple_payload_file()
         self.after_rpm.add_subpackage(self.after_rpm.name + "-newthing")
         self.inspection = "lostpayload"
-        self.label = "lost-payload"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -36,7 +35,6 @@ class PkgStillHasEmptyPayload(TestCompareKoji):
     def setUp(self):
         TestCompareKoji.setUp(self)
         self.inspection = "lostpayload"
-        self.label = "lost-payload"
         self.result = "INFO"
 
 
@@ -46,7 +44,6 @@ class PkgLostPayload(TestCompareKoji):
         TestCompareKoji.setUp(self)
         self.before_rpm.add_simple_payload_file()
         self.inspection = "lostpayload"
-        self.label = "lost-payload"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -58,6 +55,5 @@ class ExistingPkgMissing(TestCompareKoji):
         self.before_rpm.add_simple_payload_file()
         self.before_rpm.add_subpackage(self.before_rpm.name + "-newthing")
         self.inspection = "lostpayload"
-        self.label = "lost-payload"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_lto.py
+++ b/test/test_lto.py
@@ -43,7 +43,6 @@ class NoLTOSymbolsRelocRPMs(TestRPMs):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -57,7 +56,6 @@ class NoLTOSymbolsRelocKoji(TestKoji):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -71,7 +69,6 @@ class NoLTOSymbolsRelocCompareRPMs(TestCompareRPMs):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -85,7 +82,6 @@ class NoLTOSymbolsRelocCompareKoji(TestCompareKoji):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -110,7 +106,6 @@ class NoLTOSymbolsStaticLibRPMs(TestRPMs):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -134,7 +129,6 @@ class NoLTOSymbolsStaticLibKoji(TestKoji):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -158,7 +152,6 @@ class NoLTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -182,7 +175,6 @@ class NoLTOSymbolsStaticLibCompareKoji(TestCompareKoji):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -197,7 +189,6 @@ class LTOSymbolsRelocRPMs(TestRPMs):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -211,7 +202,6 @@ class LTOSymbolsRelocKoji(TestKoji):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -225,7 +215,6 @@ class LTOSymbolsRelocCompareRPMs(TestCompareRPMs):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -239,7 +228,6 @@ class LTOSymbolsRelocCompareKoji(TestCompareKoji):
             installPath="usr/lib/lto.o",
         )
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -264,7 +252,6 @@ class LTOSymbolsStaticLibRPMs(TestRPMs):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -288,7 +275,6 @@ class LTOSymbolsStaticLibKoji(TestKoji):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -312,7 +298,6 @@ class LTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -336,6 +321,5 @@ class LTOSymbolsStaticLibCompareKoji(TestCompareKoji):
         sub.section_files += "/usr/lib/liblto.a\n"
 
         self.inspection = "lto"
-        self.label = "lto"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"

--- a/test/test_manpage.py
+++ b/test/test_manpage.py
@@ -42,7 +42,6 @@ class ManPageCorrectSectionRPM(TestRPMs):
         )
 
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "OK"
 
 
@@ -62,7 +61,6 @@ class ManPageCorrectSectionKoji(TestKoji):
         )
 
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "OK"
 
 
@@ -87,7 +85,6 @@ class ManPageCorrectSectionCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "OK"
 
 
@@ -112,7 +109,6 @@ class ManPageCorrectSectionCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "OK"
 
 
@@ -134,7 +130,6 @@ class ManPageNotGzippedRPM(TestRPMs):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -157,7 +152,6 @@ class ManPageNotGzippedKoji(TestKoji):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -185,7 +179,6 @@ class ManPageNotGzippedCompareRPMs(TestCompareRPMs):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -213,7 +206,6 @@ class ManPageNotGzippedCompareKoji(TestCompareKoji):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -226,7 +218,6 @@ class ManPageWrongSectionRPM(TestRPMs):
             sourceFileName="foo.8", installPath="usr/share/man/man1/foo.8.gz"
         )
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -239,7 +230,6 @@ class ManPageWrongSectionKoji(TestKoji):
             sourceFileName="foo.8", installPath="usr/share/man/man1/foo.8.gz"
         )
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -255,7 +245,6 @@ class ManPageWrongSectionCompareRPMs(TestCompareRPMs):
             sourceFileName="foo.8", installPath="usr/share/man/man1/foo.8.gz"
         )
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -271,7 +260,6 @@ class ManPageWrongSectionCompareKoji(TestCompareKoji):
             sourceFileName="foo.8", installPath="usr/share/man/man1/foo.8.gz"
         )
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -292,7 +280,6 @@ class InvalidManPageRPM(TestRPMs):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -313,7 +300,6 @@ class InvalidManPageKoji(TestKoji):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -339,7 +325,6 @@ class InvalidManPageCompareRPMs(TestCompareRPMs):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -365,7 +350,6 @@ class InvalidManPageCompareKoji(TestCompareKoji):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -389,7 +373,6 @@ class EmptyManPageRPM(TestRPMs):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -413,7 +396,6 @@ class EmptyManPageKoji(TestKoji):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -437,7 +419,6 @@ class EmptyManPageCompareRPMs(TestCompareRPMs):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -461,6 +442,5 @@ class EmptyManPageCompareKoji(TestCompareKoji):
 
         # the test
         self.inspection = "manpage"
-        self.label = "man-pages"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -32,7 +32,6 @@ class ValidVendorSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "OK"
 
 
@@ -42,7 +41,6 @@ class ValidVendorRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "OK"
 
 
@@ -52,7 +50,6 @@ class ValidVendorKojiBuild(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "OK"
 
 
@@ -62,7 +59,6 @@ class InvalidVendorSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addVendor("Amalgamated Amalgamations LLC")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -72,7 +68,6 @@ class InvalidVendorRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.addVendor("Amalgamated Amalgamations LLC")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -82,7 +77,6 @@ class InvalidVendorKojiBuild(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addVendor("Amalgamated Amalgamations LLC")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -92,7 +86,6 @@ class GainingVendorCompareSRPM(TestCompareSRPM):
         TestCompareSRPM.setUp(self)
         self.after_rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -103,7 +96,6 @@ class GainingVendorCompareRPMs(TestCompareRPMs):
         TestCompareRPMs.setUp(self)
         self.after_rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -114,7 +106,6 @@ class GainingVendorCompareKojiBuild(TestCompareKoji):
         TestCompareKoji.setUp(self)
         self.after_rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -125,7 +116,6 @@ class LosingVendorCompareSRPM(TestCompareSRPM):
         TestCompareSRPM.setUp(self)
         self.before_rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.waiver_auth = "Anyone"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
@@ -137,7 +127,6 @@ class LosingVendorCompareRPMs(TestCompareRPMs):
         TestCompareRPMs.setUp(self)
         self.before_rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.waiver_auth = "Anyone"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
@@ -149,7 +138,6 @@ class LosingVendorCompareKojiBuild(TestCompareKoji):
         TestCompareKoji.setUp(self)
         self.before_rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.waiver_auth = "Anyone"
         self.result = "VERIFY"
 
@@ -161,7 +149,6 @@ class ChangingVendorCompareSRPM(TestCompareSRPM):
         self.before_rpm.addVendor("Amalgamated Amalgamations LLC")
         self.after_rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.waiver_auth = "Anyone"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
@@ -174,7 +161,6 @@ class ChangingVendorCompareRPMs(TestCompareRPMs):
         self.before_rpm.addVendor("Amalgamated Amalgamations LLC")
         self.after_rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -186,7 +172,6 @@ class LosingVendorCompareKojiBeforeAfterBuild(TestCompareKoji):
         self.before_rpm.addVendor("Amalgamated Amalgamations LLC")
         self.after_rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -198,7 +183,6 @@ class InvalidBuildhostSubdomainSRPM(TestSRPM):
         self.buildhost_subdomain = ".totallylegitbuilder.com"
         self.rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -209,7 +193,6 @@ class InvalidBuildhostSubdomainRPMs(TestRPMs):
         self.buildhost_subdomain = ".totallylegitbuilder.com"
         self.rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -220,7 +203,6 @@ class InvalidBuildhostSubdomainKojiBuild(TestKoji):
         self.buildhost_subdomain = ".totallylegitbuilder.com"
         self.rpm.addVendor("Vendorco Ltd.")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -230,7 +212,6 @@ class CleanSummarySRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.add_summary("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "OK"
 
 
@@ -240,7 +221,6 @@ class CleanSummaryRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.add_summary("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "OK"
 
 
@@ -250,7 +230,6 @@ class CleanSummaryKojiBuild(TestKoji):
         TestKoji.setUp(self)
         self.rpm.add_summary("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "OK"
 
 
@@ -260,7 +239,6 @@ class DirtySummarySRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.add_summary("Lorem ipsum reallybadword dolor sit amet")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -270,7 +248,6 @@ class DirtySummaryRPMs(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.add_summary("Lorem ipsum reallybadword dolor sit amet")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -280,7 +257,6 @@ class DirtySummaryKojiBuild(TestKoji):
         TestKoji.setUp(self)
         self.rpm.add_summary("Lorem ipsum reallybadword dolor sit amet")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -291,7 +267,6 @@ class ChangingSummaryCompareSRPM(TestCompareSRPM):
         self.before_rpm.add_summary("Lorem ipsum dolor sit amet")
         self.after_rpm.add_summary("Lorem ipsum")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -303,7 +278,6 @@ class ChangingSummaryCompareRPMs(TestCompareRPMs):
         self.before_rpm.add_summary("Lorem ipsum dolor sit amet")
         self.after_rpm.add_summary("Lorem ipsum")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -315,7 +289,6 @@ class ChangingSummaryCompareKojiBuild(TestCompareKoji):
         self.before_rpm.add_summary("Lorem ipsum dolor sit amet")
         self.after_rpm.add_summary("Lorem ipsum")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -333,7 +306,6 @@ class CleanDescriptionSRPM(TestSRPM):
             "sunt in culpa qui officia deserunt mollit anim id est laborum."
         )
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "OK"
 
 
@@ -350,7 +322,6 @@ class CleanDescriptionRPMs(TestRPMs):
             "sunt in culpa qui officia deserunt mollit anim id est laborum."
         )
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "OK"
 
 
@@ -367,7 +338,6 @@ class CleanDescriptionKojiBuild(TestKoji):
             "sunt in culpa qui officia deserunt mollit anim id est laborum."
         )
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "OK"
 
 
@@ -384,7 +354,6 @@ class DirtyDescriptionSRPM(TestSRPM):
             "sunt in culpa qui officia deserunt mollit anim id est laborum."
         )
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -401,7 +370,6 @@ class DirtyDescriptionRPMs(TestRPMs):
             "sunt in culpa qui officia deserunt mollit anim id est laborum."
         )
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -418,7 +386,6 @@ class DirtyDescriptionKojiBuild(TestKoji):
             "sunt in culpa qui officia deserunt mollit anim id est laborum."
         )
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "BAD"
 
 
@@ -436,7 +403,6 @@ class ChangingDescriptionCompareSRPM(TestCompareSRPM):
         )
         self.after_rpm.add_description("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -455,7 +421,6 @@ class ChangingDescriptionCompareRPMs(TestCompareRPMs):
         )
         self.after_rpm.add_description("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -474,6 +439,5 @@ class ChangingDescriptionCompareKojiBuild(TestCompareKoji):
         )
         self.after_rpm.add_description("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
-        self.label = "header-metadata"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_ownership.py
+++ b/test/test_ownership.py
@@ -49,7 +49,6 @@ class SlashBinOwnedByRootRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -70,7 +69,6 @@ class SlashSbinOwnedByRootRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -91,7 +89,6 @@ class SlashUsrSlashBinOwnedByRootRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -112,7 +109,6 @@ class SlashUsrSlashSbinOwnedByRootRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -133,7 +129,6 @@ class SlashBinOwnedByBinRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -155,7 +150,6 @@ class SlashSbinOwnedByBinRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -177,7 +171,6 @@ class SlashUsrSlashBinOwnedByBinRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -199,7 +192,6 @@ class SlashUsrSlashSbinOwnedByBinRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -221,7 +213,6 @@ class SlashBinOwnedByRootKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -242,7 +233,6 @@ class SlashSbinOwnedByRootKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -263,7 +253,6 @@ class SlashUsrSlashBinOwnedByRootKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -284,7 +273,6 @@ class SlashUsrSlashSbinOwnedByRootKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -305,7 +293,6 @@ class SlashBinOwnedByBinKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -327,7 +314,6 @@ class SlashSbinOwnedByBinKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -349,7 +335,6 @@ class SlashUsrSlashBinOwnedByBinKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -371,7 +356,6 @@ class SlashUsrSlashSbinOwnedByBinKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -393,7 +377,6 @@ class SlashBinOwnedByRootCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -414,7 +397,6 @@ class SlashSbinOwnedByRootCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -435,7 +417,6 @@ class SlashUsrSlashBinOwnedByRootCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -456,7 +437,6 @@ class SlashUsrSlashSbinOwnedByRootCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -477,7 +457,6 @@ class SlashBinOwnedByBinCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -499,7 +478,6 @@ class SlashSbinOwnedByBinCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -521,7 +499,6 @@ class SlashUsrSlashBinOwnedByBinCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -543,7 +520,6 @@ class SlashUsrSlashSbinOwnedByBinCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -565,7 +541,6 @@ class SlashBinOwnedByRootCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -586,7 +561,6 @@ class SlashSbinOwnedByRootCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -607,7 +581,6 @@ class SlashUsrSlashBinOwnedByRootCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -628,7 +601,6 @@ class SlashUsrSlashSbinOwnedByRootCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -649,7 +621,6 @@ class SlashBinOwnedByBinCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -671,7 +642,6 @@ class SlashSbinOwnedByBinCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -693,7 +663,6 @@ class SlashUsrSlashBinOwnedByBinCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -715,7 +684,6 @@ class SlashUsrSlashSbinOwnedByBinCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -742,7 +710,6 @@ class SlashBinOwnedByGroupRootRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -763,7 +730,6 @@ class SlashSbinOwnedByGroupRootRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -784,7 +750,6 @@ class SlashUsrSlashBinOwnedByGroupRootRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -805,7 +770,6 @@ class SlashUsrSlashSbinOwnedByGroupRootRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -826,7 +790,6 @@ class SlashBinOwnedByGroupBinRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -848,7 +811,6 @@ class SlashSbinOwnedByGroupBinRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -870,7 +832,6 @@ class SlashiUsrSlashBinOwnedByGroupBinRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -892,7 +853,6 @@ class SlashUsrSlashSbinOwnedByGroupBinRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -914,7 +874,6 @@ class SlashBinOwnedByGroupRootKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -935,7 +894,6 @@ class SlashSbinOwnedByGroupRootKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -956,7 +914,6 @@ class SlashUsrSlashBinOwnedByGroupRootKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -977,7 +934,6 @@ class SlashUsrSlashSbinOwnedByGroupRootKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -998,7 +954,6 @@ class SlashBinOwnedByGroupBinKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1020,7 +975,6 @@ class SlashSbinOwnedByGroupBinKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1042,7 +996,6 @@ class SlashUsrSlashBinOwnedByGroupBinKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1064,7 +1017,6 @@ class SlashUsrSlashSbinOwnedByGroupBinKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1086,7 +1038,6 @@ class SlashBinOwnedByGroupRootCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -1107,7 +1058,6 @@ class SlashSbinOwnedByGroupRootCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -1128,7 +1078,6 @@ class SlashUsrSlashBinOwnedByGroupRootCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -1149,7 +1098,6 @@ class SlashUsrSlashSbinOwnedByGroupRootCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -1170,7 +1118,6 @@ class SlashBinOwnedByGroupBinCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1192,7 +1139,6 @@ class SlashSbinOwnedByGroupBinCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1214,7 +1160,6 @@ class SlashUsrSlashBinOwnedByGroupBinCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1236,7 +1181,6 @@ class SlashUsrSlashSbinOwnedByGroupBinCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1258,7 +1202,6 @@ class SlashBinOwnedByGroupRootCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -1279,7 +1222,6 @@ class SlashSbinOwnedByGroupRootCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -1300,7 +1242,6 @@ class SlashUsrSlashBinOwnedByGroupRootCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -1321,7 +1262,6 @@ class SlashUsrSlashSbinOwnedByGroupRootCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "OK"
 
 
@@ -1342,7 +1282,6 @@ class SlashBinOwnedByGroupBinCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1364,7 +1303,6 @@ class SlashSbinOwnedByGroupBinCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1386,7 +1324,6 @@ class SlashUsrSlashBinOwnedByGroupBinCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1408,7 +1345,6 @@ class SlashUsrSlashSbinOwnedByGroupBinCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1434,7 +1370,6 @@ class SlashBinOwnedByMockRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1455,7 +1390,6 @@ class SlashBinOwnedByMockKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1477,7 +1411,6 @@ class SlashBinOwnedByMockCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1499,7 +1432,6 @@ class SlashBinOwnedByMockCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1526,7 +1458,6 @@ class SlashBinOwnedByGroupMockRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1548,7 +1479,6 @@ class SlashBinOwnedByGroupMockKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1570,7 +1500,6 @@ class SlashBinOwnedByGroupMockCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1592,7 +1521,6 @@ class SlashBinOwnedByGroupMockCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1627,7 +1555,6 @@ class CapSETUIDWithOtherExecRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1657,7 +1584,6 @@ class CapSETUIDWithOtherExecKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1689,7 +1615,6 @@ class CapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1721,7 +1646,6 @@ class CapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1756,7 +1680,6 @@ class CapSETUIDWithGroupExecRPMs(TestRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1786,7 +1709,6 @@ class CapSETUIDWithGroupExecKoji(TestKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1818,7 +1740,6 @@ class CapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1850,7 +1771,6 @@ class CapSETUIDWithGroupExecCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1885,7 +1805,6 @@ class FileOwnerChangedCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1916,7 +1835,6 @@ class FileOwnerChangedCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1951,7 +1869,6 @@ class FileGroupChangedCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1982,6 +1899,5 @@ class FileGroupChangedCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "ownership"
-        self.label = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -165,7 +165,6 @@ class PatchUnderFourBytes(TestSRPM):
         self.rpm.add_patch(rpmfluff.SourceFile("some.patch", "Qx"), False)
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -184,7 +183,6 @@ class PatchUnderFourBytesCompare(TestCompareSRPM):
         self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", "Qx"), False)
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -200,7 +198,6 @@ class PatchChangedNotRebaseCompare(TestCompareSRPM):
         )
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -215,7 +212,6 @@ class PatchChangedInRebaseCompare(TestCompareSRPM):
         )
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -228,7 +224,6 @@ class PatchAddedNotRebaseCompare(TestCompareSRPM):
         self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -241,7 +236,6 @@ class PatchAddedInRebaseCompare(TestCompareSRPM):
         self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -257,7 +251,6 @@ class PatchTouchesTooManyFiles(TestSRPM):
         )
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -286,7 +279,6 @@ class PatchTouchesTooManyFilesCompare(TestCompareSRPM):
         )
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -316,7 +308,6 @@ class PatchTouchesTooManyLines(TestSRPM):
         )
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -345,7 +336,6 @@ class PatchTouchesTooManyLinesCompare(TestCompareSRPM):
         )
 
         self.inspection = "patches"
-        self.label = "patches"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 

--- a/test/test_pathmigration.py
+++ b/test/test_pathmigration.py
@@ -35,7 +35,6 @@ class SlashBinFileRPM(TestRPMs):
         self.rpm.add_simple_compilation(installPath="bin/hello-world")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -50,7 +49,6 @@ class SlashBinFileCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_simple_compilation(installPath="bin/hello-world")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -64,7 +62,6 @@ class SlashBinFileKoji(TestKoji):
         self.rpm.add_simple_compilation(installPath="bin/hello-world")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -79,7 +76,6 @@ class SlashBinFileCompareKoji(TestCompareKoji):
         self.after_rpm.add_simple_compilation(installPath="bin/hello-world")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -97,7 +93,6 @@ class SlashSbinFileRPM(TestRPMs):
         self.rpm.add_simple_compilation(installPath="sbin/hello-world")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -112,7 +107,6 @@ class SlashSbinFileCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_simple_compilation(installPath="sbin/hello-world")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -126,7 +120,6 @@ class SlashSbinFileKoji(TestKoji):
         self.rpm.add_simple_compilation(installPath="sbin/hello-world")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -141,7 +134,6 @@ class SlashSbinFileCompareKoji(TestCompareKoji):
         self.after_rpm.add_simple_compilation(installPath="sbin/hello-world")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -159,7 +151,6 @@ class SlashLibFileRPM(TestRPMs):
         self.rpm.add_simple_compilation(installPath="lib/libfoo.so")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -174,7 +165,6 @@ class SlashLibFileCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_simple_compilation(installPath="lib/libfoo.so")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -188,7 +178,6 @@ class SlashLibFileKoji(TestKoji):
         self.rpm.add_simple_compilation(installPath="lib/libfoo.so")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -203,7 +192,6 @@ class SlashLibFileCompareKoji(TestCompareKoji):
         self.after_rpm.add_simple_compilation(installPath="lib/libfoo.so")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -221,7 +209,6 @@ class SlashLib64FileRPM(TestRPMs):
         self.rpm.add_simple_compilation(installPath="lib64/libfoo.so")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -236,7 +223,6 @@ class SlashLib64FileCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_simple_compilation(installPath="lib64/libfoo.so")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -250,7 +236,6 @@ class SlashLib64FileKoji(TestKoji):
         self.rpm.add_simple_compilation(installPath="lib64/libfoo.so")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -265,6 +250,5 @@ class SlashLib64FileCompareKoji(TestCompareKoji):
         self.after_rpm.add_simple_compilation(installPath="lib64/libfoo.so")
 
         self.inspection = "pathmigration"
-        self.label = "path-migration"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -36,7 +36,6 @@ class ExecutableWithSetUIDSRPM(TestSRPM):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -54,7 +53,6 @@ class ExecutableWithSetUIDRPMs(TestRPMs):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "INFO"
 
 
@@ -72,7 +70,6 @@ class ExecutableWithSetUIDKoji(TestKoji):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "INFO"
 
 
@@ -90,7 +87,6 @@ class ExecutableWithSetUIDCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -108,7 +104,6 @@ class ExecutableWithSetUIDCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "INFO"
 
 
@@ -126,7 +121,6 @@ class ExecutableWithSetUIDCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "INFO"
 
 
@@ -144,7 +138,6 @@ class UnapprovedExecutableWithSetUIDSRPM(TestSRPM):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -162,7 +155,6 @@ class UnapprovedExecutableWithSetUIDRPMs(TestRPMs):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -181,7 +173,6 @@ class UnapprovedExecutableWithSetUIDKoji(TestKoji):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -200,7 +191,6 @@ class UnapprovedExecutableWithSetUIDCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -218,7 +208,6 @@ class UnapprovedExecutableWithSetUIDCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -237,7 +226,6 @@ class UnapprovedExecutableWithSetUIDCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -256,7 +244,6 @@ class FileIWOTHProhibitedSRPM(TestSRPM):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -274,7 +261,6 @@ class FileIWOTHProhibitedRPMs(TestRPMs):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -293,7 +279,6 @@ class FileIWOTHProhibitedKoji(TestKoji):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -312,7 +297,6 @@ class FileIWOTHProhibitedCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -330,7 +314,6 @@ class FileIWOTHProhibitedCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -349,7 +332,6 @@ class FileIWOTHProhibitedCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -368,7 +350,6 @@ class FileIWOTHandISVTXProhibitedSRPM(TestSRPM):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -386,7 +367,6 @@ class FileIWOTHandISVTXProhibitedRPMs(TestRPMs):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -405,7 +385,6 @@ class FileIWOTHandISVTXProhibitedKoji(TestKoji):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -424,7 +403,6 @@ class FileIWOTHandISVTXProhibitedCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -442,7 +420,6 @@ class FileIWOTHandISVTXProhibitedCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -461,7 +438,6 @@ class FileIWOTHandISVTXProhibitedCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -478,7 +454,6 @@ class DirIWOTHProhibitedSRPM(TestSRPM):
         self.rpm.add_installed_directory("/usr/share/dumping-ground", mode="0757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -494,7 +469,6 @@ class DirIWOTHProhibitedRPMs(TestRPMs):
         self.rpm.add_installed_directory("/usr/share/dumping-ground", mode="0757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -511,7 +485,6 @@ class DirIWOTHProhibitedKoji(TestKoji):
         self.rpm.add_installed_directory("/usr/share/dumping-ground", mode="0757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -528,7 +501,6 @@ class DirIWOTHProhibitedCompareSRPM(TestCompareSRPM):
         self.after_rpm.add_installed_directory("/usr/share/dumping-ground", mode="0757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -544,7 +516,6 @@ class DirIWOTHProhibitedCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_installed_directory("/usr/share/dumping-ground", mode="0757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -561,7 +532,6 @@ class DirIWOTHProhibitedCompareKoji(TestCompareKoji):
         self.after_rpm.add_installed_directory("/usr/share/dumping-ground", mode="0757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -578,7 +548,6 @@ class DirIWOTHandISVTXProhibitedSRPM(TestSRPM):
         self.rpm.add_installed_directory("/usr/share/dumping-ground", mode="1757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -594,7 +563,6 @@ class DirIWOTHandISVTXProhibitedRPMs(TestRPMs):
         self.rpm.add_installed_directory("/usr/share/dumping-ground", mode="1757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -611,7 +579,6 @@ class DirIWOTHandISVTXProhibitedKoji(TestKoji):
         self.rpm.add_installed_directory("/usr/share/dumping-ground", mode="1757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -628,7 +595,6 @@ class DirIWOTHandISVTXProhibitedCompareSRPM(TestCompareSRPM):
         self.after_rpm.add_installed_directory("/usr/share/dumping-ground", mode="1757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "OK"
 
 
@@ -644,7 +610,6 @@ class DirIWOTHandISVTXProhibitedCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_installed_directory("/usr/share/dumping-ground", mode="1757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"
 
@@ -661,6 +626,5 @@ class DirIWOTHandISVTXProhibitedCompareKoji(TestCompareKoji):
         self.after_rpm.add_installed_directory("/usr/share/dumping-ground", mode="1757")
 
         self.inspection = "permissions"
-        self.label = "permissions"
         self.result = "BAD"
         self.waiver_auth = "Security"

--- a/test/test_politics.py
+++ b/test/test_politics.py
@@ -37,7 +37,6 @@ class AllowedPoliticallySensitiveFileSRPM(TestSRPM):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -52,7 +51,6 @@ class AllowedPoliticallySensitiveFileRPMs(TestRPMs):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -67,7 +65,6 @@ class AllowedPoliticallySensitiveFileKoji(TestKoji):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -82,7 +79,6 @@ class AllowedPoliticallySensitiveFileCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -97,7 +93,6 @@ class AllowedPoliticallySensitiveFileCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -112,7 +107,6 @@ class AllowedPoliticallySensitiveFileCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -128,7 +122,6 @@ class ForbiddenPoliticallySensitiveFileSRPM(TestSRPM):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -143,7 +136,6 @@ class ForbiddenPoliticallySensitiveFileRPMs(TestRPMs):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -158,7 +150,6 @@ class ForbiddenPoliticallySensitiveFileKoji(TestKoji):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -173,7 +164,6 @@ class ForbiddenPoliticallySensitiveFileCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -188,7 +178,6 @@ class ForbiddenPoliticallySensitiveFileCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -203,6 +192,5 @@ class ForbiddenPoliticallySensitiveFileCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "politics"
-        self.label = "politics"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"

--- a/test/test_runpath.py
+++ b/test/test_runpath.py
@@ -34,7 +34,6 @@ class ValidRPATH1RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -47,7 +46,6 @@ class ValidRPATH1Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -60,7 +58,6 @@ class ValidRPATH1CompareRPMs(TestCompareRPMs):
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -73,7 +70,6 @@ class ValidRPATH1CompareKoji(TestCompareKoji):
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -89,7 +85,6 @@ class ValidRPATH2RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN/' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -102,7 +97,6 @@ class ValidRPATH2Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN/' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -115,7 +109,6 @@ class ValidRPATH2CompareRPMs(TestCompareRPMs):
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN/' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -128,7 +121,6 @@ class ValidRPATH2CompareKoji(TestCompareKoji):
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN/' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -146,7 +138,6 @@ class ValidRPATH3RPMs(TestRPMs):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -161,7 +152,6 @@ class ValidRPATH3Koji(TestKoji):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -174,7 +164,6 @@ class ValidRPATH3CompareRPMs(TestCompareRPMs):
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN/../lib/jli:$ORIGIN/../lib' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -187,7 +176,6 @@ class ValidRPATH3CompareKoji(TestCompareKoji):
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN/../lib/jli:$ORIGIN/../lib' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -203,7 +191,6 @@ class ValidRPATH4RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN/../lib64' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -216,7 +203,6 @@ class ValidRPATH4Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN/../lib64' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -231,7 +217,6 @@ class ValidRPATH4CompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -246,7 +231,6 @@ class ValidRPATH4CompareKoji(TestCompareKoji):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -264,7 +248,6 @@ class ValidRPATH5RPMs(TestRPMs):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -279,7 +262,6 @@ class ValidRPATH5Koji(TestKoji):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -294,7 +276,6 @@ class ValidRPATH5CompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -309,7 +290,6 @@ class ValidRPATH5CompareKoji(TestCompareKoji):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -325,7 +305,6 @@ class InvalidRPATH1RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/jq-1.6/.libs' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -338,7 +317,6 @@ class InvalidRPATH1Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/jq-1.6/.libs' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -351,7 +329,6 @@ class InvalidRPATH1CompareRPMs(TestCompareRPMs):
         self.after_rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/jq-1.6/.libs' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -364,7 +341,6 @@ class InvalidRPATH1CompareKoji(TestCompareKoji):
         self.after_rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/jq-1.6/.libs' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -380,7 +356,6 @@ class InvalidRPATH2RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/texlive-base-20200327/source/inst/lib' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -393,7 +368,6 @@ class InvalidRPATH2Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/texlive-base-20200327/source/inst/lib' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -406,7 +380,6 @@ class InvalidRPATH2CompareRPMs(TestCompareRPMs):
         self.after_rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/texlive-base-20200327/source/inst/lib' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -419,7 +392,6 @@ class InvalidRPATH2CompareKoji(TestCompareKoji):
         self.after_rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/texlive-base-20200327/source/inst/lib' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -435,7 +407,6 @@ class ValidRPATH6RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib/systemd' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -448,7 +419,6 @@ class ValidRPATH6Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib/systemd' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -463,7 +433,6 @@ class ValidRPATH6CompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -478,7 +447,6 @@ class ValidRPATH6CompareKoji(TestCompareKoji):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -494,7 +462,6 @@ class ValidRPATH7RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -507,7 +474,6 @@ class ValidRPATH7Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -520,7 +486,6 @@ class ValidRPATH7CompareRPMs(TestCompareRPMs):
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -533,7 +498,6 @@ class ValidRPATH7CompareKoji(TestCompareKoji):
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -549,7 +513,6 @@ class ValidRPATH8RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64/sssd' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -562,7 +525,6 @@ class ValidRPATH8Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64/sssd' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -575,7 +537,6 @@ class ValidRPATH8CompareRPMs(TestCompareRPMs):
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64/sssd' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -588,7 +549,6 @@ class ValidRPATH8CompareKoji(TestCompareKoji):
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64/sssd' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -604,7 +564,6 @@ class ValidRPATH9RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64:/usr/lib64/firebird/intl' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -617,7 +576,6 @@ class ValidRPATH9Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64:/usr/lib64/firebird/intl' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -630,7 +588,6 @@ class ValidRPATH9CompareRPMs(TestCompareRPMs):
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64:/usr/lib64/firebird/intl' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -643,7 +600,6 @@ class ValidRPATH9CompareKoji(TestCompareKoji):
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64:/usr/lib64/firebird/intl' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -659,7 +615,6 @@ class ValidRPATH10RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '/usr/libexec/sudo' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -672,7 +627,6 @@ class ValidRPATH10Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '/usr/libexec/sudo' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -687,7 +641,6 @@ class ValidRPATH10CompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -702,7 +655,6 @@ class ValidRPATH10CompareKoji(TestCompareKoji):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -718,7 +670,6 @@ class InvalidRPATH3RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '/lib64:$ORIGIN/../etc:$ORIGIN/usr/lib64/:/builddir/build/BUILD/lib64' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -731,7 +682,6 @@ class InvalidRPATH3Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '/lib64:$ORIGIN/../etc:$ORIGIN/usr/lib64/:/builddir/build/BUILD/lib64' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -744,7 +694,6 @@ class InvalidRPATH3CompareRPMs(TestCompareRPMs):
         self.after_rpm.section_build += "patchelf --set-rpath '/lib64:$ORIGIN/../etc:$ORIGIN/usr/lib64/:/builddir/build/BUILD/lib64' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -757,7 +706,6 @@ class InvalidRPATH3CompareKoji(TestCompareKoji):
         self.after_rpm.section_build += "patchelf --set-rpath '/lib64:$ORIGIN/../etc:$ORIGIN/usr/lib64/:/builddir/build/BUILD/lib64' a.out\n"  # noqa: E501
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -773,7 +721,6 @@ class ValidRPATH11RPMs(TestRPMs):
         self.rpm.section_build += "patchelf --set-rpath '/usr/src/kernels/' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -786,7 +733,6 @@ class ValidRPATH11Koji(TestKoji):
         self.rpm.section_build += "patchelf --set-rpath '/usr/src/kernels/' a.out\n"
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -801,7 +747,6 @@ class ValidRPATH11CompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -816,6 +761,5 @@ class ValidRPATH11CompareKoji(TestCompareKoji):
         )
 
         self.inspection = "runpath"
-        self.label = "runpath"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_shellsyntax.py
+++ b/test/test_shellsyntax.py
@@ -77,7 +77,6 @@ class ShWellFormedRPM(TestRPMs):
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -94,7 +93,6 @@ class ShMalformedRPM(TestRPMs):
             rpmfluff.SourceFile("invalid_sh.sh", invalid_sh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -111,7 +109,6 @@ class ShWellFormedKoji(TestKoji):
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -128,7 +125,6 @@ class ShMalformedKoji(TestKoji):
             rpmfluff.SourceFile("invalid_sh.sh", invalid_sh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -147,7 +143,6 @@ class ShWellFormedCompareRPMs(TestCompareRPMs):
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -167,7 +162,6 @@ class ShMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_sh.sh", invalid_sh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -186,7 +180,6 @@ class ShWellFormedCompareKoji(TestCompareKoji):
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -206,7 +199,6 @@ class ShMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_sh.sh", invalid_sh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -226,7 +218,6 @@ class ShWellMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_sh.sh", invalid_sh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -246,7 +237,6 @@ class ShWellMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_sh.sh", invalid_sh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -318,7 +308,6 @@ class KshWellFormedRPM(TestRPMs):
             rpmfluff.SourceFile("valid_ksh.sh", valid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -335,7 +324,6 @@ class KshMalformedRPM(TestRPMs):
             rpmfluff.SourceFile("invalid_ksh.sh", invalid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -353,7 +341,6 @@ class KshWellFormedKoji(TestKoji):
             rpmfluff.SourceFile("valid_ksh.sh", valid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -370,7 +357,6 @@ class KshMalformedKoji(TestKoji):
             rpmfluff.SourceFile("invalid_ksh.sh", invalid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -391,7 +377,6 @@ class KshWellFormedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("valid_sh.sh", valid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -411,7 +396,6 @@ class KshMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_ksh.sh", invalid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -432,7 +416,6 @@ class KshWellFormedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("valid_ksh.sh", valid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -452,7 +435,6 @@ class KshMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_ksh.sh", invalid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -473,7 +455,6 @@ class KshWellMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_ksh.sh", invalid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -494,7 +475,6 @@ class KshWellMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_ksh.sh", invalid_ksh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -562,7 +542,6 @@ class ZshWellFormedRPM(TestRPMs):
             rpmfluff.SourceFile("valid_zsh.sh", valid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -579,7 +558,6 @@ class ZshMalformedRPM(TestRPMs):
             rpmfluff.SourceFile("invalid_zsh.sh", invalid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -597,7 +575,6 @@ class ZshWellFormedKoji(TestKoji):
             rpmfluff.SourceFile("valid_zsh.sh", valid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -614,7 +591,6 @@ class ZshMalformedKoji(TestKoji):
             rpmfluff.SourceFile("invalid_zsh.sh", invalid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -635,7 +611,6 @@ class ZshWellFormedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("valid_zsh.sh", valid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -655,7 +630,6 @@ class ZshMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_zsh.sh", invalid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -676,7 +650,6 @@ class ZshWellFormedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("valid_zsh.sh", valid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -696,7 +669,6 @@ class ZshMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_zsh.sh", invalid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -717,7 +689,6 @@ class ZshWellMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_zsh.sh", invalid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -738,7 +709,6 @@ class ZshWellMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_zsh.sh", invalid_zsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -823,7 +793,6 @@ class CshWellFormedRPM(TestRPMs):
             rpmfluff.SourceFile("valid_csh.sh", valid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -840,7 +809,6 @@ class CshMalformedRPM(TestRPMs):
             rpmfluff.SourceFile("invalid_csh.sh", invalid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -858,7 +826,6 @@ class CshWellFormedKoji(TestKoji):
             rpmfluff.SourceFile("valid_csh.sh", valid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -875,7 +842,6 @@ class CshMalformedKoji(TestKoji):
             rpmfluff.SourceFile("invalid_csh.sh", invalid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -896,7 +862,6 @@ class CshWellFormedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("valid_csh.sh", valid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -916,7 +881,6 @@ class CshMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_csh.sh", invalid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -937,7 +901,6 @@ class CshWellFormedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("valid_csh.sh", valid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -957,7 +920,6 @@ class CshMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_csh.sh", invalid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -978,7 +940,6 @@ class CshWellMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_csh.sh", invalid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -999,7 +960,6 @@ class CshWellMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_csh.sh", invalid_csh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1056,7 +1016,6 @@ class TcshWellFormedRPM(TestRPMs):
             rpmfluff.SourceFile("valid_tcsh.sh", valid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1073,7 +1032,6 @@ class TcshMalformedRPM(TestRPMs):
             rpmfluff.SourceFile("invalid_tcsh.sh", invalid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1091,7 +1049,6 @@ class TcshWellFormedKoji(TestKoji):
             rpmfluff.SourceFile("valid_tcsh.sh", valid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1108,7 +1065,6 @@ class TcshMalformedKoji(TestKoji):
             rpmfluff.SourceFile("invalid_tcsh.sh", invalid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1129,7 +1085,6 @@ class TcshWellFormedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("valid_tcsh.sh", valid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1149,7 +1104,6 @@ class TcshMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_tcsh.sh", invalid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1170,7 +1124,6 @@ class TcshWellFormedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("valid_tcsh.sh", valid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1190,7 +1143,6 @@ class TcshMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_tcsh.sh", invalid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1211,7 +1163,6 @@ class TcshWellMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_tcsh.sh", invalid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1232,7 +1183,6 @@ class TcshWellMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_tcsh.sh", invalid_tcsh),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1310,7 +1260,6 @@ class RcWellFormedRPM(TestRPMs):
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1327,7 +1276,6 @@ class RcMalformedRPM(TestRPMs):
             rpmfluff.SourceFile("invalid_rc.sh", invalid_rc),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1344,7 +1292,6 @@ class RcWellFormedKoji(TestKoji):
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1361,7 +1308,6 @@ class RcMalformedKoji(TestKoji):
             rpmfluff.SourceFile("invalid_rc.sh", invalid_rc),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1380,7 +1326,6 @@ class RcWellFormedCompareRPMs(TestCompareRPMs):
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1400,7 +1345,6 @@ class RcMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_rc.sh", invalid_rc),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1419,7 +1363,6 @@ class RcWellFormedCompareKoji(TestCompareKoji):
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1439,7 +1382,6 @@ class RcMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_rc.sh", invalid_rc),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1459,7 +1401,6 @@ class RcWellMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_rc.sh", invalid_rc),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1479,7 +1420,6 @@ class RcWellMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_rc.sh", invalid_rc),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1561,7 +1501,6 @@ class BashWellFormedRPM(TestRPMs):
             rpmfluff.SourceFile("valid_bash.sh", valid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1578,7 +1517,6 @@ class BashMalformedRPM(TestRPMs):
             rpmfluff.SourceFile("invalid_bash.sh", invalid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1596,7 +1534,6 @@ class BashExtglobWellFormedRPM(TestRPMs):
             rpmfluff.SourceFile("valid_bash_extglob.sh", valid_bash_extglob),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "INFO"
 
 
@@ -1613,7 +1550,6 @@ class BashWellFormedKoji(TestKoji):
             rpmfluff.SourceFile("valid_bash.sh", valid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1630,7 +1566,6 @@ class BashMalformedKoji(TestKoji):
             rpmfluff.SourceFile("invalid_bash.sh", invalid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1648,7 +1583,6 @@ class BashExtglobWellFormedKoji(TestKoji):
             rpmfluff.SourceFile("valid_bash_extglob.sh", valid_bash_extglob),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "INFO"
 
 
@@ -1668,7 +1602,6 @@ class BashWellFormedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("valid_sh.sh", valid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1688,7 +1621,6 @@ class BashMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_bash.sh", invalid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1709,7 +1641,6 @@ class BashExtglobWellFormedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("valid_bash_extglob.sh", valid_bash_extglob),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "INFO"
 
 
@@ -1729,7 +1660,6 @@ class BashWellFormedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("valid_bash.sh", valid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "OK"
 
 
@@ -1749,7 +1679,6 @@ class BashMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_bash.sh", invalid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1770,7 +1699,6 @@ class BashExtglobWellFormedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("valid_bash_extglob.sh", valid_bash_extglob),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "INFO"
 
 
@@ -1790,7 +1718,6 @@ class BashWellMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid_bash.sh", invalid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -1811,6 +1738,5 @@ class BashWellMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid_bash.sh", invalid_bash),
         )
         self.inspection = "shellsyntax"
-        self.label = "shell-syntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"

--- a/test/test_specname.py
+++ b/test/test_specname.py
@@ -26,7 +26,6 @@ class SpecNameSRPM(TestSRPM):
     def setUp(self):
         TestSRPM.setUp(self)
         self.inspection = "specname"
-        self.label = "spec-file-name"
         self.result = "OK"
 
 
@@ -35,7 +34,6 @@ class SpecNameKojiBuild(TestKoji):
     def setUp(self):
         TestKoji.setUp(self)
         self.inspection = "specname"
-        self.label = "spec-file-name"
         self.result = "OK"
 
 
@@ -44,7 +42,6 @@ class SpecNameRPMs(TestRPMs):
     def setUp(self):
         TestRPMs.setUp(self)
         self.inspection = "specname"
-        self.label = "spec-file-name"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -56,7 +53,6 @@ class BadSpecNameSRPM(TestSRPM):
         TestSRPM.setUp(self)
         self.rpm.addSpecBasename("badspecname")
         self.inspection = "specname"
-        self.label = "spec-file-name"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
 
@@ -68,6 +64,5 @@ class BadSpecNameKojiBuild(TestKoji):
         TestKoji.setUp(self)
         self.rpm.addSpecBasename("badspecname")
         self.inspection = "specname"
-        self.label = "spec-file-name"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"

--- a/test/test_symlinks.py
+++ b/test/test_symlinks.py
@@ -60,7 +60,6 @@ class AbsoluteSymlinkExistsRPMs(TestRPMs):
         self.rpm.add_installed_symlink("usr/sbin/testscript", "/usr/bin/testscript")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -78,7 +77,6 @@ class AbsoluteSymlinkExistsKoji(TestKoji):
         self.rpm.add_installed_symlink("usr/sbin/rpminspect", "/usr/bin/rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -98,7 +96,6 @@ class AbsoluteSymlinkExistsCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -118,7 +115,6 @@ class AbsoluteSymlinkExistsCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -137,7 +133,6 @@ class RelativeSymlinkExistsParentDirRPMs(TestRPMs):
         self.rpm.add_installed_symlink("usr/sbin/rpminspect", "../bin/rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -155,7 +150,6 @@ class RelativeSymlinkExistsParentDirKoji(TestKoji):
         self.rpm.add_installed_symlink("usr/sbin/rpminspect", "../bin/rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -173,7 +167,6 @@ class RelativeSymlinkExistsParentDirCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_installed_symlink("usr/sbin/rpminspect", "../bin/rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -191,7 +184,6 @@ class RelativeSymlinkExistsParentDirCompareKoji(TestCompareKoji):
         self.after_rpm.add_installed_symlink("usr/sbin/rpminspect", "../bin/rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -210,7 +202,6 @@ class RelativeSymlinkExistsCurrentDirRPMs(TestRPMs):
         self.rpm.add_installed_symlink("usr/bin/anotherrpminspect", "rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -228,7 +219,6 @@ class RelativeSymlinkExistsCurrentDirKoji(TestKoji):
         self.rpm.add_installed_symlink("usr/bin/anotherrpminspect", "rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -246,7 +236,6 @@ class RelativeSymlinkExistsCurrentDirCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_installed_symlink("usr/bin/anotherrpminspect", "rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -264,7 +253,6 @@ class RelativeSymlinkExistsCurrentDirCompareKoji(TestCompareKoji):
         self.after_rpm.add_installed_symlink("usr/bin/anotherrpminspect", "rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -286,7 +274,6 @@ class SymlinkExistsMultiplePackagesRPMS(TestRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -307,7 +294,6 @@ class SymlinkExistsMultiplePackagesKoji(TestKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -328,7 +314,6 @@ class SymlinkExistsMultiplePackagesCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -349,7 +334,6 @@ class SymlinkExistsMultiplePackagesCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -370,7 +354,6 @@ class AbsoluteSymlinkDanglingRPMs(TestRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -390,7 +373,6 @@ class AbsoluteSymlinkDanglingKoji(TestKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -410,7 +392,6 @@ class AbsoluteSymlinkDanglingCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -430,7 +411,6 @@ class AbsoluteSymlinkDanglingCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -451,7 +431,6 @@ class RelativeSymlinkDanglingParentDirRPMs(TestRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -471,7 +450,6 @@ class RelativeSymlinkDanglingParentDirKoji(TestKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -491,7 +469,6 @@ class RelativeSymlinkDanglingParentDirAfterRPMs(TestCompareRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -511,7 +488,6 @@ class RelativeSymlinkDanglingParentDirAfterKoji(TestCompareKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -532,7 +508,6 @@ class RelativeSymlinkDanglingCurrentDirRPMs(TestRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -552,7 +527,6 @@ class RelativeSymlinkDanglingCurrentDirKoji(TestKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -572,7 +546,6 @@ class RelativeSymlinkDanglingCurrentDirCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -592,7 +565,6 @@ class RelativeSymlinkDanglingCurrentDirCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -625,7 +597,6 @@ class TooManySymlinkLevelsRPMs(TestRPMs):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -654,7 +625,6 @@ class TooManySymlinkLevelsKoji(TestKoji):
         )
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -687,7 +657,6 @@ class TooManySymlinkLevelsCompareRPMs(TestCompareRPMs):
         self.after_rpm.header += "\n%global __arch_install_post %{nil}\n"
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -720,7 +689,6 @@ class TooManySymlinkLevelsCompareKoji(TestCompareKoji):
         self.after_rpm.header += "\n%global __arch_install_post %{nil}\n"
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -739,7 +707,6 @@ class DirectoryBecomesSymlinkCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_installed_directory("usr/share/actualdirectory")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -757,7 +724,6 @@ class DirectoryBecomesSymlinkCompareKoji(TestCompareKoji):
         self.after_rpm.add_installed_directory("usr/share/actualdirectory")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -786,7 +752,6 @@ class NonDirectoryBecomesSymlinkCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_installed_symlink("usr/bin/anotherrpminspect", "rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -814,6 +779,5 @@ class NonDirectoryBecomesSymlinkCompareKoji(TestCompareKoji):
         self.after_rpm.add_installed_symlink("usr/bin/anotherrpminspect", "rpminspect")
 
         self.inspection = "symlinks"
-        self.label = "symlinks"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -31,7 +31,6 @@ class SameTypeCompareSRPM(TestCompareSRPM):
         self.after_rpm.add_simple_compilation(installPath="/usr/bin/rpminspect")
 
         self.inspection = "types"
-        self.label = "types"
         self.result = "OK"
 
 
@@ -42,7 +41,6 @@ class SameTypeCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_simple_compilation(installPath="/usr/bin/rpminspect")
 
         self.inspection = "types"
-        self.label = "types"
         self.result = "OK"
 
 
@@ -53,7 +51,6 @@ class SameTypeCompareKoji(TestCompareKoji):
         self.after_rpm.add_simple_compilation(installPath="/usr/bin/rpminspect")
 
         self.inspection = "types"
-        self.label = "types"
         self.result = "OK"
 
 
@@ -70,7 +67,6 @@ class ChangedTypeCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "types"
-        self.label = "types"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -88,7 +84,6 @@ class ChangedTypeCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "types"
-        self.label = "types"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -106,6 +101,5 @@ class ChangedTypeCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "types"
-        self.label = "types"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -49,7 +49,7 @@ class SkipUpstreamSRPM(TestSRPM):
         self.inspection = "upstream"
 
         # since it should skip, only look for our diagnostic output
-        self.label = "rpminspect"
+        self.result_inspection = "rpminspect"
         self.result = "INFO"
 
     def runTest(self):
@@ -71,7 +71,7 @@ class SkipUpstreamRPMs(TestRPMs):
         self.inspection = "upstream"
 
         # since it should skip, only look for our diagnostic output
-        self.label = "rpminspect"
+        self.result_inspection = "rpminspect"
         self.result = "INFO"
 
     def runTest(self):
@@ -93,7 +93,7 @@ class SkipUpstreamKoji(TestKoji):
         self.inspection = "upstream"
 
         # since it should skip, only look for our diagnostic output
-        self.label = "rpminspect"
+        self.result_inspection = "rpminspect"
         self.result = "INFO"
 
     def runTest(self):
@@ -117,7 +117,6 @@ class DiffVerUpstreamCompareSRPM(TestCompareSRPM):
     def setUp(self):
         super().setUp()
         self.inspection = "upstream"
-        self.label = "upstream"
         self.result = "OK"
 
 
@@ -143,7 +142,6 @@ class SameVerChangeUpstreamCompareSRPM(TestCompareSRPM):
 
         # what we are checking
         self.inspection = "upstream"
-        self.label = "upstream"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -168,7 +166,6 @@ class SameVerRemoveUpstreamCompareSRPM(TestCompareSRPM):
 
         # what we are checking
         self.inspection = "upstream"
-        self.label = "upstream"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -188,7 +185,6 @@ class DiffVerUpstreamCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
         self.inspection = "upstream"
-        self.label = "upstream"
         self.result = "OK"
 
 
@@ -214,7 +210,6 @@ class SameVerChangeUpstreamCompareKoji(TestCompareKoji):
 
         # what we are checking
         self.inspection = "upstream"
-        self.label = "upstream"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -239,6 +234,5 @@ class SameVerRemoveUpstreamCompareKoji(TestCompareKoji):
 
         # what we are checking
         self.inspection = "upstream"
-        self.label = "upstream"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"

--- a/test/test_virus.py
+++ b/test/test_virus.py
@@ -33,7 +33,6 @@ class HasNoVirusSRPM(TestSRPM):
         )
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -48,7 +47,6 @@ class HasNoVirusRPMs(TestRPMs):
         )
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -63,7 +61,6 @@ class HasNoVirusKoji(TestKoji):
         )
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -81,7 +78,6 @@ class HasNoVirusCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -99,7 +95,6 @@ class HasNoVirusCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -117,7 +112,6 @@ class HasNoVirusCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
@@ -131,7 +125,6 @@ class HasVirusSRPM(TestSRPM):
         self.rpm.add_fake_virus("usr/lib/whte_rbt.obj", "whte_rbt.pas", mode="0755")
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -144,7 +137,6 @@ class HasVirusRPMs(TestRPMs):
         self.rpm.add_fake_virus("usr/lib/whte_rbt.obj", "whte_rbt.pas", mode="0755")
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -157,7 +149,6 @@ class HasVirusKoji(TestKoji):
         self.rpm.add_fake_virus("usr/lib/whte_rbt.obj", "whte_rbt.pas", mode="0755")
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -175,7 +166,6 @@ class HasVirusCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -193,7 +183,6 @@ class HasVirusCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
 
@@ -211,6 +200,5 @@ class HasVirusCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "virus"
-        self.label = "virus"
         self.result = "BAD"
         self.waiver_auth = "Anyone"

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -44,7 +44,6 @@ class XMLWellFormedRPM(TestRPMs):
             "/usr/share/data/valid.xml", rpmfluff.SourceFile("valid.xml", valid_xml)
         )
         self.inspection = "xml"
-        self.label = "xml-files"
         self.result = "OK"
 
 
@@ -56,7 +55,6 @@ class XMLWellFormedKoji(TestKoji):
             "/usr/share/data/valid.xml", rpmfluff.SourceFile("valid.xml", valid_xml)
         )
         self.inspection = "xml"
-        self.label = "xml-files"
         self.result = "OK"
 
 
@@ -71,7 +69,6 @@ class XMLWellFormedCompareRPMs(TestCompareRPMs):
             "/usr/share/data/valid.xml", rpmfluff.SourceFile("valid.xml", valid_xml)
         )
         self.inspection = "xml"
-        self.label = "xml-files"
         self.result = "OK"
 
 
@@ -86,7 +83,6 @@ class XMLWellFormedCompareKoji(TestCompareKoji):
             "/usr/share/data/valid.xml", rpmfluff.SourceFile("valid.xml", valid_xml)
         )
         self.inspection = "xml"
-        self.label = "xml-files"
         self.result = "OK"
 
 
@@ -99,7 +95,6 @@ class XMLMalformedRPM(TestRPMs):
             rpmfluff.SourceFile("invalid.xml", invalid_xml),
         )
         self.inspection = "xml"
-        self.label = "xml-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -113,7 +108,6 @@ class XMLMalformedKoji(TestKoji):
             rpmfluff.SourceFile("invalid.xml", invalid_xml),
         )
         self.inspection = "xml"
-        self.label = "xml-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -131,7 +125,6 @@ class XMLMalformedCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("invalid.xml", invalid_xml),
         )
         self.inspection = "xml"
-        self.label = "xml-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
@@ -149,6 +142,5 @@ class XMLMalformedCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("invalid.xml", invalid_xml),
         )
         self.inspection = "xml"
-        self.label = "xml-files"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"


### PR DESCRIPTION
The original idea behind the NAME_* and HEADER_* defines was to
provide more descriptive names for the output vs. what you typed on
the command line.  This has just led to confusion because people are
looking for the short name in the output.  This patch drops the
distinction and everything just uses the NAME_* names, even on the
output report.

Signed-off-by: David Cantrell <dcantrell@redhat.com>