### PR TITLE
[fix] desktop: demote as INFO a missing Exec w/ TryExec (#395)

### DIFF
--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -188,8 +188,6 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
 
     /* Set up result parameters */
     init_result_params(&params);
-    params.severity = RESULT_VERIFY;
-    params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_DESKTOP;
     params.remedy = REMEDY_DESKTOP;
     params.arch = arch;
@@ -264,12 +262,16 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
 
             if (!(sb.st_mode & S_IXOTH)) {
                 xasprintf(&params.msg, _("Desktop file %s on %s references executable %s but %s is not executable by all"), file->localpath, arch, tmp, tmp);
+                params.severity = RESULT_VERIFY;
+                params.waiverauth = WAIVABLE_BY_ANYONE;
                 add_result(ri, &params);
                 free(params.msg);
                 result = false;
             }
         } else {
             xasprintf(&params.msg, _("Desktop file %s on %s references executable %s but no subpackages contain an executable of that name"), file->localpath, arch, tmp);
+            params.severity = RESULT_VERIFY;
+            params.waiverauth = WAIVABLE_BY_ANYONE;
             add_result(ri, &params);
             free(params.msg);
             result = false;
@@ -299,6 +301,8 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
 
             if (!(sb.st_mode & S_IROTH)) {
                 xasprintf(&params.msg, _("Desktop file %s on %s references icon %s but %s is not readable by all"), file->localpath, arch, tmp, tmp);
+                params.severity = RESULT_VERIFY;
+                params.waiverauth = WAIVABLE_BY_ANYONE;
                 add_result(ri, &params);
                 free(params.msg);
                 result = false;
@@ -307,6 +311,8 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
 
         if (!found) {
             xasprintf(&params.msg, _("Desktop file %s on %s references icon %s but no subpackages contain %s"), file->localpath, arch, tmp, tmp);
+            params.severity = RESULT_VERIFY;
+            params.waiverauth = WAIVABLE_BY_ANYONE;
             add_result(ri, &params);
             free(params.msg);
             result = false;

--- a/test/test_desktop.py
+++ b/test/test_desktop.py
@@ -75,6 +75,26 @@ MimeType=application/x-extension-fcstd;
 """
 
 
+good_tryexec_args_desktop_file = """[Desktop Entry]
+Name=Hello World
+Name[de]=Hello World
+Name[pl]=Hello World
+Comment=Lorem ipsum dolor sit amet
+Comment[de]=Lorem ipsum dolor sit amet
+GenericName=Greeting Application
+GenericName[de]=Greeting Application
+GenericName[pl]=Greeting Application
+Exec=hello-world %F
+TryExec=something-else
+Terminal=false
+Type=Application
+Icon=hello-world
+Categories=Graphics;
+StartupNotify=true
+MimeType=application/x-extension-fcstd;
+"""
+
+
 # Valid desktop file passes in RPM (OK)
 class ValidDesktopFileRPM(TestRPMs):
     def setUp(self):
@@ -857,3 +877,111 @@ class DesktopFileWithoutWorldExecutableExecCompareKoji(TestCompareKoji):
         self.inspection = "desktop"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
+
+
+# Desktop file with invalid Exec file in RPM (VERIFY)
+class DesktopFileMissingExecWithTryExecRPM(TestRPMs):
+    def setUp(self):
+        TestRPMs.setUp(self)
+
+        # Adds /usr/share/icons/hello-world.png
+        self.rpm.add_installed_file(
+            "/usr/share/icons/hello-world.png",
+            rpmfluff.GeneratedSourceFile("hello-world.png", rpmfluff.make_png()),
+        )
+
+        # Adds /usr/share/applications/hello-world.desktop
+        self.rpm.add_installed_file(
+            "/usr/share/applications/hello-world.desktop",
+            rpmfluff.SourceFile("hello-world.desktop", good_tryexec_args_desktop_file),
+        )
+
+        self.inspection = "desktop"
+        self.label = "desktop-entry-files"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# Desktop file with invalid Exec file in Koji build (VERIFY)
+class DesktopFileMissingExecWithTryExecRPMs(TestKoji):
+    def setUp(self):
+        TestKoji.setUp(self)
+
+        # Adds /usr/share/icons/hello-world.png
+        self.rpm.add_installed_file(
+            "/usr/share/icons/hello-world.png",
+            rpmfluff.GeneratedSourceFile("hello-world.png", rpmfluff.make_png()),
+        )
+
+        # Adds /usr/share/applications/hello-world.desktop
+        self.rpm.add_installed_file(
+            "/usr/share/applications/hello-world.desktop",
+            rpmfluff.SourceFile("hello-world.desktop", good_tryexec_args_desktop_file),
+        )
+
+        self.inspection = "desktop"
+        self.label = "desktop-entry-files"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# Desktop file with invalid Exec file in RPM compare (VERIFY)
+class DesktopFileMissingExecWithTryExecCompareRPM(TestCompareRPMs):
+    def setUp(self):
+        TestCompareRPMs.setUp(self)
+
+        # Adds /usr/share/icons/hello-world.png
+        self.before_rpm.add_installed_file(
+            "/usr/share/icons/hello-world.png",
+            rpmfluff.GeneratedSourceFile("hello-world.png", rpmfluff.make_png()),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/share/icons/hello-world.png",
+            rpmfluff.GeneratedSourceFile("hello-world.png", rpmfluff.make_png()),
+        )
+
+        # Adds /usr/share/applications/hello-world.desktop
+        self.before_rpm.add_installed_file(
+            "/usr/share/applications/hello-world.desktop",
+            rpmfluff.SourceFile("hello-world.desktop", good_tryexec_args_desktop_file),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/share/applications/hello-world.desktop",
+            rpmfluff.SourceFile("hello-world.desktop", good_tryexec_args_desktop_file),
+        )
+
+        self.inspection = "desktop"
+        self.label = "desktop-entry-files"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# Desktop file with invalid Exec file in Koji compare (VERIFY)
+class DesktopFileMissingExecWithTryExecCompareKoji(TestCompareKoji):
+    def setUp(self):
+        TestCompareKoji.setUp(self)
+
+        # Adds /usr/share/icons/hello-world.png
+        self.before_rpm.add_installed_file(
+            "/usr/share/icons/hello-world.png",
+            rpmfluff.GeneratedSourceFile("hello-world.png", rpmfluff.make_png()),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/share/icons/hello-world.png",
+            rpmfluff.GeneratedSourceFile("hello-world.png", rpmfluff.make_png()),
+        )
+
+        # Adds /usr/share/applications/hello-world.desktop
+        self.before_rpm.add_installed_file(
+            "/usr/share/applications/hello-world.desktop",
+            rpmfluff.SourceFile("hello-world.desktop", good_tryexec_args_desktop_file),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/share/applications/hello-world.desktop",
+            rpmfluff.SourceFile("hello-world.desktop", good_tryexec_args_desktop_file),
+        )
+
+        self.inspection = "desktop"
+        self.label = "desktop-entry-files"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
According to the desktop-entry-spec [1], menu implementations may ignore a desktop file in case it has a `TryExec` key, and what is mentioned there either does not exist, or it is not executable.

Hence, in case `Exec` does not exist in the inspected RPMs, check whether `TryExec` was specified: if so, then only report the missing `Exec` as INFO, rather than VERIFY.

Includes some mostly no-op code refactoring that makes the fixes much easier to develop & review.

[1] https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

Fixes: #395