### PR TITLE
[lib] Skip source packages in 'emptyrpm'

### DIFF
--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -53,7 +53,8 @@ static bool is_expected_empty(const struct rpminspect *ri, const char *p)
  *
  * @param ri Pointer to the struct rpminspect for the program.
  */
-bool inspect_emptyrpm(struct rpminspect *ri) {
+bool inspect_emptyrpm(struct rpminspect *ri)
+{
     bool good = true;
     rpmpeer_entry_t *peer = NULL;
     const char *name = NULL;
@@ -74,6 +75,11 @@ bool inspect_emptyrpm(struct rpminspect *ri) {
 
     /* Check the binary peers */
     TAILQ_FOREACH(peer, ri->peers, items) {
+        /* only check built RPMs, not the source RPM */
+        if (headerIsSource(peer->after_hdr)) {
+            continue;
+        }
+
         if (is_payload_empty(peer->after_files) && peer->before_rpm == NULL) {
             name = headerGetString(peer->after_hdr, RPMTAG_NAME);
             assert(name != NULL);


### PR DESCRIPTION
Make sure we skip source packages in the emptyrpm inspection.  The
purpose of this inspection is to catch built RPMs with empty payloads.
At the very least a source RPM will always have a payload that at
least consists of the spec file.

Signed-off-by: David Cantrell <dcantrell@redhat.com>