### PR TITLE
[ci] Support older libraries on CentOS 7

### DIFF
--- a/lib/diags.c
+++ b/lib/diags.c
@@ -74,11 +74,14 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     xasprintf(&entry->data, "zlib version %s", zlibVersion());
     TAILQ_INSERT_TAIL(list, entry, items);
 
+#ifdef _HAVE_MAGIC_VERSION
     /* libmagic */
+    /* older versions of libmagic lack this function */
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
     xasprintf(&entry->data, "libmagic version %d", magic_version());
     TAILQ_INSERT_TAIL(list, entry, items);
+#endif
 
     /* libclamav */
     entry = calloc(1, sizeof(*entry));
@@ -127,6 +130,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(tmp);
 
     /* libarchive */
+#ifdef _HAVE_ARCHIVE_VERSION_DETAILS
     tmp = strreplace(archive_version_details(), "libarchive ", NULL);
     details = strsplit(tmp, " ");
     free(tmp);
@@ -147,6 +151,12 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     free(ver);
     free(tmp);
+#elif _HAVE_ARCHIVE_VERSION_STRING
+    entry = calloc(1, sizeof(*entry));
+    assert(entry != NULL);
+    xasprintf(&entry->data, "%s", archive_version_string());
+    TAILQ_INSERT_TAIL(list, entry, items);
+#endif
 
     /* libyaml */
     entry = calloc(1, sizeof(*entry));
@@ -154,6 +164,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     xasprintf(&entry->data, "libyaml version %s", yaml_get_version_string());
     TAILQ_INSERT_TAIL(list, entry, items);
 
+#ifndef NO_OPENSSL_VERSION_FUNCTION
     /* openssl */
     tmp = strreplace(OpenSSL_version(OPENSSL_VERSION), "OpenSSL ", "OpenSSL version ");
     entry = calloc(1, sizeof(*entry));
@@ -161,6 +172,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     xasprintf(&entry->data, "%s", tmp);
     TAILQ_INSERT_TAIL(list, entry, items);
     free(tmp);
+#endif
 
     /* xmlrpc-c */
     xmlrpc_client_version(&major, &minor, &update);

--- a/meson.build
+++ b/meson.build
@@ -25,13 +25,29 @@ endif
 jsonc = dependency('json-c', required : true)
 libxml = dependency('libxml-2.0', required : true)
 rpm = dependency('rpm', required : true)
-libarchive = dependency('libarchive', required : true)
 libkmod = dependency('libkmod', required : true)
 libcurl = dependency('libcurl', required : true)
 zlib = dependency('zlib', required : true)
 yaml = dependency('yaml-0.1', required : true)
-openssl = dependency('openssl', required : true)
 clamav = dependency('libclamav', required : true)
+
+# libarchive (need to check for specific functions)
+libarchive = dependency('libarchive', required : true)
+
+if cc.has_function('archive_version_details', dependencies : [ libarchive ])
+    add_project_arguments('-D_HAVE_ARCHIVE_VERSION_DETAILS', language : 'c')
+elif cc.has_function('archive_version_string', dependencies : [ libarchive ])
+    add_project_arguments('-D_HAVE_ARCHIVE_VERSION_STRING', language : 'c')
+endif
+
+# openssl (need to check for the version info function)
+openssl = dependency('openssl', required : true)
+
+if not cc.has_function('OpenSSL_version', dependencies : [ openssl ]) and cc.has_function('SSLeay_version', dependencies : [ openssl ])
+    add_project_arguments('-DOpenSSL_version=SSLeay_version', language : 'c')
+elif not cc.has_function('OpenSSL_version', dependencies : [ openssl ]) and not cc.has_function('SSLeay_version', dependencies : [ openssl ])
+    add_project_arguments('-D_NO_OPENSSL_VERSION_FUNCTION', language : 'c')
+endif
 
 # Test suite dependencies
 run_tests = get_option('tests')
@@ -119,6 +135,10 @@ endif
 # libmagic
 if not cc.has_function('magic_open', args : ['-lmagic'])
     error('*** unable to find magic_open() in libmagic')
+endif
+
+if cc.has_function('magic_version', args : ['-lmagic'])
+    add_project_arguments('-D_HAVE_MAGIC_VERSION', language : 'c')
 endif
 
 magic = declare_dependency(link_args : ['-lmagic'])


### PR DESCRIPTION
Extend the API support in meson.build so we can build with older
versions of libmagic, libarchive, and libcrypto.

Signed-off-by: David Cantrell <dcantrell@redhat.com>