### PR TITLE
[ci] Define OPENSSL_VERSION to 0 if it's undefined

### DIFF
--- a/lib/diags.c
+++ b/lib/diags.c
@@ -31,6 +31,11 @@
 
 #include "rpminspect.h"
 
+/* For older versions of OpenSSL */
+#ifndef OPENSSL_VERSION
+#define OPENSSL_VERSION 0
+#endif
+
 /*
  * Gather versions of dependent libraries and programs and add the
  * information as strings to a list and return the list.  Caller must


### PR DESCRIPTION
Older versions of OpenSSL lack this definition in the headers.

Signed-off-by: David Cantrell <dcantrell@redhat.com>