### PR TITLE
[fix] Check return code of yaml_scan_parser()

### DIFF
--- a/lib/builds.c
+++ b/lib/builds.c
@@ -388,7 +388,10 @@ static int download_build(const struct rpminspect *ri, const struct koji_build *
                  * a hash table at the end.
                  */
                 do {
-                    yaml_parser_scan(&parser, &token);
+                    if (yaml_parser_scan(&parser, &token) == 0) {
+                        warnx(_("ignoring malformed module metadata file: %s"), dst);
+                        return -1;
+                    }
 
                     switch (token.type) {
                         case YAML_SCALAR_TOKEN:

--- a/lib/init.c
+++ b/lib/init.c
@@ -500,7 +500,10 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
     yaml_parser_set_input_file(&parser, fp);
 
     do {
-        yaml_parser_scan(&parser, &token);
+        if (yaml_parser_scan(&parser, &token) == 0) {
+            warnx(_("ignoring malformed %s configuration file: %s"), COMMAND_NAME, filename);
+            return -1;
+        }
 
         switch (token.type) {
             case YAML_STREAM_START_TOKEN:


### PR DESCRIPTION
This function returns 0 if there's an error.  We need to do that to
find malformed YAML input files and then bail.  Otherwise the YAML
parsing loops in librpminspect will run indefinitely.

Signed-off-by: David Cantrell <dcantrell@redhat.com>