### PR TITLE
[lib] Report new patches at the INFO level only

### DIFF
--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -258,6 +258,8 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
     } else if (comparison && file->peer_file == NULL) {
         xasprintf(&params.msg, _("New patch file `%s` appeared"), params.file);
+        params.severity = RESULT_INFO;
+        params.waiverauth = NOT_WAIVABLE;
         params.verb = VERB_ADDED;
         params.noun = _("patch file ${FILE}");
         add_result(ri, &params);


### PR DESCRIPTION
In the patches inspections, we should always report new patches at the
INFO level.  The threshold counting for number of files or number of
lines triggering a VERIFY reporting level is still there.  New patches
can appear in maintenance or rebase builds, but should be taken as
addressing one or more bug fixes.  Reporting levels should not change
until we can examine patch size changes.

Signed-off-by: David Cantrell <dcantrell@redhat.com>