### PR TITLE
[doc] Drop mention of LibreSSL from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ meson and ninja, plus the following libraries:
 | mandoc                | https://mandoc.bsd.lv/                                    | ISC                          |
 | libyaml               | https://github.com/yaml/libyaml                           | MIT                          |
 | file (for libmagic)   | http://www.darwinsys.com/file/                            | BSD                          |
-| OpenSSL or LibreSSL   | https://www.openssl.org/ or http://www.libressl.org/      | OpenSSL or (OpenSSL and ISC) |
+| OpenSSL               | https://www.openssl.org/                                  | OpenSSL                      |
 | libcap                | https://sites.google.com/site/fullycapable/               | BSD-3-Clause                 |
 
 Additionally, the unit test suite requires the following packages:


### PR DESCRIPTION
I no longer make any effort to ensure rpminspect works with LibreSSL.
This library began as a drop-in replacement (mostly) for OpenSSL, but
over time it has diverged in to its own API.  If anyone wants to
submit patches that ensure rpminspect works with LibreSSL, I am happy
to review them.

Signed-off-by: David Cantrell <dcantrell@redhat.com>