### PR TITLE
[fix] Skip .spec files in the types inspection

### DIFF
--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -51,6 +51,11 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         return true;
     }
 
+    /* Skip spec files in source RPMs */
+    if (headerIsSource(file->rpm_header) && strsuffix(file->localpath, SPEC_FILENAME_EXTENSION)) {
+        return true;
+    }
+
     /* We need the architecture for reporting */
     arch = get_rpm_header_arch(file->rpm_header);
 


### PR DESCRIPTION
The libmagic MIME type for spec files tends to vary and there is no
MIME type for an RPM spec file.  But that really doesn't matter
because the types inspection can just ignore spec files.  If we have a
built RPM or a Koji build, then there was a valid spec file provided
in the first place.

The purpose of the types inspection is to catch type changes for
runtime data used by programs or examples provided.  We let it run
across all files for completeness but in this case we can ignore spec
files in source RPMs.

Signed-off-by: David Cantrell <dcantrell@redhat.com>