### PR TITLE
[fix] Description and Summary changes are reported as INFO

### DIFF
--- a/lib/inspect_metadata.c
+++ b/lib/inspect_metadata.c
@@ -125,12 +125,6 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         after_name = headerGetString(after_hdr, RPMTAG_NAME);
         params.msg = NULL;
 
-        if (rebase) {
-            params.severity = RESULT_INFO;
-        } else {
-            params.severity = RESULT_VERIFY;
-        }
-
         if (before_vendor == NULL && after_vendor) {
             xasprintf(&params.msg, _("Gained Package Vendor \"%s\" in %s"), after_vendor, after_name);
         } else if (before_vendor && after_vendor == NULL) {
@@ -140,6 +134,12 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         }
 
         if (params.msg) {
+            if (rebase) {
+                params.severity = RESULT_INFO;
+            } else {
+                params.severity = RESULT_VERIFY;
+            }
+
             params.waiverauth = WAIVABLE_BY_ANYONE;
             params.remedy = NULL;
             add_result(ri, &params);
@@ -149,7 +149,8 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
 
         if (strcmp(before_summary, after_summary)) {
             xasprintf(&params.msg, _("Package Summary change from \"%s\" to \"%s\" in %s"), before_summary, after_summary, after_name);
-            params.waiverauth = WAIVABLE_BY_ANYONE;
+            params.severity = RESULT_INFO;
+            params.waiverauth = NOT_WAIVABLE;
             params.remedy = NULL;
             add_result(ri, &params);
             free(params.msg);
@@ -159,7 +160,8 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         if (strcmp(before_description, after_description)) {
             xasprintf(&params.msg, _("Package Description changed in %s"), after_name);
             xasprintf(&params.details, _("from:\n\n%s\n\nto:\n\n%s"), before_description, after_description);
-            params.waiverauth = WAIVABLE_BY_ANYONE;
+            params.severity = RESULT_INFO;
+            params.waiverauth = NOT_WAIVABLE;
             params.remedy = NULL;
             add_result(ri, &params);
             free(params.msg);

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -260,37 +260,37 @@ class DirtySummaryKojiBuild(TestKoji):
         self.result = "BAD"
 
 
-# Verify changing Summary reports verify on SRPM (VERIFY)
+# Verify changing Summary reports verify on SRPM (INFO)
 class ChangingSummaryCompareSRPM(TestCompareSRPM):
     def setUp(self):
         TestCompareSRPM.setUp(self)
         self.before_rpm.add_summary("Lorem ipsum dolor sit amet")
         self.after_rpm.add_summary("Lorem ipsum")
         self.inspection = "metadata"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
-# Verify changing Summary reports verify on built RPMs (VERIFY)
+# Verify changing Summary reports verify on built RPMs (INFO)
 class ChangingSummaryCompareRPMs(TestCompareRPMs):
     def setUp(self):
         TestCompareRPMs.setUp(self)
         self.before_rpm.add_summary("Lorem ipsum dolor sit amet")
         self.after_rpm.add_summary("Lorem ipsum")
         self.inspection = "metadata"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
-# Verify changing Summary reports verify on Koji build (VERIFY)
+# Verify changing Summary reports verify on Koji build (INFO)
 class ChangingSummaryCompareKojiBuild(TestCompareKoji):
     def setUp(self):
         TestCompareKoji.setUp(self)
         self.before_rpm.add_summary("Lorem ipsum dolor sit amet")
         self.after_rpm.add_summary("Lorem ipsum")
         self.inspection = "metadata"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify Description without bad words passes on an SRPM (OK)
@@ -389,7 +389,7 @@ class DirtyDescriptionKojiBuild(TestKoji):
         self.result = "BAD"
 
 
-# Verify changing Description reports verify on SRPM (VERIFY)
+# Verify changing Description reports verify on SRPM (INFO)
 class ChangingDescriptionCompareSRPM(TestCompareSRPM):
     def setUp(self):
         TestCompareSRPM.setUp(self)
@@ -403,11 +403,11 @@ class ChangingDescriptionCompareSRPM(TestCompareSRPM):
         )
         self.after_rpm.add_description("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
-# Verify changing Description reports verify on built RPMs (VERIFY)
+# Verify changing Description reports verify on built RPMs (INFO)
 class ChangingDescriptionCompareRPMs(TestCompareRPMs):
     def setUp(self):
         TestCompareRPMs.setUp(self)
@@ -421,11 +421,11 @@ class ChangingDescriptionCompareRPMs(TestCompareRPMs):
         )
         self.after_rpm.add_description("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
-# Verify changing Description reports verify on Koji build (VERIFY)
+# Verify changing Description reports verify on Koji build (INFO)
 class ChangingDescriptionCompareKojiBuild(TestCompareKoji):
     def setUp(self):
         TestCompareKoji.setUp(self)
@@ -439,5 +439,5 @@ class ChangingDescriptionCompareKojiBuild(TestCompareKoji):
         )
         self.after_rpm.add_description("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
It's not uncommon for the package Descriptions or Summary lines to
change in a maintenance build.  These changes are now reported at the
INFO level.  Previously they were reported at the INFO level if the
builds compared were a rebase, otherwise it would report them as
VERIFY.  The idea here I think was to restrict non-code changes in
maintenance builds, but personally I feel that Description and Summary
changes are ok in a maintenance build.

The bad words check is still there and any matches trigger a BAD
result.

Signed-off-by: David Cantrell <dcantrell@redhat.com>