### PR TITLE
[fix] Fall back on full license name if there are no abbrevs

### DIFF
--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -90,6 +90,7 @@ static struct json_object *read_licensedb(const char *licensedb)
 static bool check_license_abbrev(const char *lic)
 {
     const char *fedora_abbrev = NULL;
+    const char *fedora_name = NULL;
     const char *spdx_abbrev = NULL;
     bool approved = false;
 
@@ -98,6 +99,7 @@ static bool check_license_abbrev(const char *lic)
     json_object_object_foreach(licdb, license_name, val) {
         /* first reset our variables */
         fedora_abbrev = NULL;
+        fedora_name = NULL;
         spdx_abbrev = NULL;
         approved = false;
 
@@ -109,6 +111,8 @@ static bool check_license_abbrev(const char *lic)
         json_object_object_foreach(val, prop, propval) {
             if (!strcmp(prop, "fedora_abbrev")) {
                 fedora_abbrev = json_object_get_string(propval);
+            } else if (!strcmp(prop, "fedora_name")) {
+                fedora_name = json_object_get_string(propval);
             } else if (!strcmp(prop, "spdx_abbrev")) {
                 spdx_abbrev = json_object_get_string(propval);
             } else if (!strcmp(prop, "approved") && !strcasecmp(json_object_get_string(propval), "yes")) {
@@ -119,7 +123,7 @@ static bool check_license_abbrev(const char *lic)
         /*
          * no full tag match and no abbreviations, license entry invalid
          */
-        if (strlen(fedora_abbrev) == 0 && strlen(spdx_abbrev) == 0) {
+        if (strlen(fedora_abbrev) == 0 && strlen(spdx_abbrev) == 0 && strlen(fedora_name) == 0) {
             continue;
         }
 
@@ -129,7 +133,7 @@ static bool check_license_abbrev(const char *lic)
          * if we hit 'spdx_abbrev' and approved is true, that is valid
          * NOTE: we only match the first hit in the license database
          */
-        if (approved && (!strcmp(lic, fedora_abbrev) || !strcmp(lic, spdx_abbrev))) {
+        if (approved && ((!strcmp(lic, fedora_abbrev) || !strcmp(lic, spdx_abbrev)) || !strcmp(lic, fedora_name))) {
             return true;
         }
     }

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -89,18 +89,18 @@ static struct json_object *read_licensedb(const char *licensedb)
  */
 static bool check_license_abbrev(const char *lic)
 {
-    const char *fedora_abbrev = NULL;
-    const char *fedora_name = NULL;
-    const char *spdx_abbrev = NULL;
+    const char *fedora_abbrev = "";
+    const char *fedora_name = "";
+    const char *spdx_abbrev = "";
     bool approved = false;
 
     assert(lic != NULL);
 
     json_object_object_foreach(licdb, license_name, val) {
         /* first reset our variables */
-        fedora_abbrev = NULL;
-        fedora_name = NULL;
-        spdx_abbrev = NULL;
+        fedora_abbrev = "";
+        fedora_name = "";
+        spdx_abbrev = "";
         approved = false;
 
         if (strlen(license_name) == 0) {
@@ -133,7 +133,8 @@ static bool check_license_abbrev(const char *lic)
          * if we hit 'spdx_abbrev' and approved is true, that is valid
          * NOTE: we only match the first hit in the license database
          */
-        if (approved && ((!strcmp(lic, fedora_abbrev) || !strcmp(lic, spdx_abbrev)) || !strcmp(lic, fedora_name))) {
+        if (approved && ((!strcmp(lic, fedora_abbrev) || !strcmp(lic, spdx_abbrev)) ||
+                         (strlen(fedora_abbrev) == 0 && strlen(spdx_abbrev) == 0 && !strcmp(lic, fedora_name)))) {
             return true;
         }
     }

--- a/test/data/licenses/test.json
+++ b/test/data/licenses/test.json
@@ -218,5 +218,15 @@
     "spdx_abbrev": "CC0-1.0",
     "spdx_name": "Creative Commons Zero v1.0 Universal",
     "url": "http://creativecommons.org/publicdomain/zero/1.0/legalcode"
+  },
+  "Lorem ipsum": {
+    "approved": "yes",
+    "fedora_abbrev": "",
+    "fedora_name": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+    "id": "8000",
+    "license_text": "",
+    "spdx_abbrev": "#No official SPDX support",
+    "spdx_name": "#No official SPDX support",
+    "url": "https://www.lipsum.com/"
   }
 }

--- a/test/data/licenses/test.json
+++ b/test/data/licenses/test.json
@@ -225,8 +225,8 @@
     "fedora_name": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
     "id": "8000",
     "license_text": "",
-    "spdx_abbrev": "#No official SPDX support",
-    "spdx_name": "#No official SPDX support",
+    "spdx_abbrev": "",
+    "spdx_name": "",
     "url": "https://www.lipsum.com/"
   }
 }

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -296,3 +296,28 @@ class ValidLoremIpsonLicenseTagKoji(TestKoji):
         )
         self.inspection = "license"
         self.result = "INFO"
+
+
+# Invalid use of fedora_name string when an abbreviation is available (BAD)
+class InvalidUseOfLicenseStringSRPM(TestSRPM):
+    def setUp(self):
+        TestSRPM.setUp(self)
+        self.rpm.addLicense("Apache Software License 2.0")
+        self.inspection = "license"
+        self.result = "BAD"
+
+
+class InvalidUseOfLicenseStringRPMs(TestRPMs):
+    def setUp(self):
+        TestRPMs.setUp(self)
+        self.rpm.addLicense("Apache Software License 2.0")
+        self.inspection = "license"
+        self.result = "BAD"
+
+
+class InvalidUseOfLicenseStringKoji(TestKoji):
+    def setUp(self):
+        TestKoji.setUp(self)
+        self.rpm.addLicense("Apache Software License 2.0")
+        self.inspection = "license"
+        self.result = "BAD"

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -265,3 +265,34 @@ class ValidPerlHTTPMessageLicenseTagKoji(TestKoji):
         self.rpm.addLicense("(GPL+ or Artistic) and CC0")
         self.inspection = "license"
         self.result = "INFO"
+
+
+# Valid License string without any official abbreviations (OK)
+class ValidLoremIpsonLicenseTagSRPM(TestSRPM):
+    def setUp(self):
+        TestSRPM.setUp(self)
+        self.rpm.addLicense(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"  # noqa: E501
+        )
+        self.inspection = "license"
+        self.result = "INFO"
+
+
+class ValidLoremIpsonLicenseTagRPMs(TestRPMs):
+    def setUp(self):
+        TestRPMs.setUp(self)
+        self.rpm.addLicense(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"  # noqa: E501
+        )
+        self.inspection = "license"
+        self.result = "INFO"
+
+
+class ValidLoremIpsonLicenseTagKoji(TestKoji):
+    def setUp(self):
+        TestKoji.setUp(self)
+        self.rpm.addLicense(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"  # noqa: E501
+        )
+        self.inspection = "license"
+        self.result = "INFO"


### PR DESCRIPTION
If the fedora_abbrev and spdx_abbrev values are missing for a license
entry, then fall back on doing a full string match of the License tag
value and the fedora_name value.  Some packages, like linux-firmware
in Fedora, use a special value in the License tag that we lack any
official abbreviation for.  There will likely be others.  There always
are.

Signed-off-by: David Cantrell <dcantrell@redhat.com>