### PR TITLE
[lib] Always run inspections with possible security results

### DIFF
--- a/include/inspect.h
+++ b/include/inspect.h
@@ -562,6 +562,12 @@ bool inspect_runpath(struct rpminspect *ri);
 #define INSPECT_BADFUNCS                    (((uint64_t) 1) << 41)
 #define INSPECT_RUNPATH                     (((uint64_t) 1) << 42)
 
+/*
+ * The following inspections carry one or more checks that can trigger
+ * a WAIVABLE_BY_SECURITY result.
+ */
+#define SECURITY_INSPECTIONS                (INSPECT_ADDEDFILES | INSPECT_CAPABILITIES | INSPECT_CHANGEDFILES | INSPECT_ELF | INSPECT_OWNERSHIP | INSPECT_PERMISSIONS | INSPECT_REMOVEDFILES)
+
 /* Inspection names */
 #define NAME_LICENSE                        "license"
 #define NAME_EMPTYRPM                       "emptyrpm"

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -88,7 +88,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             add_result(ri, &params);
             free(params.msg);
             result = false;
-        } else if (!cap_compare(beforecap, aftercap)) {
+        } else if (!cap_compare(beforecap, aftercap) && (ri->tests & INSPECT_CAPABILITIES)) {
             xasprintf(&params.msg, _("File capabilities found for %s: '%s' on %s\n"), file->localpath, after, arch);
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
@@ -110,7 +110,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     if (aftercap && expected) {
-        if (!cap_compare(aftercap, expected)) {
+        if (!cap_compare(aftercap, expected) && (ri->tests & INSPECT_CAPABILITIES)) {
             xasprintf(&params.msg, _("File capabilities list entry found for %s: '%s' on %s, matches package\n"), file->localpath, flcaps->caps, arch);
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -120,7 +120,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
      */
 
     /* Report forbidden file owners */
-    if (ri->forbidden_owners && list_contains(ri->forbidden_owners, owner)) {
+    if (ri->forbidden_owners && list_contains(ri->forbidden_owners, owner) && (ri->tests & INSPECT_OWNERSHIP)) {
         xasprintf(&params.msg, _("File %s has forbidden owner `%s` on %s"), file->localpath, owner, arch);
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
@@ -131,7 +131,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     }
 
     /* Report forbidden file groups */
-    if (ri->forbidden_groups && list_contains(ri->forbidden_groups, group)) {
+    if (ri->forbidden_groups && list_contains(ri->forbidden_groups, group) && (ri->tests & INSPECT_OWNERSHIP)) {
         xasprintf(&params.msg, _("File %s has forbidden group `%s` on %s"), file->localpath, owner, arch);
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
@@ -147,7 +147,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
             bin = true;
 
             /* Check the owner */
-            if (strcmp(owner, ri->bin_owner) && !match_fileinfo_owner(ri, file, owner, NAME_OWNERSHIP, NULL)) {
+            if (strcmp(owner, ri->bin_owner) && !match_fileinfo_owner(ri, file, owner, NAME_OWNERSHIP, NULL) && (ri->tests & INSPECT_OWNERSHIP)) {
                 xasprintf(&params.msg, _("File %s has owner `%s` on %s, but should be `%s`"), file->localpath, owner, arch, ri->bin_owner);
                 params.severity = RESULT_BAD;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
@@ -171,7 +171,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
 
                 /* Handle if CAP_SETUID is present or not */
                 if (have_setuid == CAP_SET) {
-                    if (file->st.st_mode & S_IXOTH) {
+                    if (file->st.st_mode & S_IXOTH & (ri->tests & INSPECT_OWNERSHIP)) {
                         xasprintf(&params.msg, _("File %s on %s has CAP_SETUID capability but group `%s` and is world executable"), file->localpath, arch, group);
                         params.severity = RESULT_BAD;
                         params.waiverauth = WAIVABLE_BY_ANYONE;
@@ -190,7 +190,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
                         free(params.msg);
                         result = false;
                     }
-                } else if (!match_fileinfo_group(ri, file, group, NAME_OWNERSHIP, NULL)) {
+                } else if (!match_fileinfo_group(ri, file, group, NAME_OWNERSHIP, NULL) && (ri->tests & INSPECT_OWNERSHIP)) {
                     xasprintf(&params.msg, _("File %s has group `%s` on %s, but should be `%s`"), file->localpath, group, arch, ri->bin_group);
                     params.severity = RESULT_BAD;
                     params.waiverauth = WAIVABLE_BY_ANYONE;
@@ -208,7 +208,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     /*
      * BEFORE AND AFTER
      */
-    if (file->peer_file) {
+    if (file->peer_file && (ri->tests & INSPECT_OWNERSHIP)) {
         /* Get the before file values */
         before_owner = get_header_value(file->peer_file, RPMTAG_FILEUSERNAME);
         before_group = get_header_value(file->peer_file, RPMTAG_FILEGROUPNAME);

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -68,7 +68,7 @@ static bool permissions_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     allowed = match_fileinfo_mode(ri, file, NAME_PERMISSIONS, NULL);
 
     /* if setuid/setgid or new mode is more open */
-    if (mode_diff && file->peer_file && !allowed) {
+    if (mode_diff && file->peer_file && !allowed && (ri->tests & INSPECT_PERMISSIONS)) {
         if (!(before_mode & (S_ISUID|S_ISGID)) && (after_mode & (S_ISUID|S_ISGID))) {
             params.severity = RESULT_BAD;
             what = _("changed setuid/setgid");

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -120,25 +120,27 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /*
      * File has been removed, report results.
      */
-    if (is_elf(file->fullpath) && !strcmp(type, "application/x-pie-executable")) {
-        soname = get_elf_soname(file->fullpath);
-        params.severity = RESULT_BAD;
+    if (params.waiverauth == WAIVABLE_BY_SECURITY || (ri->tests & INSPECT_REMOVEDFILES)) {
+        if (is_elf(file->fullpath) && !strcmp(type, "application/x-pie-executable")) {
+            soname = get_elf_soname(file->fullpath);
+            params.severity = RESULT_BAD;
 
-        if (soname) {
-            xasprintf(&params.msg, _("ABI break: Library %s with SONAME '%s' removed from %s"), file->localpath, soname, arch);
-            free(soname);
+            if (soname) {
+                xasprintf(&params.msg, _("ABI break: Library %s with SONAME '%s' removed from %s"), file->localpath, soname, arch);
+                free(soname);
+            } else {
+                xasprintf(&params.msg, _("ABI break: Library %s removed from %s"), file->localpath, arch);
+            }
+
+            add_removedfiles_result(ri, &params);
+            result = !(params.severity >= RESULT_VERIFY);
+            free(params.msg);
         } else {
-            xasprintf(&params.msg, _("ABI break: Library %s removed from %s"), file->localpath, arch);
+            xasprintf(&params.msg, _("%s removed from %s"), file->localpath, arch);
+            add_removedfiles_result(ri, &params);
+            result = !(params.severity >= RESULT_VERIFY);
+            free(params.msg);
         }
-
-        add_removedfiles_result(ri, &params);
-        result = !(params.severity >= RESULT_VERIFY);
-        free(params.msg);
-    } else {
-        xasprintf(&params.msg, _("%s removed from %s"), file->localpath, arch);
-        add_removedfiles_result(ri, &params);
-        result = !(params.severity >= RESULT_VERIFY);
-        free(params.msg);
     }
 
     return result;

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -804,8 +804,8 @@ int main(int argc, char **argv)
         }
 
         for (i = 0; inspections[i].name != NULL; i++) {
-            /* test not selected by user */
-            if (!(ri->tests & inspections[i].flag)) {
+            /* test not selected by user and not a security inspection */
+            if (!(ri->tests & inspections[i].flag) && !(SECURITY_INSPECTIONS & inspections[i].flag)) {
                 continue;
             }
 


### PR DESCRIPTION
Some inspections produce results that librpminspect marks with
WAIVABLE_BY_SECURITY.  This is simply a categorization type thing.
Any result in this category is broadly considered "important for
security purposes".  That means that disabling an inspection via the
config file or command line option will still run it anyway if it
could possibly generate a security result.  If the inspection is
disabled, the non-security results are skipped and only security
results would show up.

The main reason for this change is to shift control of
WAIVABLE_BY_SECURITY findings to be controlled by settings in the
rpminspect-data package.  That ways changes to the vendor's data
package can have a workflow applied to ensure the security changes are
validated by some security team or group or something.

Signed-off-by: David Cantrell <dcantrell@redhat.com>