### PR TITLE
[fix] Ignore "complex" spec file macros in get_macros()

### DIFF
--- a/lib/macros.c
+++ b/lib/macros.c
@@ -124,7 +124,9 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
         entry = TAILQ_FIRST(fields);
 
         if (strcmp(entry->data, SPEC_MACRO_DEFINE) && strcmp(entry->data, SPEC_MACRO_GLOBAL)) {
-            err(RI_PROGRAM_ERROR, "unexpected macro line: %s", specline->data);
+            /* ignore complex macros, like a conditional define with a %global */
+            list_free(fields, free);
+            continue;
         }
 
         TAILQ_REMOVE(fields, entry, items);

--- a/test/data/SPECS/good.spec
+++ b/test/data/SPECS/good.spec
@@ -10,6 +10,7 @@
 
 # Extra macros that should be ignored by rpminspect
 %{!?_selinux_policy_version: %global _selinux_policy_version %(%{__sed} -e 's,.*selinux-policy-\\([^/]*\\)/.*,\\1,' /usr/share/selinux/devel/policyhelp 2>/dev/null)}
+%{!?_licensedir:%global license %%doc}
 
 # Multiline macros should be ignored
 %define multiline_macro \


### PR DESCRIPTION
This is a mini macro parser for the purposes of reading the Release
tag value.  Just make sure we skip over "complex" macro lines to avoid
trying to parse them here.

Signed-off-by: David Cantrell <dcantrell@redhat.com>