### PR TITLE
[fix] Fix a lot of xmlrpc-c memory leaks in builds.c

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -158,6 +158,7 @@ bool is_local_rpm(struct rpminspect *, const char *);
 koji_buildlist_t *init_koji_buildlist(void);
 void free_koji_buildlist(koji_buildlist_t *);
 koji_rpmlist_t *init_koji_rpmlist(void);
+void free_koji_rpmlist_entry(koji_rpmlist_entry_t *);
 void free_koji_rpmlist(koji_rpmlist_t *);
 void init_koji_build(struct koji_build *);
 void free_koji_build(struct koji_build *);
@@ -179,7 +180,7 @@ bool compare_module_aliases(kernel_alias_data_t *, kernel_alias_data_t *, module
 string_list_t *get_kmod_values(const char *, const char *);
 
 /* mkdirp.c */
-int mkdirp(char *, mode_t);
+int mkdirp(const char *, mode_t);
 
 /* rmtree.c */
 int rmtree(const char *, const bool, const bool);

--- a/lib/mkdirp.c
+++ b/lib/mkdirp.c
@@ -29,7 +29,7 @@
 #include <unistd.h>
 #include "rpminspect.h"
 
-int mkdirp(char *path, mode_t mode) {
+int mkdirp(const char *path, mode_t mode) {
     int r = 0;
     char *p = NULL;
     char *start = NULL;

--- a/lib/rmtree.c
+++ b/lib/rmtree.c
@@ -1,6 +1,6 @@
 /*
- * Copyright 2003-2021 David Shea <david@reallylongword.org>
- *                     David Cantrell <david.l.cantrell@gmail.com>
+ * Copyright 2003 David Shea <david@reallylongword.org>
+ *                David Cantrell <david.l.cantrell@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,13 +32,15 @@
 static int rmtree_entry(const char *, const struct stat *, int, struct FTW *);
 
 static int rmtree_entry(const char *fpath, __attribute__((unused)) const struct stat *sb,
-                        __attribute__((unused)) int tflag, __attribute__((unused)) struct FTW *ftwbuf) {
+                        __attribute__((unused)) int tflag, __attribute__((unused)) struct FTW *ftwbuf)
+{
     assert(fpath != NULL);
     return remove(fpath);
 }
 
 /* Remove specified tree, ignoring errors if specified. */
-int rmtree(const char *path, const bool ignore_errors, const bool contentsonly) {
+int rmtree(const char *path, const bool ignore_errors, const bool contentsonly)
+{
     struct stat sb;
     int status = 0;
     int flags = FTW_DEPTH | FTW_MOUNT | FTW_PHYS;


### PR DESCRIPTION
Clean up the librpminspect usage of xmlrpc-c.  All xmlrpc_value
variables need to be cleared using xmlrpc_DECREF since the library
does this whole reference counting thing.  *but* other variable types
from the library, so as those created with a *_new() function usually
(but not always) have a corresponding *_free() function.  What I have
found is that if you get an xmlrpc_value back from a function, then
you need to DECREF it.  Otherwise look for a free type function and
use that.

Also clean up some other memory management mishaps in the downloading
code and the rpminspect command line program.

Signed-off-by: David Cantrell <dcantrell@redhat.com>