### PR TITLE
[ci] Install epel-release in pre.sh on centos7

### DIFF
--- a/osdeps/centos7/pre.sh
+++ b/osdeps/centos7/pre.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/sbin:/usr/sbin
 
-# Update pip and setuptools
-yum install -y python36-pip
-pip3 install --upgrade pip setuptools
+# EPEL is required
+yum install -y epel-release
+rpm --import /etc/pki/rpm-gpg/*

--- a/osdeps/centos7/reqs.txt
+++ b/osdeps/centos7/reqs.txt
@@ -37,6 +37,7 @@ patchelf
 python36-devel
 python36-pip
 python36-rpm
+python36-setuptools_scm
 rc
 rpm-build
 rpm-devel


### PR DESCRIPTION
Modify the osdeps scripts for centos7 a bit.  This makes it work more
cleanly with 'make instreqs' in addition to GitHub Actions.  Install
setuptools using the python36 package from EPEL.

Signed-off-by: David Cantrell <dcantrell@redhat.com>