### PR TITLE
[ci] Pass CRYPTOGRAPHY_DONT_BUILD_RUST=1 to pip on centos7

### DIFF
--- a/osdeps/centos7/defs.mk
+++ b/osdeps/centos7/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = yum install -y
-PIP_CMD = pip-3 install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install


### PR DESCRIPTION
Similar to the Debian-derived platforms, pass this environment
variable to avoid pip installs dragging in a ton of Rust stuff that
won't build.

Signed-off-by: David Cantrell <dcantrell@redhat.com>