### PR TITLE
[ci] Restore previous centos7 pip and setuptools behavior

### DIFF
--- a/osdeps/centos7/pre.sh
+++ b/osdeps/centos7/pre.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/sbin:/usr/sbin
 
-# EPEL is required
-yum install -y epel-release
-rpm --import /etc/pki/rpm-gpg/*
+# Update pip and setuptools
+dnf install -y python3-pip
+pip3 install --upgrade pip setuptools

--- a/osdeps/centos7/reqs.txt
+++ b/osdeps/centos7/reqs.txt
@@ -37,7 +37,6 @@ patchelf
 python36-devel
 python36-pip
 python36-rpm
-python36-setuptools_scm
 rc
 rpm-build
 rpm-devel


### PR DESCRIPTION
Not sure why this was not working in my test environment earlier, but
this is what I need to be doing so restore the behavior.

Signed-off-by: David Cantrell <dcantrell@redhat.com>