### PR TITLE
[fix] Adjust where the 'good' bool is set in the emptyrpm loop

### DIFF
--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -96,12 +96,11 @@ bool inspect_emptyrpm(struct rpminspect *ri)
                 params.severity = RESULT_VERIFY;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
                 params.remedy = REMEDY_EMPTYRPM;
+                good = false;
             }
 
             add_result(ri, &params);
             free(params.msg);
-
-            good = false;
         }
     }
 


### PR DESCRIPTION
If a user declares a list of expected empty RPM packages, the emptyrpm
inspection should return successfully if all RPMs pass.

Resolves #430

Signed-off-by: David Cantrell <dcantrell@redhat.com>