### PR TITLE
[cmd] Discontinue realpath() call on argv[0]

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -286,7 +286,6 @@ static void check_found(const bool found, const char *inspection)
 
 int main(int argc, char **argv)
 {
-    char resolved[PATH_MAX];
     struct sigaction abrt;
     struct sigaction winch;
     int c = 0;
@@ -526,13 +525,6 @@ int main(int argc, char **argv)
         exit(RI_INSPECTION_SUCCESS);
     }
 
-    /* Get the full path to the program */
-    memset(resolved, '\0', sizeof(resolved));
-
-    if (realpath(argv[0], resolved) == NULL) {
-        err(EXIT_FAILURE, "realpath");
-    }
-
     /*
      * Find an appropriate configuration file. This involves:
      *
@@ -584,7 +576,7 @@ int main(int argc, char **argv)
     free(profile);
 
     /* various options from the command line or elsewhere */
-    ri->progname = strdup(resolved);
+    ri->progname = strdup(argv[0]);
     ri->verbose = verbose;
     ri->product_release = release;
     ri->threshold = getseverity(threshold);


### PR DESCRIPTION
I can't remember why I added this, but I think it was for reporting in
the log output.  At any rate, this really isn't needed now so I am
just going to remove it.

Fixed #433

Signed-off-by: David Cantrell <dcantrell@redhat.com>