### PR TITLE
[cmd] Honor -T/-E correctly even with security-focused checks

### DIFF
--- a/include/inspect.h
+++ b/include/inspect.h
@@ -562,12 +562,6 @@ bool inspect_runpath(struct rpminspect *ri);
 #define INSPECT_BADFUNCS                    (((uint64_t) 1) << 41)
 #define INSPECT_RUNPATH                     (((uint64_t) 1) << 42)
 
-/*
- * The following inspections carry one or more checks that can trigger
- * a WAIVABLE_BY_SECURITY result.
- */
-#define SECURITY_INSPECTIONS                (INSPECT_ADDEDFILES | INSPECT_CAPABILITIES | INSPECT_CHANGEDFILES | INSPECT_ELF | INSPECT_OWNERSHIP | INSPECT_PERMISSIONS | INSPECT_REMOVEDFILES)
-
 /* Inspection names */
 #define NAME_LICENSE                        "license"
 #define NAME_EMPTYRPM                       "emptyrpm"

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -814,8 +814,8 @@ int main(int argc, char **argv)
         }
 
         for (i = 0; inspections[i].name != NULL; i++) {
-            /* test not selected by user and not a security inspection */
-            if (!(ri->tests & inspections[i].flag) && !(SECURITY_INSPECTIONS & inspections[i].flag)) {
+            /* test not selected by user */
+            if (!(ri->tests & inspections[i].flag)) {
                 continue;
             }
 


### PR DESCRIPTION
When I modified librpminspect to always run the security checks, I
also modified the command so any inspection with a security check
can't be skipped.  This is not very intuitive given the -T and -E
options, so this patch restores the -T and -E behavior.  However, if
an inspection runs with security checks then those security checks are
always run regardless of settings in a config file.

Signed-off-by: David Cantrell <dcantrell@redhat.com>