### PR TITLE
[lib] Replace get_header_value() with get_rpm_header_value()

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -214,6 +214,7 @@ char *get_nevr(Header);
 char *get_nevra(Header);
 const char *get_rpm_header_arch(Header);
 string_list_t *get_rpm_header_string_array(Header h, rpmTagVal tag);
+char *get_rpm_header_value(const rpmfile_entry_t *file, rpmTag tag);
 
 /* peers.c */
 rpmpeer_t *init_rpmpeer(void);

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -32,7 +32,8 @@
 #include "rpminspect.h"
 
 /* Main driver for the 'ownership' inspection */
-static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
+static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
+{
     bool result = true;
     const char *arch = NULL;
     char *owner = NULL;
@@ -226,7 +227,8 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
 /*
  * Main driver for the 'ownership' inspection.
  */
-bool inspect_ownership(struct rpminspect *ri) {
+bool inspect_ownership(struct rpminspect *ri)
+{
     bool result = false;
     struct result_params params;
 


### PR DESCRIPTION
Turn the former static function in inspect_ownership.c in to a
function in rpm.c that can be used elsewhere.

Signed-off-by: David Cantrell <dcantrell@redhat.com>