### PR TITLE
Read capabilities(7) on packaged files from the RPM header

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -226,7 +226,6 @@ void free_files(rpmfile_t *files);
 rpmfile_t * extract_rpm(const char *, Header, char **output_dir);
 bool process_file_path(const rpmfile_entry_t *, regex_t *, regex_t *);
 void find_file_peers(rpmfile_t *, rpmfile_t *);
-cap_t get_cap(rpmfile_entry_t *);
 bool is_debug_or_build_path(const char *);
 bool is_payload_empty(rpmfile_t *);
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -778,51 +778,6 @@ void find_file_peers(rpmfile_t *before, rpmfile_t *after)
 }
 
 /**
- * @brief Return the capabilities(7) of the specified rpmfile_entry_t.
- *
- * If the capabilities(7) of the specified file are cached, return
- * that.  Otherwise get and cache the capabilities, then return the
- * cached value.
- *
- * @param file rpmfile_entry_t specifying the file.
- * @return cap_t containing the capabilities(7) of the file.
- */
-cap_t get_cap(rpmfile_entry_t *file)
-{
-    int fd;
-    const char *arch = NULL;
-
-    assert(file != NULL);
-    arch = get_rpm_header_arch(file->rpm_header);
-    assert(arch != NULL);
-
-    if (file->cap) {
-        return file->cap;
-    }
-
-    assert(file->fullpath != NULL);
-
-    /* Only for regular files */
-    if (!S_ISREG(file->st.st_mode)) {
-        return NULL;
-    }
-
-    /* Gather capabilities(7) for the file we need */
-    if ((fd = open(file->fullpath, O_RDONLY)) == -1) {
-        warn("open()");
-        return NULL;
-    }
-
-    file->cap = cap_get_fd(fd);
-
-    if (close(fd) == -1) {
-        warn("close()");
-    }
-
-    return file->cap;
-}
-
-/**
  * @brief Determine if a path is a debug or build path.
  *
  * Returns true if the specified path contains any of:

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -106,7 +106,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
     regex_t origin_root;
     int reg_result = 0;
     char reg_error[BUFSIZ];
-    regmatch_t origin_matches[1];
+    regmatch_t origin_matches[3];
     const char *arch = NULL;
     struct result_params params;
 

--- a/test/data/capabilities/GENERIC
+++ b/test/data/capabilities/GENERIC
@@ -1,0 +1,1 @@
+vaporware           /usr/sbin/approved   = cap_sys_nice+ep

--- a/test/meson.build
+++ b/test/meson.build
@@ -118,6 +118,7 @@ if python.found()
         'test_abidiff.py',
         'test_addedfiles.py',
         'test_badfuncs.py',
+        'test_capabilities.py',
         'test_changedfiles.py',
         'test_changelog.py',
         'test_command.py',

--- a/test/test_capabilities.py
+++ b/test/test_capabilities.py
@@ -1,0 +1,143 @@
+#
+# Copyright © 2021 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from baseclass import TestRPMs, TestKoji
+from baseclass import TestCompareRPMs, TestCompareKoji
+
+
+# package contains a file with capabilities(7) but it is not on the
+# list (BAD)
+class UnapprovedCapabilitiesRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_simple_compilation(installPath="usr/sbin/unapproved")
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files = sub.section_files.replace(
+            "/usr/sbin/unapproved\n", "%caps(cap_sys_nice=ep) /usr/sbin/unapproved\n"
+        )
+
+        self.inspection = "capabilities"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnapprovedCapabilitiesKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_simple_compilation(installPath="usr/sbin/unapproved")
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files = sub.section_files.replace(
+            "/usr/sbin/unapproved\n", "%caps(cap_sys_nice=ep) /usr/sbin/unapproved\n"
+        )
+
+        self.inspection = "capabilities"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnapprovedCapabilitiesCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.after_rpm.add_simple_compilation(installPath="usr/sbin/unapproved")
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files = sub.section_files.replace(
+            "/usr/sbin/unapproved\n", "%caps(cap_sys_nice=ep) /usr/sbin/unapproved\n"
+        )
+
+        self.inspection = "capabilities"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnapprovedCapabilitiesCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.after_rpm.add_simple_compilation(installPath="usr/sbin/unapproved")
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files = sub.section_files.replace(
+            "/usr/sbin/unapproved\n", "%caps(cap_sys_nice=ep) /usr/sbin/unapproved\n"
+        )
+
+        self.inspection = "capabilities"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+# package contains a file with approved capabilities(7) (OK)
+class ApprovedCapabilitiesRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_simple_compilation(installPath="usr/sbin/approved")
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files = sub.section_files.replace(
+            "/usr/sbin/approved\n", "%caps(cap_sys_nice=ep) /usr/sbin/approved\n"
+        )
+
+        self.inspection = "capabilities"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ApprovedCapabilitiesKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_simple_compilation(installPath="usr/sbin/approved")
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files = sub.section_files.replace(
+            "/usr/sbin/approved\n", "%caps(cap_sys_nice=ep) /usr/sbin/approved\n"
+        )
+
+        self.inspection = "capabilities"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
+
+
+class ApprovedCapabilitiesCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.after_rpm.add_simple_compilation(installPath="usr/sbin/approved")
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files = sub.section_files.replace(
+            "/usr/sbin/approved\n", "%caps(cap_sys_nice=ep) /usr/sbin/approved\n"
+        )
+
+        self.inspection = "capabilities"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
+
+
+class ApprovedCapabilitiesCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.after_rpm.add_simple_compilation(installPath="usr/sbin/approved")
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files = sub.section_files.replace(
+            "/usr/sbin/approved\n", "%caps(cap_sys_nice=ep) /usr/sbin/approved\n"
+        )
+
+        self.inspection = "capabilities"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"

--- a/test/test_ownership.py
+++ b/test/test_ownership.py
@@ -1556,7 +1556,7 @@ class CapSETUIDWithOtherExecRPMs(TestRPMs):
 
         self.inspection = "ownership"
         self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.waiver_auth = "Security"
 
 
 class CapSETUIDWithOtherExecKoji(TestKoji):
@@ -1585,7 +1585,7 @@ class CapSETUIDWithOtherExecKoji(TestKoji):
 
         self.inspection = "ownership"
         self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.waiver_auth = "Security"
 
 
 class CapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
@@ -1616,7 +1616,7 @@ class CapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
 
         self.inspection = "ownership"
         self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.waiver_auth = "Security"
 
 
 class CapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
@@ -1647,7 +1647,7 @@ class CapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
 
         self.inspection = "ownership"
         self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.waiver_auth = "Security"
 
 
 #################################
@@ -1681,7 +1681,7 @@ class CapSETUIDWithGroupExecRPMs(TestRPMs):
 
         self.inspection = "ownership"
         self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.waiver_auth = "Security"
 
 
 class CapSETUIDWithGroupExecKoji(TestKoji):
@@ -1710,7 +1710,7 @@ class CapSETUIDWithGroupExecKoji(TestKoji):
 
         self.inspection = "ownership"
         self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.waiver_auth = "Security"
 
 
 class CapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
@@ -1741,7 +1741,7 @@ class CapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
 
         self.inspection = "ownership"
         self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.waiver_auth = "Security"
 
 
 class CapSETUIDWithGroupExecCompareKoji(TestCompareKoji):
@@ -1772,7 +1772,7 @@ class CapSETUIDWithGroupExecCompareKoji(TestCompareKoji):
 
         self.inspection = "ownership"
         self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.waiver_auth = "Security"
 
 
 #################


### PR DESCRIPTION
Discontinue reading the extracted file to gather capabilities(7) values.  These cannot be set on extracted files except by the root user.  So instead we gather capabilities(7) from the RPM header and compare them to the capabilities settings in the vendor data package.