### PR TITLE
[fix] Handle DT_RUNPATH/DT_RPATH owned directories correctly

### DIFF
--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -198,7 +198,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
                 allowed = ri->runpath_allowed_paths;
             }
 
-            if (!valid && working_path && allowed) {
+            if (!valid && working_path) {
                 /* canonicalize the path string */
                 working_path = abspath(working_path);
 


### PR DESCRIPTION
This is a followup to 4ac9d0f00b20f28e6c3db0a062a09e4d2b752390 that
fixes the handling of DT_RUNPATH/DT_RPATH entries that are a directory
owned by the package itself.  The check for allowed here meant that
this block was only entered if the config file contained an
allowed_paths list under the runpath block, which is incorrect.  That
list is optional.  This patch fixes the behavior so it works correctly
if the list is present or missing, but still honors it correctly.

Fixes #454

Signed-off-by: David Cantrell <dcantrell@redhat.com>