### PR TITLE
[lib] Add security rule reading code to librpminspect

### DIFF
--- a/data/security/GENERIC
+++ b/data/security/GENERIC
@@ -1,0 +1,43 @@
+#
+# Security rules for the test suite
+#
+# One package per line.  Blank lines and lines beginning with '#' are
+# ignored.  Malformed lines are ignored, but a warning is displayed.
+# Each rule consists of four fields separated by spaces or tabs (any
+# number):
+#
+#     name           The name of the package
+#     version        The package version, can use glob(7) syntax
+#     release        The package release, can use glob(7) syntax
+#     rules          Comma-delimited list of security rules where each
+#                    element is RULE=ACTION.
+#
+# Available RULES (case-insensitive in the config file):
+#
+#     caps           Check file capabilities(7)
+#     execstack      Check for executable stack in ELF objects or programs
+#                    built without GNU_STACK.
+#     relro          Check for ELF objects losing GNU_RELRO protection.
+#     fortifysource  Check for ELF objects losing -D_FORTIFY_SOURCE.
+#     pic            Check for ELF objects built without -fPIC in static
+#                    libraries.
+#     textrel        Check for an TEXTREL relocations.
+#     setuid         Check for CAP_SETUID and group writable permissions.
+#     worldwritable  Check for world writable permissions.
+#     securitypath   Check for loss of file(s) that belong in a security
+#                    path prefix.
+#     modes          Check for expected file ownership and permissions.
+#
+# Available ACTIONS (case-insensitive in the config file):
+#
+#     SKIP           The finding is ignored.
+#     INFORM         The finding is reported at the INFO level, which does
+#                    not trigger a failing exit code.
+#     VERIFY         The finding is reported at the VERIFY level, which does
+#                    trigger a failing exit code.
+#     FAIL           The finding is reported at the BAD level, which does
+#                    trigger a failing exit code.
+#
+
+slirp       *        *    caps=SKIP,execStack=INFORM,RELRO=verify,FortifySOURCE=FAIL,pic=inform,TEXTrel=Verify,setUID=FaIl,worldwritable=Skip,SECURITYPATH=verify,Modes=Inform
+xanim       *        *    relro=inform,pic=SKIP

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -227,6 +227,22 @@ Here is a description of the subdirectories found in
     packages rather than modifying the **rpminspect.yaml** files for
     each of those packages.
 
+- **security/**
+
+    Contains per-product files that specify the actions to take for
+    different security rules on a per package and version basis.  For
+    example, a product may have an older build of a package like
+    openssl and needs to relax some of the security rules in
+    rpminspect.  Later product versions can define stricter rules.
+    This file is also how you instruct rpminspect to ignore things it
+    reports as needed product security inspection.  The idea here is
+    that the package maintainer will consult with their product
+    security team to determine if the reported problem warrants a
+    security rule and if so add it to this file for that product.
+    Subsequent runs of rpminspect on the package in question will
+    follow the rule here and ideally not continue reporting the
+    security failure.
+
 .. _rpminspect: https://github.com/rpminspect/rpminspect
 
 .. _rpminspect-data-fedora: https://github.com/rpminspect/rpminspect-data-fedora

--- a/include/constants.h
+++ b/include/constants.h
@@ -132,6 +132,13 @@
  */
 #define POLITICS_DIR "politics"
 
+/**
+ * @def SECURITY_DIR
+ * Name of the VENDOR_DATA_DIR subdirectory with security related
+ * package rules.
+ */
+#define SECURITY_DIR "security"
+
 /** @} */
 
 /**

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -125,6 +125,7 @@ bool init_fileinfo(struct rpminspect *);
 bool init_caps(struct rpminspect *);
 bool init_rebaseable(struct rpminspect *);
 bool init_politics(struct rpminspect *ri);
+bool init_security(struct rpminspect *ri);
 struct rpminspect *init_rpminspect(struct rpminspect *, const char *, const char *);
 
 /* free.c */

--- a/include/secrules.h
+++ b/include/secrules.h
@@ -30,85 +30,88 @@
  * corresponding configuration file string is in a comment for each
  * rule type (e.g., "caps" or "fortifysource").
  */
-enum secrule_type {
-    /* not used */
-    SECRULE_NULL = 0,
 
-    /*
-     * caps
-     * Any inspection that looks at capabilities(7) values.
-     */
-    SECRULE_CAPS = 1,
+/* only used to indicate an unknown rule */
+#define SECRULE_NULL 0
 
-    /*
-     * execstack
-     * ELF object contains an executable stack or built without
-     * GNU_STACK.
-     */
-    SECRULE_EXECSTACK = 2,
+/*
+ * caps
+ * Any inspection that looks at capabilities(7) values.
+ */
+#define SECRULE_CAPS 1
 
-    /*
-     * relro
-     * ELF object loses partial or full GNU_RELRO protection.
-     */
-    SECRULE_RELRO = 3,
+/*
+ * execstack
+ * ELF object contains an executable stack or built without
+ * GNU_STACK.
+ */
+#define SECRULE_EXECSTACK 2
 
-    /*
-     * fortifysource
-     * ELF object loses -D_FORTIFY_SOURCE protection.
-     */
-    SECRULE_FORTIFYSOURCE = 4,
+/*
+ * relro
+ * ELF object loses partial or full GNU_RELRO protection.
+ */
+#define SECRULE_RELRO 3
 
-    /*
-     * pic
-     * ELF objects in static libraries built without -fPIC
-     */
-    SECRULE_PIC = 5,
+/*
+ * fortifysource
+ * ELF object loses -D_FORTIFY_SOURCE protection.
+ */
+#define SECRULE_FORTIFYSOURCE 4
 
-    /*
-     * textrel
-     * ELF object has TEXTREL relocations.
-     */
-    SECRULE_TEXTREL = 6,
+/*
+ * pic
+ * ELF objects in static libraries built without -fPIC
+ */
+#define SECRULE_PIC 5
 
-    /*
-     * setuid
-     * File has CAP_SETUID but is group writable.
-     */
-    SECRULE_SETUID = 7,
+/*
+ * textrel
+ * ELF object has TEXTREL relocations.
+ */
+#define SECRULE_TEXTREL 6
 
-    /*
-     * worldwritable
-     * File or directory is world writable.
-     */
-    SECRULE_WORLDWRITABLE = 8,
+/*
+ * setuid
+ * File has CAP_SETUID but is group writable.
+ */
+#define SECRULE_SETUID 7
 
-    /*
-     * securitypath
-     * File is removed but belonged in a security path prefix as
-     * defined in the configuration file.
-     */
-    SECRULE_SECURITYPATH = 9,
+/*
+ * worldwritable
+ * File or directory is world writable.
+ */
+#define SECRULE_WORLDWRITABLE 8
 
-    /*
-     * modes
-     * File mode does not match expected mode from the fileinfo rules.
-     */
-    SECRULE_MODES = 10
-};
+/*
+ * securitypath
+ * File is removed but belonged in a security path prefix as
+ * defined in the configuration file.
+ */
+#define SECRULE_SECURITYPATH 9
+
+/*
+ * modes
+ * File mode does not match expected mode from the fileinfo rules.
+ */
+#define SECRULE_MODES 10
+
 
 enum secrule_action {
     /* not used */
     SECRULE_ACTION_NULL = 0,
 
+    /* ignore the finding */
+    SECRULE_ACTION_SKIP = 1,
+
     /* reporting level will be INFO */
-    SECRULE_ACTION_INFORM = 1,
+    SECRULE_ACTION_INFORM = 2,
 
     /* reporting level will be VERIFY */
-    SECRULE_ACTION_VERIFY = 2,
+    SECRULE_ACTION_VERIFY = 3,
 
     /* reporting level will be BAD */
-    SECRULE_ACTION_FAIL = 3
+    SECRULE_ACTION_FAIL = 4
 };
 
 /*
@@ -117,7 +120,7 @@ enum secrule_action {
  * definitions file.
  */
 typedef struct _secrule_t {
-    enum secrule_type type;
+    int type;
     enum secrule_action action;
     UT_hash_handle hh;
 } secrule_t;

--- a/include/types.h
+++ b/include/types.h
@@ -347,6 +347,7 @@ struct rpminspect {
     string_list_t *rebaseable;
     politics_list_t *politics;
     security_t *security;
+    bool security_initialized;
 
     /* Koji information (from config file) */
     char *kojihub;             /* URL of Koji hub */


### PR DESCRIPTION
This commit adds in the code that reads in the security rules for the
product during the initialization phase.  librpminspect will collect
all the rules first because it will need to use them across a variety
of inspections.

Signed-off-by: David Cantrell <dcantrell@redhat.com>