### PR TITLE
[fix] Convert the security rules from a hash table to a list

### DIFF
--- a/include/secrules.h
+++ b/include/secrules.h
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+#include "queue.h"
 #include "uthash.h"
 
 #ifndef _LIBRPMINSPECT_SECRULES_H
@@ -126,16 +127,18 @@ typedef struct _secrule_t {
 } secrule_t;
 
 /*
- * Security hash table
- * This table holds the rows as read from the vendor security
+ * Security rules list
+ * This list holds the rows as read from the vendor security
  * definitions files.
  */
-typedef struct _security_t {
+typedef struct _security_entry_t {
     char *pkg;
     char *ver;
     char *rel;
     secrule_t *rules;
-    UT_hash_handle hh;
-} security_t;
+    TAILQ_ENTRY(_security_entry_t) items;
+} security_entry_t;
+
+typedef TAILQ_HEAD(security_entry_s, _security_entry_t) security_list_t;
 
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -133,11 +133,13 @@ typedef TAILQ_HEAD(rpmpeer_s, _rpmpeer_entry_t) rpmpeer_t;
  * And individual inspection result and the list to hold them.
  */
 typedef enum _severity_t {
-    RESULT_OK     = 0,
-    RESULT_INFO   = 1,
-    RESULT_WAIVED = 2,
-    RESULT_VERIFY = 3,
-    RESULT_BAD    = 4
+    RESULT_NULL   = 0,      /* used to indicate internal error */
+    RESULT_OK     = 1,
+    RESULT_INFO   = 2,
+    RESULT_WAIVED = 3,
+    RESULT_VERIFY = 4,
+    RESULT_BAD    = 5,
+    RESULT_SKIP   = 6       /* not reported, used to skip output */
 } severity_t;
 
 typedef enum _waiverauth_t {
@@ -346,7 +348,7 @@ struct rpminspect {
     caps_t *caps;
     string_list_t *rebaseable;
     politics_list_t *politics;
-    security_t *security;
+    security_list_t *security;
     bool security_initialized;
 
     /* Koji information (from config file) */

--- a/lib/free.c
+++ b/lib/free.c
@@ -82,8 +82,7 @@ void free_rpminspect(struct rpminspect *ri) {
     caps_filelist_entry_t *cflentry = NULL;
     header_cache_entry_t *hentry = NULL;
     politics_entry_t *pentry = NULL;
-    security_t *sentry = NULL;
-    security_t *tmp_sentry = NULL;
+    security_entry_t *sentry = NULL;
     secrule_t *srentry = NULL;
     secrule_t *tmp_srentry = NULL;
 
@@ -160,8 +159,10 @@ void free_rpminspect(struct rpminspect *ri) {
     }
 
     if (ri->security) {
-        HASH_ITER(hh, ri->security, sentry, tmp_sentry) {
-            HASH_DEL(ri->security, sentry);
+        while (!TAILQ_EMPTY(ri->security)) {
+            sentry = TAILQ_FIRST(ri->security);
+            TAILQ_REMOVE(ri->security, sentry, items);
+
             free(sentry->pkg);
             free(sentry->ver);
             free(sentry->rel);
@@ -175,6 +176,8 @@ void free_rpminspect(struct rpminspect *ri) {
 
             free(sentry);
         }
+
+        free(ri->security);
     }
 
     list_free(ri->badwords, free);


### PR DESCRIPTION
Working on the rule implementation revealed that I actually need each
rule and can't use a hash table because there's no easy way to create
a key given an RPM header, so there's nothing to retrieve an element
with.

Signed-off-by: David Cantrell <dcantrell@redhat.com>