### PR TITLE
[lib] Removed RESULT_WAIVED from severity_t

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -136,10 +136,9 @@ typedef enum _severity_t {
     RESULT_NULL   = 0,      /* used to indicate internal error */
     RESULT_OK     = 1,
     RESULT_INFO   = 2,
-    RESULT_WAIVED = 3,
-    RESULT_VERIFY = 4,
-    RESULT_BAD    = 5,
-    RESULT_SKIP   = 6       /* not reported, used to skip output */
+    RESULT_VERIFY = 3,
+    RESULT_BAD    = 4,
+    RESULT_SKIP   = 5       /* not reported, used to skip output */
 } severity_t;
 
 typedef enum _waiverauth_t {

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -253,16 +253,18 @@ cleanup:
  */
 char *strseverity(const severity_t severity) {
     switch (severity) {
+        case RESULT_NULL:
+            return _("NULL");
         case RESULT_OK:
             return _("OK");
         case RESULT_INFO:
             return _("INFO");
-        case RESULT_WAIVED:
-            return _("WAIVED");
         case RESULT_VERIFY:
             return _("VERIFY");
         case RESULT_BAD:
             return _("BAD");
+        case RESULT_SKIP:
+            return _("SKIP");
         default:
             return _("UnKnOwN");
     }
@@ -281,16 +283,18 @@ severity_t getseverity(const char *name) {
         return s;
     }
 
-    if (!strcasecmp(name, _("OK"))) {
+    if (!strcasecmp(name, _("NULL"))) {
+        s = RESULT_NULL;
+    } else if (!strcasecmp(name, _("OK"))) {
         s = RESULT_OK;
     } else if (!strcasecmp(name, _("INFO"))) {
         s = RESULT_INFO;
-    } else if (!strcasecmp(name, _("WAIVED"))) {
-        s = RESULT_WAIVED;
     } else if (!strcasecmp(name, _("VERIFY"))) {
         s = RESULT_VERIFY;
     } else if (!strcasecmp(name, _("BAD"))) {
         s = RESULT_BAD;
+    } else if (!strcasecmp(name, _("SKIP"))) {
+        s = RESULT_SKIP;
     }
 
     return s;

--- a/test/lib/test-strfuncs.c
+++ b/test/lib/test-strfuncs.c
@@ -50,11 +50,12 @@ void test_printwrap(void) {
 }
 
 void test_strseverity(void) {
+    RI_ASSERT_EQUAL(strcmp(strseverity(RESULT_NULL), "NULL"), 0);
     RI_ASSERT_EQUAL(strcmp(strseverity(RESULT_OK), "OK"), 0);
     RI_ASSERT_EQUAL(strcmp(strseverity(RESULT_INFO), "INFO"), 0);
-    RI_ASSERT_EQUAL(strcmp(strseverity(RESULT_WAIVED), "WAIVED"), 0);
     RI_ASSERT_EQUAL(strcmp(strseverity(RESULT_VERIFY), "VERIFY"), 0);
     RI_ASSERT_EQUAL(strcmp(strseverity(RESULT_BAD), "BAD"), 0);
+    RI_ASSERT_EQUAL(strcmp(strseverity(RESULT_SKIP), "SKIP"), 0);
     RI_ASSERT_EQUAL(strcmp(strseverity(-1), "UnKnOwN"), 0);
 }
 


### PR DESCRIPTION
This has never been used and is out of place now.  The reason it
exists is from ideas originally obtained from rpmdiff.  The
implementation of rpminspect does deals with things rpmdiff called
waivers in a different way.

Signed-off-by: David Cantrell <dcantrell@redhat.com>