### PR TITLE
[lib] Improve remedy reporting to tell users what data file to edit

### DIFF
--- a/include/results.h
+++ b/include/results.h
@@ -87,18 +87,18 @@
 #define REMEDY_REMOVEDFILES _("Unexpected file removals were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file removals between builds.")
 
 /* addedfiles */
-#define REMEDY_ADDEDFILES _("Unexpected file additions were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file additions between builds.")
+#define REMEDY_ADDEDFILES _("Unexpected file additions were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file additions between builds.  If they are correct, update %s and send a patch to the project owning that file so rpminspect knows to expect this change.")
 
 /* upstream */
-#define REMEDY_UPSTREAM _("Unexpected changed source archive content.  The version of the package did not change between builds, but the source archive content did.  This may be deliberate, but needs inspection.")
+#define REMEDY_UPSTREAM _("Unexpected changed source archive content. The version of the package did not change between builds, but the source archive content did. This may be deliberate, but needs inspection. If this change is expected, update %s and send a patch to the project that owns that file.")
 
 /* ownership */
-#define REMEDY_OWNERSHIP_DEFATTR _("Make sure the %files section includes the %defattr macro.")
-#define REMEDY_OWNERSHIP_BIN_OWNER _("Bin path files must be owned by the bin_owner set in the rpminspect configuration, which is usually root.")
-#define REMEDY_OWNERSHIP_BIN_GROUP _("Bin path files must be owned by the bin_group set in the rpminspect configuration, which is usually root.")
-#define REMEDY_OWNERSHIP_IXOTH _("Either chgrp the file to the bin_group set in the rpminspect configuration or remove the world execute bit on the file (chmod o-x).")
-#define REMEDY_OWNERSHIP_IWGRP _("Either chgrp the file to the bin_group set in the rpminspect configuration or remove the group write bit on the file (chmod g-w).")
-#define REMEDY_OWNERSHIP_CHANGED _("Verify the ownership changes are expected. If not, adjust the package build process to set correct owner and group information.")
+#define REMEDY_OWNERSHIP_DEFATTR _("Make sure the %%files section includes the %%defattr macro. If these permissions are expected, update %s and send a patch to the project that owns it.")
+#define REMEDY_OWNERSHIP_BIN_OWNER _("Bin path files must be owned by the bin_owner set in the rpminspect configuration, which is usually root. If this ownership is expected, update %s and send a patch to the project that owns it.")
+#define REMEDY_OWNERSHIP_BIN_GROUP _("Bin path files must be owned by the bin_group set in the rpminspect configuration, which is usually root. If this ownership is expect, update %s and send a patch to the project that owns it.")
+#define REMEDY_OWNERSHIP_IXOTH _("Either chgrp the file to the bin_group set in the rpminspect configuration or remove the world execute bit on the file (chmod o-x). If this ownership is expected, update %s and send a patch to the project that owns it.")
+#define REMEDY_OWNERSHIP_IWGRP _("Either chgrp the file to the bin_group set in the rpminspect configuration or remove the group write bit on the file (chmod g-w). If this ownership is expected, update %s and send a patch to the project that owns it.")
+#define REMEDY_OWNERSHIP_CHANGED _("Verify the ownership changes are expected. If not, adjust the package build process to set correct owner and group information. If expected, update %s and send a patch to the project that owns it.")
 
 /* shellsyntax */
 #define REMEDY_SHELLSYNTAX _("Consult the shell documentation for proper syntax.")
@@ -116,7 +116,7 @@
 #define REMEDY_FILESIZE_BECAME_EMPTY _("A previously non-empty file is now empty.  Make sure this change is intended and fix the package space file if necessary.")
 
 /* capabilities */
-#define REMEDY_CAPABILITIES _("Unexpected capabilities were found on the indicated file.  Consult capabilities(7) and either adjust the files in the package or modify the capabilities list in the rpminspect vendor data package.  The security team may also be of help for this situation.")
+#define REMEDY_CAPABILITIES _("Unexpected capabilities were found on the indicated file.  Consult capabilities(7) and either adjust the files in the package or modify the capabilities list in the rpminspect vendor data package.  The security team may also be of help for this situation.  If necessary, update %s with the changes found here and send a patch to the project that owns the data file.")
 
 /* kmod */
 #define REMEDY_KMOD_PARM _("Kernel module parameters were removed between builds.  This may present usability problems for users if module parameters were removed in a maintenance update.")
@@ -144,7 +144,7 @@
 #define REMEDY_SYMLINKS _("Make sure symlinks point to a valid destination in one of the subpackages of the build; dangling symlinks are not allowed.  If you are comparing builds and have a non-symlink turn in to a symlink, ensure this is deliberate.  NOTE:  You cannot turn a directory in to a symlink due to RPM limitations.");
 #define REMEDY_SYMLINKS_DIRECTORY _("Make sure symlinks point to a valid destination in one of the subpackages of the build; dangling symlinks are not allowed.  If you are comparing builds and have a non-symlink turn in to a symlink, ensure this is deliberate.  NOTE:  You cannot turn a directory in to a symlink due to RPM limitations.  If you absolutely must do that, make sure you include the %pretrans scriptlet for replacing a directory.  See the packaging guidelines for 'Scriptlet to replace a directory' for more information.");
 
-/* %files */
+/* files */
 #define REMEDY_FILES _("Remove forbidden path references from the indicated line in the %files section.  In many cases you can use RPM macros to specify path locations.  See the RPM documentation or distribution package maintainer guide for more information.")
 
 /* types */
@@ -169,7 +169,7 @@
 #define REMEDY_VIRUS _("ClamAV has found a virus in the named file.  This may be a false positive, but you should manually inspect the file in question to ensure it is clean.  This may be a problem with the ClamAV database or detection.  If you are sure the file in question is clean, please file a bug with rpminspect for further help.")
 
 /* politics */
-#define REMEDY_POLITICS _("A file with potential politically sensitive content was found in the package.  If this file is permitted, it should be added to the rpminspect vendor data package for the product.")
+#define REMEDY_POLITICS _("A file with potential politically sensitive content was found in the package.  If this file is permitted, it should be added to the rpminspect vendor data package for the product.  Modify the %s file and send a patch to the project that owns it.")
 
 /* badfuncs */
 #define REMEDY_BADFUNCS _("Forbidden symbols were found in an ELF file in the package.  The configuration settings for rpminspect indicate the named symbols are forbidden in packages.  If this is deliberate, you may want to disable the badfuncs inspection.  If it is not deliberate, check the man pages for the named symbols to see what API functions have replaced the forbidden symbols.  Usually a function is marked as deprecated but still provided in order to allow for backwards compatibility.  Whenever possible the deprecated functions should not be used.")

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -269,9 +269,9 @@ char *run_cmd(int *, const char *, ...) __attribute__((__sentinel__));
 void free_argv_table(struct rpminspect *ri, string_list_map_t *table);
 
 /* fileinfo.c */
-bool match_fileinfo_mode(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *);
-bool match_fileinfo_owner(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *);
-bool match_fileinfo_group(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *);
+bool match_fileinfo_mode(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *);
+bool match_fileinfo_owner(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *);
+bool match_fileinfo_group(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *);
 caps_filelist_entry_t *get_caps_entry(struct rpminspect *, const char *, const char *);
 
 /* flags.c */

--- a/include/types.h
+++ b/include/types.h
@@ -165,7 +165,7 @@ struct result_params {
     const char *header;
     char *msg;
     char *details;
-    const char *remedy;
+    char *remedy;
     verb_t verb;
     const char *noun;
     const char *arch;
@@ -178,7 +178,7 @@ typedef struct _results_entry_t {
     const char *header;       /* header string for reporting */
     char *msg;                /* the result message */
     char *details;            /* details (optional, can be NULL) */
-    const char *remedy;       /* suggested correction for the result */
+    char *remedy;             /* suggested correction for the result */
     verb_t verb;              /* verb indicating what happened */
     char *noun;               /* noun impacted by 'verb', one line
                                  (e.g., a file path or an RPM dependency
@@ -343,11 +343,16 @@ struct rpminspect {
     favor_release_t favor_release;
 
     /* Populated at runtime for the product release */
+    char *fileinfo_filename;
     fileinfo_t *fileinfo;
     caps_t *caps;
+    char *caps_filename;
     string_list_t *rebaseable;
+    char *rebaseable_filename;
     politics_list_t *politics;
+    char *politics_filename;
     security_list_t *security;
+    char *security_filename;
     bool security_initialized;
 
     /* Koji information (from config file) */

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -37,10 +37,11 @@
  * @param header The header string to use for results reporting if the
  *               file is found.
  * @param remedy The remedy string to use for results reporting if the
- *               file is found.
+ *               file is found.  Must contain a %s for fname.
+ * @param fname The filename of the data package file to update.
  * @return True if the file is on the fileinfo list, false otherwise.
  */
-bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, const char *header, const char *remedy)
+bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, const char *header, const char *remedy, const char *fname)
 {
     fileinfo_entry_t *fientry = NULL;
     mode_t interesting = S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO;
@@ -51,6 +52,10 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
     assert(ri != NULL);
     assert(file != NULL);
 
+    if (remedy) {
+        assert(fname != NULL);
+    }
+
     perms = file->st.st_mode & interesting;
     pkg = headerGetString(file->rpm_header, RPMTAG_NAME);
 
@@ -58,7 +63,10 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
     params.header = header;
     params.arch = get_rpm_header_arch(file->rpm_header);
     params.file = file->localpath;
-    params.remedy = remedy;
+
+    if (remedy) {
+        xasprintf(&params.remedy, remedy, fname);
+    }
 
     if (init_fileinfo(ri)) {
         TAILQ_FOREACH(fientry, ri->fileinfo, items) {
@@ -69,6 +77,7 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
                     params.waiverauth = NOT_WAIVABLE;
                     add_result(ri, &params);
                     free(params.msg);
+                    free(params.remedy);
                     return true;
                 } else {
                     xasprintf(&params.msg, _("%s in %s on %s carries mode %04o, is on the fileinfo list but expected mode %04o"), file->localpath, pkg, params.arch, perms, fientry->mode);
@@ -76,6 +85,7 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
                     params.waiverauth = WAIVABLE_BY_SECURITY;
                     add_result(ri, &params);
                     free(params.msg);
+                    free(params.remedy);
                     return true;
                 }
 
@@ -91,8 +101,11 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
         params.waiverauth = WAIVABLE_BY_SECURITY;
         add_result(ri, &params);
         free(params.msg);
+        free(params.remedy);
+        params.remedy = NULL;
     }
 
+    free(params.remedy);
     return false;
 }
 
@@ -106,10 +119,11 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
  * @param header The header string to use for results reporting if the
  *               file is found.
  * @param remedy The remedy string to use for results reporting if the
- *               file is found.
+ *               file is found.  Must contain %s for fname.
+ * @param fname The filename of the data package file to update.
  * @return True if the file is on the fileinfo list, false otherwise.
  */
-bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, const char *owner, const char *header, const char *remedy)
+bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, const char *owner, const char *header, const char *remedy, const char *fname)
 {
     fileinfo_entry_t *fientry = NULL;
     const char *pkg = NULL;
@@ -119,13 +133,20 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
     assert(file != NULL);
     assert(owner != NULL);
 
+    if (remedy) {
+        assert(fname != NULL);
+    }
+
     pkg = headerGetString(file->rpm_header, RPMTAG_NAME);
 
     init_result_params(&params);
     params.header = header;
     params.arch = get_rpm_header_arch(file->rpm_header);
     params.file = file->localpath;
-    params.remedy = remedy;
+
+    if (remedy) {
+        xasprintf(&params.remedy, remedy, fname);
+    }
 
     if (init_fileinfo(ri)) {
         TAILQ_FOREACH(fientry, ri->fileinfo, items) {
@@ -136,6 +157,7 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
                     params.waiverauth = NOT_WAIVABLE;
                     add_result(ri, &params);
                     free(params.msg);
+                    free(params.remedy);
                     return true;
                 } else {
                     xasprintf(&params.msg, _("%s in %s on %s carries owner '%s', but is on the fileinfo list with expected owner '%s'"), file->localpath, pkg, params.arch, owner, fientry->owner);
@@ -143,6 +165,7 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
                     params.waiverauth = WAIVABLE_BY_SECURITY;
                     add_result(ri, &params);
                     free(params.msg);
+                    free(params.remedy);
                     return true;
                 }
 
@@ -151,6 +174,7 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
         }
     }
 
+    free(params.remedy);
     return false;
 }
 
@@ -164,10 +188,11 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
  * @param header The header string to use for results reporting if the
  *               file is found.
  * @param remedy The remedy string to use for results reporting if the
- *               file is found.
+ *               file is found.  Must contain %s for fname.
+ * @param fname The filename of the data package file to update.
  * @return True if the file is on the fileinfo list, false otherwise.
  */
-bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, const char *group, const char *header, const char *remedy)
+bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, const char *group, const char *header, const char *remedy, const char *fname)
 {
     fileinfo_entry_t *fientry = NULL;
     const char *pkg = NULL;
@@ -176,13 +201,20 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
     assert(ri != NULL);
     assert(file != NULL);
 
+    if (remedy) {
+        assert(fname != NULL);
+    }
+
     pkg = headerGetString(file->rpm_header, RPMTAG_NAME);
 
     init_result_params(&params);
     params.header = header;
     params.arch = get_rpm_header_arch(file->rpm_header);
     params.file = file->localpath;
-    params.remedy = remedy;
+
+    if (remedy) {
+        xasprintf(&params.remedy, remedy, fname);
+    }
 
     if (init_fileinfo(ri)) {
         TAILQ_FOREACH(fientry, ri->fileinfo, items) {
@@ -193,6 +225,7 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
                     params.waiverauth = NOT_WAIVABLE;
                     add_result(ri, &params);
                     free(params.msg);
+                    free(params.remedy);
                     return true;
                 } else {
                     xasprintf(&params.msg, _("%s in %s on %s carries group '%s', but is on the fileinfo list with expected group '%s'"), file->localpath, pkg, params.arch, group, fientry->group);
@@ -200,6 +233,7 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
                     params.waiverauth = WAIVABLE_BY_SECURITY;
                     add_result(ri, &params);
                     free(params.msg);
+                    free(params.remedy);
                     return true;
                 }
 
@@ -208,6 +242,7 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
         }
     }
 
+    free(params.remedy);
     return false;
 }
 

--- a/lib/free.c
+++ b/lib/free.c
@@ -169,7 +169,6 @@ void free_rpminspect(struct rpminspect *ri) {
             sentry = TAILQ_FIRST(ri->security);
             TAILQ_REMOVE(ri->security, sentry, items);
 
-            free(sentry->path);
             free(sentry->pkg);
             free(sentry->ver);
             free(sentry->rel);

--- a/lib/free.c
+++ b/lib/free.c
@@ -116,6 +116,8 @@ void free_rpminspect(struct rpminspect *ri) {
         free(ri->fileinfo);
     }
 
+    free(ri->fileinfo_filename);
+
     if (ri->caps) {
         while (!TAILQ_EMPTY(ri->caps)) {
             centry = TAILQ_FIRST(ri->caps);
@@ -143,7 +145,9 @@ void free_rpminspect(struct rpminspect *ri) {
         free(ri->caps);
     }
 
+    free(ri->caps_filename);
     list_free(ri->rebaseable, free);
+    free(ri->rebaseable_filename);
 
     if (ri->politics) {
         while (!TAILQ_EMPTY(ri->politics)) {
@@ -158,11 +162,14 @@ void free_rpminspect(struct rpminspect *ri) {
         free(ri->politics);
     }
 
+    free(ri->politics_filename);
+
     if (ri->security) {
         while (!TAILQ_EMPTY(ri->security)) {
             sentry = TAILQ_FIRST(ri->security);
             TAILQ_REMOVE(ri->security, sentry, items);
 
+            free(sentry->path);
             free(sentry->pkg);
             free(sentry->ver);
             free(sentry->rel);
@@ -180,6 +187,7 @@ void free_rpminspect(struct rpminspect *ri) {
         free(ri->security);
     }
 
+    free(ri->security_filename);
     list_free(ri->badwords, free);
 
     free_regex(ri->elf_path_include);

--- a/lib/init.c
+++ b/lib/init.c
@@ -1649,8 +1649,6 @@ bool init_security(struct rpminspect *ri)
             assert(sentry != NULL);
 
             /* the main values of a rule */
-            free(sentry->path);
-            sentry->path = strdup(path);
             free(sentry->pkg);
             sentry->pkg = strdup(pkg);
             free(sentry->ver);

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -91,9 +91,9 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.severity = RESULT_BAD;
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_ADDEDFILES;
-    params.remedy = REMEDY_ADDEDFILES;
     params.arch = arch;
     params.file = file->localpath;
+    xasprintf(&params.remedy, REMEDY_ADDEDFILES, ri->fileinfo_filename);
 
     /* Check for any forbidden path prefixes */
     if (ri->forbidden_path_prefixes && (ri->tests & INSPECT_ADDEDFILES)) {
@@ -169,7 +169,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Check for any new setuid or setgid files */
     if (!S_ISDIR(file->st.st_mode) && (file->st.st_mode & (S_ISUID|S_ISGID))) {
-        match_fileinfo_mode(ri, file, NAME_ADDEDFILES, REMEDY_ADDEDFILES);
+        match_fileinfo_mode(ri, file, NAME_ADDEDFILES, REMEDY_ADDEDFILES, ri->fileinfo_filename);
         goto done;
     }
 
@@ -190,6 +190,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
 done:
     free(params.msg);
+    free(params.remedy);
 
     return result;
 }

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -89,13 +89,14 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (beforecap && aftercap) {
         if (cap_compare(beforecap, aftercap)) {
             xasprintf(&params.msg, _("File capabilities for %s changed from '%s' to '%s' on %s\n"), file->localpath, before, after, arch);
+            xasprintf(&params.remedy, REMEDY_CAPABILITIES, ri->caps_filename);
             params.severity = RESULT_VERIFY;
             params.waiverauth = WAIVABLE_BY_SECURITY;
-            params.remedy = REMEDY_CAPABILITIES;
             params.verb = VERB_CHANGED;
             params.noun = _("${FILE} capabilities");
             add_result(ri, &params);
             free(params.msg);
+            free(params.remedy);
             result = false;
         } else if (!cap_compare(beforecap, aftercap) && (ri->tests & INSPECT_CAPABILITIES)) {
             xasprintf(&params.msg, _("File capabilities found for %s: '%s' on %s\n"), file->localpath, after, arch);
@@ -129,34 +130,37 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             free(params.msg);
         } else {
             xasprintf(&params.msg, _("File capabilities list mismatch for %s: expected '%s', got '%s'\n"), file->localpath, flcaps->caps, arch);
+            xasprintf(&params.remedy, REMEDY_CAPABILITIES, ri->caps_filename);
             params.severity = RESULT_BAD;
             params.waiverauth = WAIVABLE_BY_SECURITY;
-            params.remedy = REMEDY_CAPABILITIES;
             params.verb = VERB_FAILED;
             params.noun = _("${FILE} capabilities list");
             add_result(ri, &params);
             free(params.msg);
+            free(params.remedy);
             result = false;
         }
     } else if (aftercap && cap_compare(aftercap, expected)) {
         xasprintf(&params.msg, _("File capabilities for %s not found on the capabilities list on %s\n"), file->localpath, arch);
+        xasprintf(&params.remedy, REMEDY_CAPABILITIES, ri->caps_filename);
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_SECURITY;
-        params.remedy = REMEDY_CAPABILITIES;
         params.verb = VERB_REMOVED;
         params.noun = _("${FILE} capabilities list");
         add_result(ri, &params);
         free(params.msg);
+        free(params.remedy);
         result = false;
     } else if (!aftercap && expected) {
         xasprintf(&params.msg, _("File capabilities expected for %s but not found on %s: expected '%s'\n"), file->localpath, arch, flcaps->caps);
+        xasprintf(&params.remedy, REMEDY_CAPABILITIES, ri->caps_filename);
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_SECURITY;
-        params.remedy = REMEDY_CAPABILITIES;
         params.verb = VERB_FAILED;
         params.noun = _("${FILE} capabilities list");
         add_result(ri, &params);
         free(params.msg);
+        free(params.remedy);
         result = false;
     }
 

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -75,22 +75,24 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Report forbidden file owners */
     if (ri->forbidden_owners && list_contains(ri->forbidden_owners, owner) && (ri->tests & INSPECT_OWNERSHIP)) {
         xasprintf(&params.msg, _("File %s has forbidden owner `%s` on %s"), file->localpath, owner, arch);
+        xasprintf(&params.remedy, REMEDY_OWNERSHIP_DEFATTR, ri->fileinfo_filename);
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.remedy = REMEDY_OWNERSHIP_DEFATTR;
         add_result(ri, &params);
         free(params.msg);
+        free(params.remedy);
         result = false;
     }
 
     /* Report forbidden file groups */
     if (ri->forbidden_groups && list_contains(ri->forbidden_groups, group) && (ri->tests & INSPECT_OWNERSHIP)) {
         xasprintf(&params.msg, _("File %s has forbidden group `%s` on %s"), file->localpath, owner, arch);
+        xasprintf(&params.remedy, REMEDY_OWNERSHIP_DEFATTR, ri->fileinfo_filename);
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.remedy = REMEDY_OWNERSHIP_DEFATTR;
         add_result(ri, &params);
         free(params.msg);
+        free(params.remedy);
         result = false;
     }
 
@@ -100,13 +102,14 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             bin = true;
 
             /* Check the owner */
-            if (strcmp(owner, ri->bin_owner) && !match_fileinfo_owner(ri, file, owner, NAME_OWNERSHIP, NULL) && (ri->tests & INSPECT_OWNERSHIP)) {
+            if (strcmp(owner, ri->bin_owner) && !match_fileinfo_owner(ri, file, owner, NAME_OWNERSHIP, NULL, NULL) && (ri->tests & INSPECT_OWNERSHIP)) {
                 xasprintf(&params.msg, _("File %s has owner `%s` on %s, but should be `%s`"), file->localpath, owner, arch, ri->bin_owner);
+                xasprintf(&params.remedy, REMEDY_OWNERSHIP_BIN_OWNER, ri->fileinfo_filename);
                 params.severity = RESULT_BAD;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
-                params.remedy = REMEDY_OWNERSHIP_BIN_OWNER;
                 add_result(ri, &params);
                 free(params.msg);
+                free(params.remedy);
                 result = false;
             }
 
@@ -133,30 +136,33 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 if (have_setuid == CAP_SET) {
                     if ((file->st.st_mode & S_IXOTH) && (ri->tests & INSPECT_OWNERSHIP)) {
                         xasprintf(&params.msg, _("File %s on %s has CAP_SETUID capability but group `%s` and is world executable"), file->localpath, arch, group);
+                        xasprintf(&params.remedy, REMEDY_OWNERSHIP_IXOTH, ri->fileinfo_filename);
                         params.severity = RESULT_BAD;
                         params.waiverauth = WAIVABLE_BY_SECURITY;
-                        params.remedy = REMEDY_OWNERSHIP_IXOTH;
                         add_result(ri, &params);
                         free(params.msg);
+                        free(params.remedy);
                         result = false;
                     }
 
                     if (file->st.st_mode & S_IWGRP) {
                         xasprintf(&params.msg, _("File %s on %s has CAP_SETUID capability but group `%s` and is group writable"), file->localpath, arch, group);
+                        xasprintf(&params.remedy, REMEDY_OWNERSHIP_IWGRP, ri->fileinfo_filename);
                         params.severity = RESULT_BAD;
                         params.waiverauth = WAIVABLE_BY_SECURITY;
-                        params.remedy = REMEDY_OWNERSHIP_IWGRP;
                         add_result(ri, &params);
                         free(params.msg);
+                        free(params.remedy);
                         result = false;
                     }
-                } else if (!match_fileinfo_group(ri, file, group, NAME_OWNERSHIP, NULL) && (ri->tests & INSPECT_OWNERSHIP)) {
+                } else if (!match_fileinfo_group(ri, file, group, NAME_OWNERSHIP, NULL, NULL) && (ri->tests & INSPECT_OWNERSHIP)) {
                     xasprintf(&params.msg, _("File %s has group `%s` on %s, but should be `%s`"), file->localpath, group, arch, ri->bin_group);
+                    xasprintf(&params.remedy, REMEDY_OWNERSHIP_BIN_GROUP, ri->fileinfo_filename);
                     params.severity = RESULT_BAD;
                     params.waiverauth = WAIVABLE_BY_ANYONE;
-                    params.remedy = REMEDY_OWNERSHIP_BIN_GROUP;
                     add_result(ri, &params);
                     free(params.msg);
+                    free(params.remedy);
                     result = false;
                 }
             }
@@ -215,9 +221,10 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             free(params.msg);
             xasprintf(&params.msg, _("File %s changed %s from `%s` to `%s` on %s"), file->localpath, what, before_val, after_val, arch);
-            params.remedy = REMEDY_OWNERSHIP_CHANGED;
+            xasprintf(&params.remedy, REMEDY_OWNERSHIP_CHANGED, ri->fileinfo_filename);
             add_result(ri, &params);
             free(params.msg);
+            free(params.remedy);
             result = false;
         }
 

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -65,7 +65,7 @@ static bool permissions_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     mode_diff = before_mode ^ after_mode;
-    allowed = match_fileinfo_mode(ri, file, NAME_PERMISSIONS, NULL);
+    allowed = match_fileinfo_mode(ri, file, NAME_PERMISSIONS, NULL, NULL);
 
     /* if setuid/setgid or new mode is more open */
     if (mode_diff && file->peer_file && !allowed && (ri->tests & INSPECT_PERMISSIONS)) {

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -136,7 +136,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.arch = get_rpm_header_arch(file->rpm_header);
         params.file = file->localpath;
         params.header = NAME_POLITICS;
-        params.remedy = REMEDY_POLITICS;
+        xasprintf(&params.remedy, REMEDY_POLITICS, ri->politics_filename);
 
         if (allowed) {
             xasprintf(&params.msg, _("Possible politically sensitive file (%s) found in %s on %s: rules allow this file."), file->localpath, name, params.arch);
@@ -153,6 +153,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         add_result(ri, &params);
         free(params.msg);
+        free(params.remedy);
     }
 
     return result;

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -163,12 +163,11 @@ bool inspect_upstream(struct rpminspect *ri)
         /* versions changed */
         params.severity = RESULT_INFO;
         params.waiverauth = NOT_WAIVABLE;
-        params.remedy = NULL;
     } else {
         /* versions are the same, likely maintenance */
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.remedy = REMEDY_UPSTREAM;
+        xasprintf(&params.remedy, REMEDY_UPSTREAM, ri->rebaseable_filename);
     }
 
     /* Run the main inspection */
@@ -212,9 +211,12 @@ bool inspect_upstream(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.msg = NULL;
+        free(params.remedy);
         params.remedy = NULL;
         add_result(ri, &params);
     }
+
+    free(params.remedy);
 
     return result;
 }

--- a/lib/results.c
+++ b/lib/results.c
@@ -73,6 +73,8 @@ void free_results(results_t *results) {
         entry->msg = NULL;
         free(entry->details);
         entry->details = NULL;
+        free(entry->remedy);
+        entry->remedy = NULL;
         free(entry->noun);
         entry->noun = NULL;
         free(entry->arch);
@@ -133,7 +135,7 @@ void add_result_entry(results_t **results, struct result_params *params)
     }
 
     if (params->remedy != NULL) {
-        entry->remedy = params->remedy;
+        entry->remedy = strdup(params->remedy);
     }
 
     entry->verb = params->verb;


### PR DESCRIPTION
For some inspections the correct thing to do may be to edit the data
file from the vendor data package.  Improve these remedy strings by
reporting what file to change and advise users to send a patch.  I say
send a patch here to avoid using git-specific terminology because I
know if I do that, then we'll replace git with something and the git
terminology will be outdated.

Signed-off-by: David Cantrell <dcantrell@redhat.com>