### PR TITLE
[ci] Simplify ci.yml with the i686 and x86_64 fedora builds

### DIFF
--- a/.github/workflows/ci-i686.yml
+++ b/.github/workflows/ci-i686.yml
@@ -1,0 +1,82 @@
+name: CI on i686
+
+on:
+    push:
+        branches: [ master ]
+        paths-ignore:
+        - AUTHORS.md
+        - CC-BY-4.0.txt
+        - CODE_OF_CONDUCT.md
+        - COPYING
+        - COPYING.LIB
+        - HISTORY
+        - LICENSE-2.0.txt
+        - MISSING
+        - README.md
+        - TODO
+        - 'contrib/**'
+        - 'data/**'
+        - 'doc/**'
+        - 'po/**'
+        - 'regress/**'
+        - 'utils/**'
+
+    pull_request:
+        branches: [ master ]
+        paths-ignore:
+        - AUTHORS.md
+        - CC-BY-4.0.txt
+        - CODE_OF_CONDUCT.md
+        - COPYING
+        - COPYING.LIB
+        - HISTORY
+        - LICENSE-2.0.txt
+        - MISSING
+        - README.md
+        - TODO
+        - 'contrib/**'
+        - 'data/**'
+        - 'doc/**'
+        - 'po/**'
+        - 'regress/**'
+        - 'utils/**'
+
+jobs:
+    # Fedora Linux
+    fedora-i686:
+        # Use containers on their ubuntu latest image
+        runs-on: ubuntu-latest
+
+        # Set up the matrix of distributions to test
+        strategy:
+            matrix:
+                container: ["fedora:rawhide", "fedora:latest"]
+
+        container:
+            image: ${{ matrix.container }}
+
+        # All of these steps run from within the main source
+        # directory, so think of that as your $PWD
+        steps:
+            # This means clone the git repo
+            - uses: actions/checkout@v2.1.0
+
+            # Some housekeeping
+            - name: Package housekeeping
+              run: |
+                  case "${{ matrix.container }}" in
+                      fedora*)
+                          dnf remove -y fedora-repos-modular
+                          dnf install -y make
+                          ;;
+                  esac
+
+            # 32-bit build
+            - name: Build and run the test suite on i686
+              run: |
+                  make instreqs OSDEPS_ARCH=i686
+                  env CFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig meson setup build --werror -Db_buildtype=debug -Db_coverage=true
+                  ninja -C build -v
+                  meson test -C build -v
+                  ninja -C build coverage
+                  curl -s https://codecov.io/bash | bash

--- a/.github/workflows/ci-x86_64.yml
+++ b/.github/workflows/ci-x86_64.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI on x86_64
 
 on:
     push:
@@ -43,7 +43,7 @@ on:
 
 jobs:
     # Fedora Linux
-    fedora:
+    fedora-x86_64:
         # Use containers on their ubuntu latest image
         runs-on: ubuntu-latest
 
@@ -71,19 +71,9 @@ jobs:
                           ;;
                   esac
 
-            # 32-bit build
-            - name: Build and run the test suite on i686
-              run: |
-                  make clean
-                  make instreqs OSDEPS_ARCH=i686
-                  env CFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig meson setup build --werror -Db_buildtype=debug -Db_coverage=true
-                  ninja -C build -v
-                  meson test -C build -v
-
             # 64-bit build
             - name: Build and run the test suite on x86_64
               run: |
-                  make clean
                   make instreqs
                   meson setup build --werror -Db_buildtype=debug -Db_coverage=true
                   ninja -C build -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,14 @@ jobs:
                   case "${{ matrix.container }}" in
                       fedora*)
                           dnf remove -y fedora-repos-modular
-                          dnf install -y make git
+                          dnf install -y make
                           ;;
                   esac
 
             # 32-bit build
             - name: Build and run the test suite on i686
               run: |
-                  git clean -d -x -f
+                  make clean
                   make instreqs OSDEPS_ARCH=i686
                   env CFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig meson setup build --werror -Db_buildtype=debug -Db_coverage=true
                   ninja -C build -v
@@ -83,7 +83,7 @@ jobs:
             # 64-bit build
             - name: Build and run the test suite on x86_64
               run: |
-                  git clean -d -x -f
+                  make clean
                   make instreqs
                   meson setup build --werror -Db_buildtype=debug -Db_coverage=true
                   ninja -C build -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ on:
         - 'utils/**'
 
 jobs:
-    # Fedora on x86_64
-    x86_64:
+    # Fedora Linux
+    fedora:
         # Use containers on their ubuntu latest image
         runs-on: ubuntu-latest
 
@@ -61,44 +61,8 @@ jobs:
             # This means clone the git repo
             - uses: actions/checkout@v2.1.0
 
-            # Within the container, install the dependencies, build,
-            # and run the test suite
-            - name: Build and run the test suite
-              run: |
-                  case "${{ matrix.container }}" in
-                      fedora*)
-                          dnf install -y make
-                          ;;
-                  esac
-                  make instreqs
-                  meson setup build --werror -Db_buildtype=debug -Db_coverage=true
-                  ninja -C build -v
-                  meson test -C build -v
-                  ninja -C build coverage
-                  curl -s https://codecov.io/bash | bash
-
-    # Fedora on i386
-    i386:
-        # Use containers on their ubuntu latest image
-        runs-on: ubuntu-latest
-
-        # Set up the matrix of distributions to test
-        strategy:
-            matrix:
-                container: ["fedora:rawhide", "fedora:latest"]
-
-        container:
-            image: ${{ matrix.container }}
-
-        # All of these steps run from within the main source
-        # directory, so think of that as your $PWD
-        steps:
-            # This means clone the git repo
-            - uses: actions/checkout@v2.1.0
-
-            # Within the container, install the dependencies, build,
-            # and run the test suite
-            - name: Build and run the test suite
+            # Some housekeeping
+            - name: Package housekeeping
               run: |
                   case "${{ matrix.container }}" in
                       fedora*)
@@ -106,8 +70,22 @@ jobs:
                           dnf install -y make
                           ;;
                   esac
+
+            # 32-bit build
+            - name: Build and run the test suite on i686
+              run: |
+                  git clean -d -x -f
                   make instreqs OSDEPS_ARCH=i686
                   env CFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig meson setup build --werror -Db_buildtype=debug -Db_coverage=true
+                  ninja -C build -v
+                  meson test -C build -v
+
+            # 64-bit build
+            - name: Build and run the test suite on x86_64
+              run: |
+                  git clean -d -x -f
+                  make instreqs
+                  meson setup build --werror -Db_buildtype=debug -Db_coverage=true
                   ninja -C build -v
                   meson test -C build -v
                   ninja -C build coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
                   case "${{ matrix.container }}" in
                       fedora*)
                           dnf remove -y fedora-repos-modular
-                          dnf install -y make
+                          dnf install -y make git
                           ;;
                   esac
 


### PR DESCRIPTION
Just perform them back to back in the same containers.

Signed-off-by: David Cantrell <dcantrell@redhat.com>