### PR TITLE
[bld] Update the spec file template

### DIFF
--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -10,8 +10,9 @@ Group:          Development/Tools
 # license.
 License:        GPLv3+ and LGPLv2+ and ASL 2.0 and CC-BY
 URL:            https://github.com/rpminspect/rpminspect
-Source0:        https://github.com/rpminspect/rpminspect/releases/download/v%%VERSION%%/%%TARBALL%%
-Source1:        changelog
+Source0:        https://github.com/rpminspect/rpminspect/releases/download/v%{version}/%{name}-%{version}.tar.xz
+Source1:        https://github.com/rpminspect/rpminspect/releases/download/v%{version}/%{name}-%{version}.tar.xz.asc
+Source2:        %%GPGKEYRING%%
 Requires:       librpminspect%{?_isa} = %{version}-%{release}
 
 BuildRequires:  meson
@@ -34,6 +35,7 @@ BuildRequires:  libcap-devel
 BuildRequires:  gettext-devel
 BuildRequires:  clamav-devel
 BuildRequires:  libmandoc-devel >= 1.14.5
+BuildRequires:  gnupg2
 
 
 %description
@@ -122,7 +124,8 @@ control files.
 
 
 %prep
-%setup -q
+%{gpgverify} --keyring='%{SOURCE2}' --signature='%{SOURCE1}' --data='%{SOURCE0}'
+%autosetup
 
 
 %build
@@ -159,4 +162,3 @@ control files.
 
 
 %changelog
-%include %{SOURCE1}


### PR DESCRIPTION
Get rid of the separate changelog included as Source1.  Include the
detached signature (.asc) as Source1 instead and Source2 is the GPG
keyring used to validate the source archive signature.

In %prep, use %gpgverify and %autosetup.  And drop everything after
%changelog as that will be handled by the submit-koji-builds.sh script
so that changelog in the spec only exists downstream.

Fixes: #507

Signed-off-by: David Cantrell <dcantrell@redhat.com>