### PR TITLE
Support %autorelease and other system wide macros in the disttag inspection

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -171,6 +171,25 @@ vendor:
     # there is no product release regexp mapping enabled.
     #- fc31: ^\.fc31.*$
 
+macrofiles:
+    # Paths to all RPM macro definitions that rpminspect should use.
+    # Note that you likely want to _exclude_ ~/.rpmmacros here whereas
+    # rpmbuild will include that by default.  The main reason is
+    # rpminspect is expecting to report portability across system and
+    # any locally defined macros in your home directory can impact
+    # that.
+    #
+    # This is a list of file paths.  glob(7) syntax is allowed as are
+    # RPM macros.
+    - /usr/lib/rpm/macros
+    - /usr/lib/rpm/macros.d/macros.*
+    - /usr/lib/rpm/platform/%{_target}/macros
+    - /usr/lib/rpm/fileattrs/*.attr
+    - /usr/lib/rpm/redhat/macros
+    - /etc/rpm/macros.*
+    - /etc/rpm/macros
+    - /etc/rpm/%{_target}/macros
+
 ignore:
     # Sometimes you want certain files or directories ignored by
     # rpminspect.  This section lets you list paths--glob(3) syntax

--- a/include/types.h
+++ b/include/types.h
@@ -396,6 +396,9 @@ struct rpminspect {
     /* Required subdomain for buildhosts -- multiple subdomains allowed */
     string_list_t *buildhost_subdomain;
 
+    /* Optional: list of RPM macro file paths */
+    string_list_t *macrofiles;
+
     /*
      * Optional: if not NULL, contains list of path prefixes for files
      * that are of security concern.

--- a/lib/free.c
+++ b/lib/free.c
@@ -217,6 +217,7 @@ void free_rpminspect(struct rpminspect *ri) {
     free(ri->commands.kmidiff);
 
     list_free(ri->buildhost_subdomain, free);
+    list_free(ri->macrofiles, free);
     list_free(ri->security_path_prefix, free);
     list_free(ri->header_file_extensions, free);
     list_free(ri->forbidden_path_prefixes, free);

--- a/lib/init.c
+++ b/lib/init.c
@@ -125,7 +125,8 @@ enum {
     BLOCK_XML,
     BLOCK_EMPTYRPM,
     BLOCK_EXPECTED_EMPTY_RPMS,
-    BLOCK_TYPES
+    BLOCK_TYPES,
+    BLOCK_MACROFILES
 };
 
 static int add_regex(const char *pattern, regex_t **regex_out)
@@ -635,6 +636,14 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                                                           group != BLOCK_TYPES)) {
                         block = BLOCK_IGNORE;
                         group = BLOCK_NULL;
+                    } else if (!strcmp(key, "macrofiles")) {
+                        block = BLOCK_MACROFILES;
+
+                        if (group != BLOCK_MACROFILES) {
+                            list_free(ri->macrofiles, free);
+                            ri->macrofiles = NULL;
+                            group = BLOCK_MACROFILES;
+                        }
                     } else if (!strcmp(key, "security_path_prefix")) {
                         block = BLOCK_SECURITY_PATH_PREFIX;
 
@@ -1151,6 +1160,8 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         add_entry(&ri->bad_functions, t);
                     } else if (block == BLOCK_BADWORDS) {
                         add_entry(&ri->badwords, t);
+                    } else if (block == BLOCK_MACROFILES) {
+                        add_entry(&ri->macrofiles, t);
                     } else if (block == BLOCK_SECURITY_PATH_PREFIX) {
                         add_entry(&ri->security_path_prefix, t);
                     } else if (block == BLOCK_BUILDHOST_SUBDOMAIN) {

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+#include <ctype.h>
 #include <regex.h>
 #include <assert.h>
 #include <err.h>
@@ -41,6 +42,7 @@
 int get_specfile_macros(struct rpminspect *ri, const char *specfile)
 {
     int n = 0;
+    char *sl = NULL;
     string_entry_t *specline = NULL;
     string_list_t *spec = NULL;
     string_list_t *fields = NULL;
@@ -96,11 +98,16 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
         }
 
         /* trim line endings */
-        specline->data[strcspn(specline->data, "\r\n")] = 0;
+        sl = specline->data;
+        sl[strcspn(sl, "\r\n")] = 0;
+
+        while (isspace(*sl)) {
+            sl++;
+        }
 
         /* break up fields */
-        DEBUG_PRINT("specline->data: |%s|\n", specline->data);
-        fields = strsplit(specline->data, " ");
+        DEBUG_PRINT("sl=|%s|\n", sl);
+        fields = strsplit(sl, " ");
 
         if (list_len(fields) != 3) {
             /* not a macro line */

--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -60,6 +60,11 @@ Recommends:     xhtml1-dtds
 Recommends:     html401-dtds
 %endif
 
+# Required to support things like %autorelease in spec files
+%if 0%{?fedora} >= 33
+Recommends:     rpmautospec-rpm-macros
+%endif
+
 # These programs are only required for the 'shellsyntax' functionality.
 # You can use rpminspect without these installed, just disable the
 # shellsyntax inspection.


### PR DESCRIPTION
Add a new 'macrofiles' section to the config file.  This section is where you list the file paths (glob(7) syntax and RPM macros are allowed) of all the RPM macro files that should be used when running rpminspect.  This will vary by vendor and platform.

Add macro expansion via librpm to the disttag inspection.  The existing code just did a pass across macros defined in the package's spec file.  Now we load all macros available on the system with the exception of ~/.rpmmacros.  This allows the disttag inspection to work with things like %autorelease or other systemwide macros that handle the dist tag transparently.
    
We still keep the manual pass across local spec files macros to avoid loading the entire spec file as if we are running rpmbuild.
    
The rpminspect.spec.in template also adds a Recommends for rpmautospec-rpm-macros for Fedora releases >= 33.