### PR TITLE
[fix] Remove unnecessary assert() on fname in match_fileinfo_mode

### DIFF
--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -52,10 +52,6 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
     assert(ri != NULL);
     assert(file != NULL);
 
-    if (remedy) {
-        assert(fname != NULL);
-    }
-
     perms = file->st.st_mode & interesting;
     pkg = headerGetString(file->rpm_header, RPMTAG_NAME);
 


### PR DESCRIPTION
This was leftover before I did some refactoring and is unnecessary.

Fixes: #526

Signed-off-by: David Cantrell <dcantrell@redhat.com>