### PR TITLE
[lib] Add list_add() to listfuncs() in librpminspect

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -151,6 +151,7 @@ string_list_t * list_sort(const string_list_t *);
 string_list_t * list_copy(const string_list_t *);
 string_list_t *list_from_array(const char **);
 bool list_contains(const string_list_t *, const char *);
+string_list_t *list_add(string_list_t *list, const char *s);
 
 /* local.c */
 bool is_local_build(const char *);

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -488,3 +488,32 @@ bool list_contains(const string_list_t *list, const char *s)
 
     return false;
 }
+
+/*
+ * Append the string to the string_list_t and return the
+ * string_list_t.  A NULL string is not added and the caller just gets
+ * back a pointer to the same string_list_t.  A NULL list may be
+ * specified, in which case the function will start a new list and add
+ * the string to it.  Caller responsible for all memory management.
+ */
+string_list_t *list_add(string_list_t *list, const char *s)
+{
+    string_entry_t *entry = NULL;
+
+    if (s == NULL) {
+        return list;
+    }
+
+    if (list == NULL) {
+        list = calloc(1, sizeof(*list));
+        assert(list != NULL);
+        TAILQ_INIT(list);
+    }
+
+    entry = calloc(1, sizeof(*entry));
+    assert(entry != NULL);
+    entry->data = strdup(s);
+    TAILQ_INSERT_TAIL(list, entry, items);
+
+    return list;
+}


### PR DESCRIPTION
Given a char * and a string_list_t *, create a new string_entry_t *
and add it to the named list.  If the list is NULL, initialize a new
one and add it to that.

It's really common to append to a string_list_t, so I added a function
for myself.

Signed-off-by: David Cantrell <dcantrell@redhat.com>