### PR TITLE
[fix] Correctly match debuginfo trees to subpackages

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -340,10 +340,11 @@ char *bytes_to_str(unsigned char *array, size_t len);
  *
  * @param ri The struct rpminspect for the program.
  * @param binarch The required debuginfo architecture.
+ * @param subpkg Optional subpackage name to get the debuginfo for.
  * @return Full path to the extract before build debuginfo package, or
  * NULL if not found.
  */
-const char *get_before_debuginfo_path(struct rpminspect *ri, const char *binarch);
+const char *get_before_debuginfo_path(struct rpminspect *ri, const char *binarch, const char *subpkg);
 
 /**
  * @brief Return the after build debuginfo package path where the
@@ -354,10 +355,11 @@ const char *get_before_debuginfo_path(struct rpminspect *ri, const char *binarch
  *
  * @param ri The struct rpminspect for the program.
  * @param binarch The required debuginfo architecture.
+ * @param subpkg Optional subpackage name to get the debuginfo for.
  * @return Full path to the extract after build debuginfo package, or
  * NULL if not found.
  */
-const char *get_after_debuginfo_path(struct rpminspect *ri, const char *binarch);
+const char *get_after_debuginfo_path(struct rpminspect *ri, const char *binarch, const char *subpkg);
 bool usable_path(const char *path);
 bool match_path(const char *pattern, const char *root, const char *needle);
 


### PR DESCRIPTION
The debuginfo matching code was not taking in to account the fact that
a build may include multiple debuginfo subpackages.  A common practice
now in distributions like Fedora Linux is to have one debuginfo
package for each subpackage.  In older distributions the common
practice was to include a single debuginfo package for the entire
build which covered all subpackages.

This patch modifies librpminspect to handle both types of environments
since some RPM systems may still build a single debuginfo package for
the whole build while others may have one per subpackage.

The matching code may need further work in the future depending on how
distribution policies evolve.  A better long term solution would be to
find the matching executable in a candidate debuginfo tree and if that
is found, use that tree.  We'll see how things evolve.

Signed-off-by: David Cantrell <dcantrell@redhat.com>