### PR TITLE
[fix] Remove unnecessary '()' from function names in error messages

### DIFF
--- a/lib/builds.c
+++ b/lib/builds.c
@@ -108,7 +108,7 @@ static void set_worksubdir(struct rpminspect *ri, workdir_t wd, const struct koj
         }
 
         if (mkdtemp(ri->worksubdir) == NULL) {
-            err(RI_PROGRAM_ERROR, "mkdtemp()");
+            err(RI_PROGRAM_ERROR, "mkdtemp");
         }
     }
 
@@ -160,7 +160,7 @@ static void prune_local(const int whichbuild) {
     }
 
     if (closedir(d) == -1) {
-        warn("closedir()");
+        warn("closedir");
         return;
     }
 
@@ -382,7 +382,7 @@ static void curl_helper(const bool verbose, const char *src, const char *dst) {
 
     /* initialize curl */
     if (!(c = curl_easy_init())) {
-        warn("curl_easy_init()");
+        warn("curl_easy_init");
         return;
     }
 
@@ -520,7 +520,7 @@ static int download_build(const struct rpminspect *ri, const struct koji_build *
             }
 
             if (mkdirp(dst, mode)) {
-                warn("mkdirp()");
+                warn("mkdirp");
                 return -1;
             }
 
@@ -534,12 +534,12 @@ static int download_build(const struct rpminspect *ri, const struct koji_build *
             if (filter == NULL) {
                 /* prepare a YAML parser */
                 if (!yaml_parser_initialize(&parser)) {
-                    warn("yaml_parser_initialize()");
+                    warn("yaml_parser_initialize");
                 }
 
                 /* open the modulemd file */
                 if ((fp = fopen(dst, "r")) == NULL) {
-                    err(RI_PROGRAM_ERROR, "fopen()");
+                    err(RI_PROGRAM_ERROR, "fopen");
                 }
 
                 /* initialize a string list for the loop */
@@ -722,7 +722,7 @@ static int download_task(const struct rpminspect *ri, const struct koji_task *ta
         }
 
         if (mkdirp(dst, mode)) {
-            warn("mkdirp()");
+            warn("mkdirp");
             return -1;
         }
 
@@ -740,7 +740,7 @@ static int download_task(const struct rpminspect *ri, const struct koji_task *ta
                 }
 
                 if (mkdirp(dst, mode)) {
-                    warn("mkdirp()");
+                    warn("mkdirp");
                     return -1;
                 }
 
@@ -812,7 +812,7 @@ static int download_rpm(const char *rpm)
     }
 
     if (mkdirp(dstdir, mode)) {
-        warn("mkdirp()");
+        warn("mkdirp");
         return -1;
     }
 
@@ -919,7 +919,7 @@ int gather_builds(struct rpminspect *ri, bool fo) {
 
             /* copy after tree */
             if (nftw(ri->after, copytree, FOPEN_MAX, FTW_PHYS) == -1) {
-                warn("nftw()");
+                warn("nftw");
                 return -1;
             }
 
@@ -929,14 +929,14 @@ int gather_builds(struct rpminspect *ri, bool fo) {
             set_worksubdir(ri, LOCAL_WORKDIR, NULL, NULL);
 
             if (download_rpm(ri->after)) {
-                warn("download_rpm()");
+                warn("download_rpm");
                 return -1;
             }
         } else if (is_task_id(ri->after) && (task = get_koji_task(ri, ri->after)) != NULL) {
             set_worksubdir(ri, TASK_WORKDIR, NULL, task);
 
             if (download_task(ri, task)) {
-                warn("download_task()");
+                warn("download_task");
                 free_koji_task(task);
                 return -1;
             }
@@ -946,7 +946,7 @@ int gather_builds(struct rpminspect *ri, bool fo) {
             set_worksubdir(ri, BUILD_WORKDIR, build, NULL);
 
             if (download_build(ri, build)) {
-                warn("download_build()");
+                warn("download_build");
                 free_koji_build(build);
                 return -1;
             }
@@ -971,7 +971,7 @@ int gather_builds(struct rpminspect *ri, bool fo) {
 
         /* copy before tree */
         if (nftw(ri->before, copytree, FOPEN_MAX, FTW_PHYS) == -1) {
-            warn("nftw()");
+            warn("nftw");
             return -1;
         }
 
@@ -981,14 +981,14 @@ int gather_builds(struct rpminspect *ri, bool fo) {
         set_worksubdir(ri, LOCAL_WORKDIR, NULL, NULL);
 
         if (download_rpm(ri->before)) {
-            warn("download_rpm()");
+            warn("download_rpm");
             return -1;
         }
     } else if (is_task_id(ri->before) && (task = get_koji_task(ri, ri->before)) != NULL) {
         set_worksubdir(ri, TASK_WORKDIR, NULL, task);
 
         if (download_task(ri, task)) {
-            warn("download_task()");
+            warn("download_task");
             free_koji_task(task);
             return -1;
         }
@@ -998,7 +998,7 @@ int gather_builds(struct rpminspect *ri, bool fo) {
         set_worksubdir(ri, BUILD_WORKDIR, build, NULL);
 
         if (download_build(ri, build)) {
-            warn("download_build()");
+            warn("download_build");
             free_koji_build(build);
             return -1;
         }

--- a/lib/checksums.c
+++ b/lib/checksums.c
@@ -113,12 +113,12 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
 
     /* read in the file to generate the requested checksum */
     if ((input = open(filename, O_RDONLY)) == -1) {
-        warn("open()");
+        warn("open");
         return NULL;
     }
 
     if ((len = read(input, buf, sizeof(buf))) == -1) {
-        warn("read()");
+        warn("read");
         return NULL;
     }
 
@@ -135,13 +135,13 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
         }
 
         if ((len = read(input, buf, sizeof(buf))) == -1) {
-            warn("read()");
+            warn("read");
             return NULL;
         }
     }
 
     if (close(input) == -1) {
-        warn("close()");
+        warn("close");
         return NULL;
     }
 
@@ -172,7 +172,7 @@ char *compute_checksum(const char *filename, mode_t *st_mode, enum checksum type
 
     /* this is our human readable digest, caller must free */
     if ((ret = calloc(len + 1, sizeof(char *))) == NULL) {
-        warn("calloc()");
+        warn("calloc");
         return NULL;
     }
 

--- a/lib/copyfile.c
+++ b/lib/copyfile.c
@@ -73,7 +73,7 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose) {
 
     /* stat the source */
     if (lstat(src, &sb) == -1) {
-        warn("lstat()");
+        warn("lstat");
         return -1;
     }
 
@@ -82,7 +82,7 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose) {
     destdir = dirname(destpath);
 
     if (mkdirp(destdir, S_IRWXU) == -1) {
-        warn("mkdirp()");
+        warn("mkdirp");
         return -1;
     }
 
@@ -91,12 +91,12 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose) {
     /* if src is a symlink, handle it here */
     if (S_ISLNK(sb.st_mode)) {
         if (readlink(src, linkdest, PATH_MAX) == -1) {
-            warn("readlink()");
+            warn("readlink");
             return -1;
         }
 
         if (symlink(linkdest, dest) == -1) {
-            warn("symlink()");
+            warn("symlink");
             return -1;
         }
 
@@ -105,7 +105,7 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose) {
 
     /* copy src to dest */
     if ((in = fopen(src, "r")) == NULL) {
-        warn("fopen()");
+        warn("fopen");
         return -1;
     }
 
@@ -121,11 +121,11 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose) {
                 }
 
                 if (remove(dest)) {
-                    warn("remove()");
+                    warn("remove");
                     return -1;
                 } else {
                     if ((out_fd = open(dest, oflags, mode)) == -1) {
-                        warn("open()");
+                        warn("open");
                     }
                 }
             } else {
@@ -134,36 +134,36 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose) {
                 return -1;
             }
         } else {
-            warn("open()");
+            warn("open");
             return -1;
         }
     }
 
     if ((out = fdopen(out_fd, "wb")) == NULL) {
-        warn("fdopen()");
+        warn("fdopen");
         return -1;
     }
 
     while ((s = fread(buf, sizeof(char), BUFSIZ, in)) > 0) {
         if (fwrite(buf, sizeof(char), s, out) != s) {
-            warn("fwrite()");
+            warn("fwrite");
             success = -1;
             break;
         }
     }
 
     if (fflush(out) != 0) {
-        warn("fflush()");
+        warn("fflush");
         success = -1;
     }
 
     if (fclose(out) != 0) {
-        warn("fclose()");
+        warn("fclose");
         success = -1;
     }
 
     if (fclose(in) != 0) {
-        warn("fclose()");
+        warn("fclose");
     }
 
     if (success != 0) {
@@ -173,13 +173,13 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose) {
     /* set ownerships and permissions */
     if (geteuid() == 0) {
         if (chown(dest, sb.st_uid, sb.st_gid) == -1) {
-            warn("chown()");
+            warn("chown");
             success = -1;
         }
     }
 
     if (chmod(dest, (sb.st_mode & (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO))) == -1) {
-        warn("chmod()");
+        warn("chmod");
         success = -1;
     }
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -179,7 +179,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
     }
 
     if (mkdir(*output_dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == -1) {
-        warn("mkdir()");
+        warn("mkdir");
         return NULL;
     }
 
@@ -208,7 +208,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
         rpm_path = rpmtdNextString(td);
 
         if (rpm_path == NULL) {
-            warn("rpmtdNextString()");
+            warn("rpmtdNextString");
             goto cleanup;
         }
 
@@ -231,7 +231,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
     archive_read_support_format_all(archive);
 
     if (archive_read_open_filename(archive, pkg, 10240) != ARCHIVE_OK) {
-        warn("archive_read_open_filename()");
+        warn("archive_read_open_filename");
         goto cleanup;
     }
 
@@ -246,7 +246,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
         }
 
         if (archive_result != ARCHIVE_OK) {
-            warn("archive_read_next_header()");
+            warn("archive_read_next_header");
             free_files(file_list);
             file_list = NULL;
             goto cleanup;
@@ -315,7 +315,7 @@ rpmfile_t *extract_rpm(const char *pkg, Header hdr, char **output_dir)
 
         /* Write the file to disk */
         if (archive_read_extract(archive, entry, archive_flags) != ARCHIVE_OK) {
-            warn("archive_read_extract()");
+            warn("archive_read_extract");
             free_files(file_list);
             file_list = NULL;
             goto cleanup;
@@ -467,7 +467,7 @@ static char *comparable_version_substrings(const char *s, const char *ignore)
 
     if (reg_result != 0) {
         regerror(reg_result, &num_regex, reg_error, sizeof(reg_error));
-        warn("regcomp(): %s", reg_error);
+        warn("regcomp: %s", reg_error);
         return NULL;
     }
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -497,13 +497,13 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
 
     /* prepare a YAML parser */
     if (!yaml_parser_initialize(&parser)) {
-        warn("yaml_parser_initialize()");
+        warn("yaml_parser_initialize");
         return -1;
     }
 
     /* open the config file */
     if ((fp = fopen(filename, "r")) == NULL) {
-        warn("fopen()");
+        warn("fopen");
         return -1;
     }
 
@@ -1072,7 +1072,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                                 ri->size_threshold = strtol(t, 0, 10);
 
                                 if ((ri->size_threshold == LONG_MIN || ri->size_threshold == LONG_MAX) && errno == ERANGE) {
-                                    warn("strtol()");
+                                    warn("strtol");
                                     ri->size_threshold = 0;
                                 }
                             }
@@ -1115,7 +1115,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             ri->abi_security_threshold = strtol(t, 0, 10);
 
                             if ((ri->abi_security_threshold == LONG_MIN || ri->abi_security_threshold == LONG_MAX) && errno == ERANGE) {
-                                warn("strtol()");
+                                warn("strtol");
                                 ri->abi_security_threshold = DEFAULT_ABI_SECURITY_THRESHOLD;
                             }
                         }
@@ -1141,14 +1141,14 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             ri->patch_file_threshold = strtol(t, 0, 10);
 
                             if ((ri->patch_file_threshold == LONG_MIN || ri->patch_file_threshold == LONG_MAX) && errno == ERANGE) {
-                                warn("strtol()");
+                                warn("strtol");
                                 ri->patch_file_threshold = DEFAULT_PATCH_FILE_THRESHOLD;
                             }
                         } else if (!strcmp(key, "line_count_threshold")) {
                             ri->patch_line_threshold = strtol(t, 0, 10);
 
                             if ((ri->patch_line_threshold == LONG_MIN || ri->patch_line_threshold == LONG_MAX) && errno == ERANGE) {
-                                warn("strtol()");
+                                warn("strtol");
                                 ri->patch_line_threshold = DEFAULT_PATCH_LINE_THRESHOLD;
                             }
                         }
@@ -1232,7 +1232,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
     yaml_parser_delete(&parser);
 
     if (fclose(fp) != 0) {
-        warn("fclose()");
+        warn("fclose");
         return -1;
     }
 

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -74,12 +74,12 @@ static char *run_and_capture(const char *where, char **output, char *cmd, const 
     fd = mkstemp(*output);
 
     if (fd == -1) {
-        warn("mkstemp()");
+        warn("mkstemp");
         return false;
     }
 
     if (close(fd) == -1) {
-        warn("close()");
+        warn("close");
         return false;
     }
 
@@ -195,17 +195,17 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         fd = open(file->fullpath, O_RDONLY | O_CLOEXEC | O_LARGEFILE);
 
         if (fd == -1) {
-            warn("open()");
+            warn("open");
             return true;
         }
 
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
-            warn("read()");
+            warn("read");
             return true;
         }
 
         if (close(fd) == -1) {
-            warn("close()");
+            warn("close");
             return true;
         }
 
@@ -353,11 +353,11 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         /* Remove the temporary files */
         if (unlink(before_tmp) == -1) {
-            warn("unlink()");
+            warn("unlink");
         }
 
         if (unlink(after_tmp) == -1) {
-            warn("unlink()");
+            warn("unlink");
         }
 
         if (exitcode) {

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -133,7 +133,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     fd = mkstemp(output);
 
     if (fd == -1) {
-        warn("mkstemp()");
+        warn("mkstemp");
         free(output);
         return NULL;
     }
@@ -141,7 +141,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     logfp = fdopen(fd, "w");
 
     if (logfp == NULL) {
-        warn("fdopen()");
+        warn("fdopen");
         close(fd);
         free(output);
         return NULL;
@@ -152,7 +152,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     }
 
     if (fclose(logfp) != 0) {
-        warn("fclose()");
+        warn("fclose");
         close(fd);
         free(output);
         return NULL;

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -274,7 +274,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
                 found = true;
 
                 if (lstat(file_to_find, &sb) == -1) {
-                    warn("stat()");
+                    warn("stat");
                     list_free(contents, free);
                     free(file_to_find);
                     return false;
@@ -348,7 +348,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
                 found = true;
 
                 if (lstat(file_to_find, &sb) == -1) {
-                    warn("stat()");
+                    warn("stat");
                     list_free(contents, free);
                     free(file_to_find);
                     return false;

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -63,17 +63,17 @@ static short get_jvm_major(const char *filename, const char *localpath,
         fd = open(filename, O_RDONLY | O_CLOEXEC | O_LARGEFILE);
 
         if (fd == -1) {
-            warn("open()");
+            warn("open");
             return -1;
         }
 
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
-            warn("read()");
+            warn("read");
             return -1;
         }
 
         if (close(fd) == -1) {
-            warn("close()");
+            warn("close");
             return -1;
         }
 
@@ -183,7 +183,7 @@ static bool javabytecode_driver(struct rpminspect *ri, rpmfile_entry_t *file, co
         tmppath = mkdtemp(tmppath);
 
         if (tmppath == NULL) {
-            warn("mkdtemp()");
+            warn("mkdtemp");
             free(tmppath);
             return false;
         }
@@ -203,7 +203,7 @@ static bool javabytecode_driver(struct rpminspect *ri, rpmfile_entry_t *file, co
 
         if (jarstatus != 0) {
             /* we errored somewhere, just report it */
-            warn("nftw()");
+            warn("nftw");
         }
 
         /* clean up */

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -146,7 +146,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     kctx = kmod_new(NULL, NULL);
 
     if (kctx == NULL) {
-        warn("kmod_new()");
+        warn("kmod_new");
         return false;
     }
 
@@ -163,7 +163,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     kctx = kmod_new(NULL, NULL);
 
     if (kctx == NULL) {
-        warn("kmod_new()");
+        warn("kmod_new");
         return false;
     }
 
@@ -180,7 +180,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Gather module parameters */
     err = kmod_module_get_info(beforekmod, &beforeinfo);
     if (err < 0) {
-        warn("kmod_module_get_info()");
+        warn("kmod_module_get_info");
         kmod_module_unref(beforekmod);
         kmod_module_unref(afterkmod);
         kmod_unref(kctx);
@@ -189,7 +189,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     err = kmod_module_get_info(afterkmod, &afterinfo);
     if (err < 0) {
-        warn("kmod_module_get_info()");
+        warn("kmod_module_get_info");
         kmod_module_info_free_list(beforeinfo);
         kmod_module_unref(beforekmod);
         kmod_module_unref(afterkmod);

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -75,7 +75,7 @@ static struct json_object *read_licensedb(const char *licensedb)
     jerr = json_tokener_get_error(tok);
 
     if (jerr != json_tokener_success) {
-        warnx("json_tokener_parse_ex(): %s", json_tokener_error_desc(jerr));
+        warnx("json_tokener_parse_ex: %s", json_tokener_error_desc(jerr));
     }
 
     json_tokener_free(tok);

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -203,7 +203,7 @@ static char *inspect_manpage_validity(const char *path, const char *localpath)
         fprintf(error_stream, _("Man page %s does not end in %s\n"), path, GZIPPED_FILENAME_EXTENSION);
     } else {
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
-            fprintf(error_stream, "read(): %s\n", strerror(errno));
+            fprintf(error_stream, "read: %s\n", strerror(errno));
             goto end;
         }
 
@@ -213,7 +213,7 @@ static char *inspect_manpage_validity(const char *path, const char *localpath)
 
         /* Reset the fd and continue */
         if (lseek(fd, 0, SEEK_SET) == -1) {
-            fprintf(error_stream, "lseek(): %s\n", strerror(errno));
+            fprintf(error_stream, "lseek: %s\n", strerror(errno));
             goto end;
         }
     }
@@ -320,7 +320,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             result = false;
             free(params.msg);
         } else if (r == -1) {
-            warn("stat()");
+            warn("stat");
         }
 
         free(uncompressed_man_page);

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -127,7 +127,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
                 if (cap) {
                     if (cap_get_flag(cap, CAP_SETUID, CAP_EFFECTIVE, &have_setuid) == -1) {
-                        warnx("cap_get_flag()");
+                        warnx("cap_get_flag");
                         have_setuid = CAP_CLEAR;
                     }
                 }

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -195,7 +195,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
      * generating multiple patches against multiple branches.
      */
     if (stat(after_patch, &sb) != 0) {
-        warn("stat()");
+        warn("stat");
         return false;
     }
 

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -172,7 +172,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
 
                         if (reg_result != 0) {
                             regerror(reg_result, &origin_root, reg_error, sizeof(reg_error));
-                            warn("regexec(): %s", reg_error);
+                            warn("regexec: %s", reg_error);
                             regfree(&origin_root);
                             continue;
                         }

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -50,7 +50,7 @@ static char *get_shell(const struct rpminspect *ri, const char *fullpath)
     fp = fopen(fullpath, "r");
 
     if (fp == NULL) {
-        warn("fopen()");
+        warn("fopen");
         return NULL;
     }
 
@@ -58,11 +58,11 @@ static char *get_shell(const struct rpminspect *ri, const char *fullpath)
     start = buf;
 
     if (fclose(fp) == -1) {
-        warn("fclose()");
+        warn("fclose");
     }
 
     if (r == -1) {
-        warn("getline()");
+        warn("getline");
     } else if (!strncmp(buf, "#!", 2)) {
         /* trim newlines */
         buf[strcspn(buf, "\n")] = '\0';

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -139,7 +139,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     memset(cwd, '\0', sizeof(cwd));
 
     if (getcwd(cwd, PATH_MAX) == NULL) {
-        err(RI_PROGRAM_ERROR, "getcwd()");
+        err(RI_PROGRAM_ERROR, "getcwd");
     }
 
     memset(reltarget, '\0', sizeof(reltarget));
@@ -261,7 +261,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     TAILQ_FOREACH(peer, ri->peers, items) {
         /* move to the subpackage root */
         if (chdir(peer->after_root) == -1) {
-            warn("chdir()");
+            warn("chdir");
             continue;
         }
 

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -53,7 +53,7 @@ static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         engine = cl_engine_new();
 
         if (engine == NULL) {
-            errx(RI_PROGRAM_ERROR, _("cl_engine_new() returned NULL, check clamav library"));
+            errx(RI_PROGRAM_ERROR, _("cl_engine_new returned NULL, check clamav library"));
         }
 
         /* load clamav databases */
@@ -61,7 +61,7 @@ static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (r != CL_SUCCESS) {
             cl_engine_free(engine);
-            errx(RI_PROGRAM_ERROR, _("cl_load(): %s"), cl_strerror(r));
+            errx(RI_PROGRAM_ERROR, _("cl_load: %s"), cl_strerror(r));
         }
 
         /* compile engine */
@@ -69,7 +69,7 @@ static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (r != CL_SUCCESS) {
             cl_engine_free(engine);
-            errx(RI_PROGRAM_ERROR, _("cl_engine_compile(): %s"), cl_strerror(r));
+            errx(RI_PROGRAM_ERROR, _("cl_engine_compile: %s"), cl_strerror(r));
         }
 
         /* remember to not do all this again */
@@ -126,7 +126,7 @@ bool inspect_virus(struct rpminspect *ri)
     r = cl_init(CL_INIT_DEFAULT);
 
     if (r != CL_SUCCESS) {
-        warnx(_("cl_init(): %s"), cl_strerror(r));
+        warnx(_("cl_init: %s"), cl_strerror(r));
         return false;
     }
 
@@ -147,7 +147,7 @@ bool inspect_virus(struct rpminspect *ri)
     d = opendir(dbpath);
 
     if (d == NULL) {
-        err(EXIT_FAILURE, "opendir()");
+        err(EXIT_FAILURE, "opendir");
     }
 
     errno = 0;
@@ -173,11 +173,11 @@ bool inspect_virus(struct rpminspect *ri)
     }
 
     if (errno != 0) {
-        err(EXIT_FAILURE, "readdir()");
+        err(EXIT_FAILURE, "readdir");
     }
 
     if (closedir(d) == -1) {
-        warn("closedir()");
+        warn("closedir");
     }
 
     add_result(ri, &params);

--- a/lib/local.c
+++ b/lib/local.c
@@ -51,7 +51,7 @@ bool is_local_build(const char *build) {
     }
 
     if (stat(build, &sb) == -1) {
-        warn("stat()");
+        warn("stat");
         return false;
     }
 
@@ -62,16 +62,16 @@ bool is_local_build(const char *build) {
     memset(cwd, '\0', sizeof(cwd));
 
     if (getcwd(cwd, PATH_MAX) == NULL) {
-        err(RI_PROGRAM_ERROR, "getcwd()");
+        err(RI_PROGRAM_ERROR, "getcwd");
     }
 
     if (chdir(build) == -1) {
-        warn("chdir()");
+        warn("chdir");
         return false;
     }
 
     if (chdir(cwd) == -1) {
-        warn("chdir()");
+        warn("chdir");
         return false;
     }
 

--- a/lib/mkdirp.c
+++ b/lib/mkdirp.c
@@ -43,7 +43,7 @@ int mkdirp(const char *path, mode_t mode) {
         start = p = strdup(path);
     } else {
         if ((cwd = getcwd(NULL, 0)) == NULL) {
-            warn("getcwd()");
+            warn("getcwd");
             return -1;
         }
 

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -163,7 +163,7 @@ bool usable_path(const char *path)
     memset(&sb, 0, sizeof(sb));
 
     if (lstat(path, &sb) == -1) {
-        warn("lstat(%s)", path);
+        warn("lstat");
         return false;
     }
 
@@ -194,8 +194,6 @@ bool match_path(const char *pattern, const char *root, const char *needle)
     assert(pattern != NULL);
     assert(needle != NULL);
 
-DEBUG_PRINT("pattern=|%s|, root=|%s|, needle=|%s|\n", pattern, root, needle);
-
 #ifdef GLOB_BRACE
     /* this is a GNU extension, see glob(3) */
     gflags |= GLOB_BRACE;
@@ -225,11 +223,10 @@ DEBUG_PRINT("pattern=|%s|, root=|%s|, needle=|%s|\n", pattern, root, needle);
     }
 
     gp = stpcpy(gp, pattern);
-    DEBUG_PRINT("globpath=|%s|\n", globpath);
     r = glob(globpath, gflags, NULL, &found);
 
     if (r == GLOB_NOSPACE || r == GLOB_ABORTED) {
-        warn("glob()");
+        warn("glob");
     }
 
     if (r != 0) {

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -127,7 +127,7 @@ void add_peer(rpmpeer_t **peers, int whichbuild, bool fetch_only, const char *pk
     /* Add the peer if it doesn't already exist, otherwise add it */
     if (!found) {
         if ((peer = calloc(1, sizeof(*peer))) == NULL) {
-            warn("calloc() new peer");
+            warn("calloc");
             return;
         }
     }

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -199,7 +199,7 @@ static GElf_Half _get_elf_helper(Elf *elf, elfinfo_t type, GElf_Half fail)
     assert(kind == ELF_K_ELF);
 
     if (gelf_getehdr(elf, &ehdr) == NULL) {
-        warn("gelf_getehdr()");
+        warn("gelf_getehdr");
         ret = fail;
     }
 

--- a/lib/rebase.c
+++ b/lib/rebase.c
@@ -101,6 +101,6 @@ bool is_rebase(struct rpminspect *ri)
         return true;
     } else {
         /* should not reach this */
-        err(RI_PROGRAM_ERROR, "is_rebase()");
+        err(RI_PROGRAM_ERROR, "is_rebase");
     }
 }

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -75,7 +75,7 @@ Header get_rpm_header(struct rpminspect *ri, const char *pkg)
     fd = Fopen(pkg, "r.ufdio");
 
     if (fd == NULL || Ferror(fd)) {
-        warnx(_("Fopen() failed for %s: %s"), pkg, Fstrerror(fd));
+        warnx(_("Fopen failed for %s: %s"), pkg, Fstrerror(fd));
 
         if (fd) {
             Fclose(fd);

--- a/lib/uncompress.c
+++ b/lib/uncompress.c
@@ -72,7 +72,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     r = stat(outfile, &sb);
 
     if ((r == -1) && (errno != ENOENT)) {
-        warn("stat()");
+        warn("stat");
         goto error1;
     }
 
@@ -82,7 +82,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
      */
     if (errno == ENOENT) {
         if (mkdirp(outfile, mode) == -1) {
-            warn("mkdirp()");
+            warn("mkdirp");
             goto error1;
         }
     }
@@ -104,7 +104,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     fd = mkstemp(outfile);
 
     if (fd == -1) {
-        warn("mkstemp()");
+        warn("mkstemp");
         goto error1;
     }
 
@@ -192,14 +192,14 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     r = archive_read_open_filename(input, infile, 16384);
 
     if (r != ARCHIVE_OK) {
-        warn("archive_read_open_filename(): %s", archive_error_string(input));
+        warn("archive_read_open_filename: %s", archive_error_string(input));
         goto error2;
     }
 
     r = archive_read_next_header(input, &entry);
 
     if (r == ARCHIVE_WARN || r == ARCHIVE_FAILED || r == ARCHIVE_FATAL) {
-        warn("archive_read_next_header(): %s", archive_error_string(input));
+        warn("archive_read_next_header: %s", archive_error_string(input));
         goto error2;
     }
 
@@ -212,7 +212,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
             }
 
             if (write(fd, buf, size) == -1) {
-                warn("write()");
+                warn("write");
                 goto error2;
             }
         }
@@ -221,7 +221,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
         fp = fdopen(fd, "w");
 
         if (fp == NULL) {
-            warn("fdopen()");
+            warn("fdopen");
             goto error2;
         }
 
@@ -231,7 +231,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
          * the fd
          */
         if (fclose(fp) == -1) {
-            warn("fclose()");
+            warn("fclose");
             goto error2;
         }
 
@@ -242,7 +242,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
 
     /* close up our uncompressed file */
     if (fd && close(fd) == -1) {
-        warn("close()");
+        warn("close");
         goto error1;
     }
 

--- a/lib/unpack.c
+++ b/lib/unpack.c
@@ -52,7 +52,7 @@ static int copy_data(struct archive *ar, struct archive *aw) {
         r = archive_write_data_block(aw, buf, s, o);
 
         if (r != ARCHIVE_OK) {
-            warnx("archive_write_data_block(): %s", archive_error_string(aw));
+            warnx("archive_write_data_block: %s", archive_error_string(aw));
             return r;
         }
     }
@@ -68,7 +68,7 @@ static int extract_entry(struct archive *input, struct archive *output, struct a
     r = archive_write_header(output, entry);
 
     if (r != ARCHIVE_OK) {
-        warnx("archive_write_header(): %s", archive_error_string(output));
+        warnx("archive_write_header: %s", archive_error_string(output));
         ret = -1;
     } else if (archive_entry_size(entry) > 0) {
         if (copy_data(input, output) != ARCHIVE_OK) {
@@ -76,7 +76,7 @@ static int extract_entry(struct archive *input, struct archive *output, struct a
         }
 
         if (r != ARCHIVE_OK) {
-            warnx("archive_write_header(): %s", archive_error_string(output));
+            warnx("archive_write_header: %s", archive_error_string(output));
         } else if (r < ARCHIVE_WARN) {
             ret = -1;
         }
@@ -85,7 +85,7 @@ static int extract_entry(struct archive *input, struct archive *output, struct a
     r = archive_write_finish_entry(output);
 
     if (r != ARCHIVE_OK) {
-        warnx("archive_write_finish_entry(): %s", archive_error_string(output));
+        warnx("archive_write_finish_entry: %s", archive_error_string(output));
     } else if (r < ARCHIVE_WARN) {
         ret = -1;
     }
@@ -141,17 +141,17 @@ int unpack_archive(const char *archive, const char *dest, const bool force) {
     r = archive_read_open_filename(input, archive, 16384);
 
     if (r != ARCHIVE_OK) {
-        warn("archive_read_open_filename(): %s", archive_error_string(input));
+        warn("archive_read_open_filename: %s", archive_error_string(input));
         return -1;
     }
 
     /* change to dest */
     if (getcwd(cwd, PATH_MAX) == NULL) {
-        err(RI_PROGRAM_ERROR, "getcwd()");
+        err(RI_PROGRAM_ERROR, "getcwd");
     }
 
     if (chdir(dest) != 0) {
-        warn("chdir()");
+        warn("chdir");
         return -1;
     }
 
@@ -163,7 +163,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force) {
     /* extract each archive member */
     while ((r = archive_read_next_header(input, &entry)) != ARCHIVE_EOF) {
         if (r != ARCHIVE_OK) {
-            warnx("archive_read_next_header(): %s", archive_error_string(input));
+            warnx("archive_read_next_header: %s", archive_error_string(input));
         } else if (r < ARCHIVE_WARN) {
             ret = -1;
         }
@@ -182,7 +182,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force) {
 
     /* change back to original directory */
     if (chdir(cwd) != 0) {
-        warn("chdir()");
+        warn("chdir");
         return -1;
     }
 


### PR DESCRIPTION
This was an inconsistent thing for a while and I never could make up
my mind on the reporting style.  In the end I decided to do away with
messages like this:

    fopen(): Unknown file

And it now will look like this:

    fopen: Unknown file

The parens are unnecessary in the reporting.

Signed-off-by: David Cantrell <dcantrell@redhat.com>