### PR TITLE
Refactor runcmd and update the inspections that use it

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -266,9 +266,11 @@ char *compute_checksum(const char *, mode_t *, enum checksum);
 char *checksum(rpmfile_entry_t *);
 
 /* runcmd.c */
-char *sl_run_cmd(int *exitcode, string_list_t *list);
+char *run_cmd_vpe(int *exitcode, char **argv);
 char *run_cmd(int *, const char *, ...) __attribute__((__sentinel__));
 void free_argv_table(struct rpminspect *ri, string_list_map_t *table);
+char **build_argv(const char *cmd);
+void free_argv(char **argv);
 
 /* fileinfo.c */
 bool match_fileinfo_mode(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *);

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -266,8 +266,8 @@ char *compute_checksum(const char *, mode_t *, enum checksum);
 char *checksum(rpmfile_entry_t *);
 
 /* runcmd.c */
-char *run_cmd_vpe(int *exitcode, char **argv);
-char *run_cmd(int *, const char *, ...) __attribute__((__sentinel__));
+char *run_cmd_vpe(int *exitcode, const char *workdir, char **argv);
+char *run_cmd(int *, const char *, const char *, ...) __attribute__((__sentinel__));
 void free_argv_table(struct rpminspect *ri, string_list_map_t *table);
 char **build_argv(const char *cmd);
 void free_argv(char **argv);

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -192,7 +192,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
      */
 
     /* msgunfmt */
-    tmp = run_cmd(&exitcode, ri->commands.msgunfmt, "--version", NULL);
+    tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.msgunfmt, "--version", NULL);
     details = strsplit(tmp, "\n");
     free(tmp);
 
@@ -208,7 +208,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(ver);
 
     /* diff */
-    tmp = run_cmd(&exitcode, ri->commands.diff, "--version", NULL);
+    tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "--version", NULL);
     details = strsplit(tmp, "\n");
     free(tmp);
 
@@ -224,7 +224,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(ver);
 
     /* diffstat */
-    ver = run_cmd(&exitcode, ri->commands.diffstat, "--version", NULL);
+    ver = run_cmd(&exitcode, ri->worksubdir, ri->commands.diffstat, "--version", NULL);
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
     xasprintf(&entry->data, "%s", ver);
@@ -232,7 +232,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(ver);
 
     /* annocheck */
-    tmp = run_cmd(&exitcode, ri->commands.annocheck, "--version", NULL);
+    tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.annocheck, "--version", NULL);
     details = strsplit(tmp, "\n");
     free(tmp);
 
@@ -248,7 +248,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(ver);
 
     /* abidiff */
-    tmp = run_cmd(&exitcode, ri->commands.abidiff, "--version", NULL);
+    tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.abidiff, "--version", NULL);
     details = strsplit(tmp, "\n");
     free(tmp);
 
@@ -264,7 +264,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(ver);
 
     /* kmidiff */
-    tmp = run_cmd(&exitcode, ri->commands.kmidiff, "--version", NULL);
+    tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.kmidiff, "--version", NULL);
     details = strsplit(tmp, "\n");
     free(tmp);
 

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -134,7 +134,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         /* Run the test on the file */
         after_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, get_after_debuginfo_path(ri, arch, after), file->fullpath);
         argv = build_argv(after_cmd);
-        after_out = run_cmd_vpe(&after_exit, argv);
+        after_out = run_cmd_vpe(&after_exit, ri->worksubdir, argv);
         free_argv(argv);
 
         /* If we have a before build, run the command on that */
@@ -143,7 +143,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             before_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, get_before_debuginfo_path(ri, arch, before), file->peer_file->fullpath);
             argv = build_argv(before_cmd);
-            before_out = run_cmd_vpe(&before_exit, argv);
+            before_out = run_cmd_vpe(&before_exit, ri->workdir, argv);
             free_argv(argv);
 
             /* Build a reporting message if we need to */

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -84,7 +84,7 @@ static char *run_and_capture(const char *where, char **output, char *cmd, const 
     }
 
     /* Run command and return output */
-    return run_cmd(exitcode, cmd, fullpath, ">", *output, NULL);
+    return run_cmd(exitcode, NULL, cmd, fullpath, ">", *output, NULL);
 }
 
 /*
@@ -254,7 +254,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             if (is_text_file(bun) && is_text_file(aun)) {
                 /* uncompressed files are text, use diff */
-                params.details = run_cmd(&exitcode, ri->commands.diff, "-u", before_uncompressed_file, after_uncompressed_file, NULL);
+                params.details = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", before_uncompressed_file, after_uncompressed_file, NULL);
 
                 /* clean up the diff headers */
                 if (exitcode) {
@@ -349,7 +349,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
 
         /* Now diff the mo content */
-        params.details = run_cmd(&exitcode, ri->commands.diff, "-u", before_tmp, after_tmp, NULL);
+        params.details = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", before_tmp, after_tmp, NULL);
 
         /* Remove the temporary files */
         if (unlink(before_tmp) == -1) {
@@ -391,7 +391,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     if (!strcmp(type, "text/x-c") && possible_header && (ri->tests & INSPECT_CHANGEDFILES)) {
         /* Now diff the header content */
-        errors = run_cmd(&exitcode, ri->commands.diff, "-u", "-w", "--label", file->localpath, file->peer_file->fullpath, file->fullpath, NULL);
+        errors = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", "-w", "--label", file->localpath, file->peer_file->fullpath, file->fullpath, NULL);
 
         if (exitcode) {
             /*

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -239,7 +239,7 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     /* Compare the changelogs */
     if (before_output && after_output) {
-        diff_output = run_cmd(&exitcode, ri->commands.diff, "-u", before_output, after_output, NULL);
+        diff_output = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", before_output, after_output, NULL);
     }
 
     /* Set up result parameters */
@@ -361,7 +361,7 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     /* Compare the changelogs */
     if (before_output && after_output) {
-        diff_output = run_cmd(&exitcode, ri->commands.diff, "-u", before_output, after_output, NULL);
+        diff_output = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", before_output, after_output, NULL);
     }
 
     /* Set up result parameters */

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -163,7 +163,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             if (exitcode) {
                 /* the files differ and not a rebase, see if it's only whitespace changes */
                 free(diff_output);
-                params.details = run_cmd(&exitcode, ri->commands.diff, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
+                params.details = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
 
                 if (exitcode == 0) {
                     xasprintf(&params.msg, _("%%config file content change for %s in %s on %s (comments/whitespace only)"), file->localpath, name, arch);

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -425,7 +425,8 @@ static bool desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         before_out = tmpbuf;
     }
 
-    if (after_code == -1) {
+    if (after_code) {
+        /* non-zero on exit is a failed desktop file */
         result = false;
     }
 

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -412,14 +412,14 @@ static bool desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
 
     /* Validate the desktop file */
-    params.details = run_cmd(&after_code, ri->commands.desktop_file_validate, file->fullpath, NULL);
+    params.details = run_cmd(&after_code, ri->worksubdir, ri->commands.desktop_file_validate, file->fullpath, NULL);
     tmpbuf = strreplace(params.details, file->fullpath, file->localpath);
     free(params.details);
     params.details = tmpbuf;
 
     if (file->peer_file && is_desktop_entry_file(ri->desktop_entry_files_dir, file->peer_file)) {
         /* if we have a before peer, validate the corresponding desktop file */
-        before_out = run_cmd(NULL, ri->commands.desktop_file_validate, file->peer_file->fullpath, NULL);
+        before_out = run_cmd(NULL, ri->worksubdir, ri->commands.desktop_file_validate, file->peer_file->fullpath, NULL);
         tmpbuf = strreplace(before_out, file->peer_file->fullpath, file->peer_file->localpath);
         free(before_out);
         before_out = tmpbuf;

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -104,7 +104,7 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (exitcode) {
             /* the files differ, see if it's only whitespace changes */
-            diff_output = run_cmd(&exitcode, ri->commands.diff, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
+            diff_output = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
 
             /* always report content changes on %doc files as INFO */
             params.severity = RESULT_INFO;

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -219,13 +219,13 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
      * This just reports patches that change content.  It uses the INFO reporting level.
      */
     if (comparison && file->peer_file) {
-        params.details = run_cmd(&exitcode, ri->commands.diff, "-q", before_patch, after_patch, NULL);
+        params.details = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-q", before_patch, after_patch, NULL);
         free(params.details);
         params.details = NULL;
 
         if (exitcode) {
             /* the files differ, see if it's only whitespace changes */
-            params.details = run_cmd(&exitcode, ri->commands.diff, "-u", "-w", "-I^#.*", before_patch, after_patch, NULL);
+            params.details = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", "-w", "-I^#.*", before_patch, after_patch, NULL);
 
             if (exitcode) {
                 /* more than whitespace changed */
@@ -273,7 +273,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /*
      * Collect diffstat(1) data and report based on thresholds.
      */
-    params.details = run_cmd(&exitcode, ri->commands.diffstat, after_patch, NULL);
+    params.details = run_cmd(&exitcode, ri->worksubdir, ri->commands.diffstat, after_patch, NULL);
 
     if (exitcode == 0 && params.details != NULL) {
         ds = get_diffstat_counts(params.details);

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -156,18 +156,18 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Run with -n and capture results */
-    errors = run_cmd(&exitcode, shell, "-n", file->fullpath, NULL);
+    errors = run_cmd(&exitcode, ri->worksubdir, shell, "-n", file->fullpath, NULL);
     DEBUG_PRINT("exitcode=%d, errors=|%s|\n", exitcode, errors);
 
     if (before_shell) {
-        before_errors = run_cmd(&before_exitcode, before_shell, "-n", file->peer_file->fullpath, NULL);
+        before_errors = run_cmd(&before_exitcode, ri->worksubdir, before_shell, "-n", file->peer_file->fullpath, NULL);
         DEBUG_PRINT("before_exitcode=%d, before_errors=|%s|\n", before_exitcode, before_errors);
     }
 
     /* Special cash for GNU bash, try with extglob */
     if (exitcode && !strcmp(shell, "bash")) {
         free(errors);
-        errors = run_cmd(&exitcode, shell, "-n", "-O", "extglob", file->fullpath, NULL);
+        errors = run_cmd(&exitcode, ri->worksubdir, shell, "-n", "-O", "extglob", file->fullpath, NULL);
         DEBUG_PRINT("exitcode=%d, errors=|%s|\n", exitcode, errors);
 
         if (!exitcode) {

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -87,7 +87,7 @@ static bool upstream_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (strcmp(before_sum, after_sum)) {
             /* capture 'diff -u' output for text files */
             if (is_text_file(file->peer_file) && is_text_file(file)) {
-                diff_head = diff_output = run_cmd(&exitcode, ri->commands.diff, "-u", file->peer_file->fullpath, file->fullpath, NULL);
+                diff_head = diff_output = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", file->peer_file->fullpath, file->fullpath, NULL);
 
                 /* skip the two leading lines */
                 if (strprefix(diff_head, "--- ")) {


### PR DESCRIPTION
This PR contains a refactoring of the runcmd.c code away from using popen() and over to using a fork()/execvpe() model with pipe() and dup2() to redirect and collect stdout and stderr of the child process for reporting back to the caller.  The advantage we gain from this model is that run_cmd() can now detect if the child terminated due to a signal, such as SIGABRT.  popen() doesn't allow for that as it invokes commands with a 'sh -c' so any signal detection would be of the shell receiving signals and not the actual command you wanted to run.  In a way, this run_cmd() refactoring is building a custom popen() for use in librpminspect.

The exit code of the child process is handed back to the caller if requested, as is the combined stdout and stderr output.  Both of those can be ignored by the caller in which case the run_cmd() call acts as simply a way to run something and return.

The inspections using run_cmd() code have been updated for the API changes and the test suite passes.