### PR TITLE
Implement the 'unicode' inspection in librpminspect

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -768,15 +768,15 @@ unicode:
     # are written in hexidecimal notation.  The case of the letters
     # does not matter.  Be sure to prefix the code point with '0x'.
     forbidden_codepoints:
-        - 0x202A
-        - 0x202B
-        - 0x202C
-        - 0x202D
-        - 0x202E
-        - 0x2066
-        - 0x2067
-        - 0x2068
-        - 0x2069
+        - '0x202A'
+        - '0x202B'
+        - '0x202C'
+        - '0x202D'
+        - '0x202E'
+        - '0x2066'
+        - '0x2067'
+        - '0x2068'
+        - '0x2069'
 
     # Optional list of glob(7) specifications to match files to ignore
     # for this inspection.  The format of this list is the same as the

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -142,6 +142,7 @@ vendor:
     #subpackages: off
     #symlinks: off
     #types: off
+    #unicode: off
     #upstream: off
     #virus: off
     #xml: off
@@ -737,6 +738,46 @@ runpath:
     #    - /usr/lib*/libexample.so*
 
 types:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/lib*/libexample.so*
+
+unicode:
+    # Regular expression to match file and directory names for
+    # exclusion.  Take care with making this too complicated as it may
+    # become difficult to maintain over time.  The regular expression
+    # here is processed by regex(3) and can use POSIX Extended Regular
+    # Expression syntax.
+    exclude: ^(\.git|\.hg|\.desktop|\.ppd|\.txt|\.directory|ChangeLog|NEWS)$
+
+    # List of file MIME types of files this inspection should exclude.
+    # MIME types are determined by libmagic, which is how the file(1)
+    # command works.  Sometimes matching by MIME type does not quit
+    # produce the desired results, so keep that in mind when adding to
+    # this list.
+    excluded_mime_types:
+        - text/x-po
+        - text/x-tex
+        - text/x-troff
+        - text/html
+
+    # List of forbidden Unicode codepoints in source code.  Codepoints
+    # are written in hexidecimal notation.  The case of the letters
+    # does not matter.  Be sure to prefix the code point with '0x'.
+    forbidden_codepoints:
+        - 0x202A
+        - 0x202B
+        - 0x202C
+        - 0x202D
+        - 0x202E
+        - 0x2066
+        - 0x2067
+        - 0x2068
+        - 0x2069
+
     # Optional list of glob(7) specifications to match files to ignore
     # for this inspection.  The format of this list is the same as the
     # global 'ignore' list.  The difference is the items specified

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -755,7 +755,7 @@ unicode:
 
     # List of file MIME types of files this inspection should exclude.
     # MIME types are determined by libmagic, which is how the file(1)
-    # command works.  Sometimes matching by MIME type does not quit
+    # command works.  Sometimes matching by MIME type does not quite
     # produce the desired results, so keep that in mind when adding to
     # this list.
     excluded_mime_types:
@@ -766,7 +766,8 @@ unicode:
 
     # List of forbidden Unicode codepoints in source code.  Codepoints
     # are written in hexidecimal notation.  The case of the letters
-    # does not matter.  Be sure to prefix the code point with '0x'.
+    # does not matter.  Be sure to prefix the code point with '0x' and
+    # use single quotes around the values.
     forbidden_codepoints:
         - '0x202A'
         - '0x202B'

--- a/include/constants.h
+++ b/include/constants.h
@@ -427,12 +427,28 @@
 
 /** @} */
 
-#define SPEC_MACRO_DEFINE "%define"
-#define SPEC_MACRO_GLOBAL "%global"
+#define SPEC_MACRO_DEFINE      "%define"
+#define SPEC_MACRO_GLOBAL      "%global"
 #define SPEC_SECTION_CHANGELOG "%changelog"
-#define SPEC_SECTION_FILES "%files"
-#define SPEC_TAG_RELEASE "Release:"
-#define SPEC_DISTTAG "%{?dist}"
+#define SPEC_SECTION_FILES     "%files"
+#define SPEC_TAG_RELEASE       "Release:"
+#define SPEC_DISTTAG           "%{?dist}"
+
+/*
+ * Names of rpmbuild(1) subdirectories.  rpminspect models an rpmbuild
+ * layout similar to how rpmbuild is used for distributions like
+ * Fedora Linux.  That is there is a top level directory (topdir) and
+ * all of the other directories are subdirectories in topdir.  For the
+ * purposes of rpminspect, the topdir definition here is a
+ * subdirectory in the working directory location rpminspect is using.
+ */
+#define RPMBUILD_TOPDIR        "rpmbuild"
+#define RPMBUILD_BUILDDIR      "BUILD"
+#define RPMBUILD_BUILDROOTDIR  "BUILDROOT"
+#define RPMBUILD_RPMDIR        "RPMS"
+#define RPMBUILD_SOURCEDIR     "SOURCES"
+#define RPMBUILD_SPECDIR       "SPECS"
+#define RPMBUILD_SRPMDIR       "SRPMS"
 
 /** @} */
 

--- a/include/constants.h
+++ b/include/constants.h
@@ -437,10 +437,11 @@
 /*
  * Names of rpmbuild(1) subdirectories.  rpminspect models an rpmbuild
  * layout similar to how rpmbuild is used for distributions like
- * Fedora Linux.  That is there is a top level directory (topdir) and
- * all of the other directories are subdirectories in topdir.  For the
- * purposes of rpminspect, the topdir definition here is a
- * subdirectory in the working directory location rpminspect is using.
+ * Fedora Linux.  The main idea is a top level directory is defined
+ * (topdir) and all of the other directories used by rpmbuild are
+ * within topdir.  For the purposes of rpminspect, the topdir
+ * definition here is a subdirectory in the working directory location
+ * rpminspect is using.
  */
 #define RPMBUILD_TOPDIR        "rpmbuild"
 #define RPMBUILD_BUILDDIR      "BUILD"

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -508,6 +508,15 @@ bool inspect_badfuncs(struct rpminspect *ri);
  */
 bool inspect_runpath(struct rpminspect *ri);
 
+/**
+ * @brief Main driver for the 'unicode' inspection.
+ *
+ *
+ * @param ri Pointer to the struct rpminspect for the program.
+ * @return True if the inspection passed, false otherwise.
+ */
+bool inspect_unicode(struct rpminspect *ri);
+
 /** @} */
 
 /*
@@ -561,6 +570,7 @@ bool inspect_runpath(struct rpminspect *ri);
 #define INSPECT_POLITICS                    (((uint64_t) 1) << 40)
 #define INSPECT_BADFUNCS                    (((uint64_t) 1) << 41)
 #define INSPECT_RUNPATH                     (((uint64_t) 1) << 42)
+#define INSPECT_UNICODE                     (((uint64_t) 1) << 43)
 
 /* Inspection names */
 #define NAME_LICENSE                        "license"
@@ -605,6 +615,7 @@ bool inspect_runpath(struct rpminspect *ri);
 #define NAME_POLITICS                       "politics"
 #define NAME_BADFUNCS                       "badfuncs"
 #define NAME_RUNPATH                        "runpath"
+#define NAME_UNICODE                        "unicode"
 
 /* Long descriptions for the inspections */
 #define DESC_LICENSE _("Verify the string specified in the License tag of the RPM metadata describes permissible software licenses as defined by the license database. Also checks to see if the License tag contains any unprofessional words as defined in the configuration file.")
@@ -690,5 +701,7 @@ bool inspect_runpath(struct rpminspect *ri);
 #define DESC_BADFUNCS _("Check for forbidden functions in ELF files.  Forbidden functions are defined in the runtime configuration files.  Usually this inspection is used to catch built packages that make use of deprecated API functions if you wish built packages to conform to replacement APIs.")
 
 #define DESC_RUNPATH _("Check for forbidden paths in both the DT_RPATH and DT_RUNPATH settings in ELF shared objects.")
+
+#define DESC_UNICODE _("Scan extracted and patched source code files, scripts, and RPM spec files for any prohibited Unicode code points, as defined in the configuration file.  Any prohibited code points are reported as a possible security risk.")
 
 #endif

--- a/include/results.h
+++ b/include/results.h
@@ -182,4 +182,6 @@
 /* unicode */
 #define REMEDY_UNICODE _("The rpminspect configuration file contains a list of forbidden Unicode code points.  One was found in the extracted and patched source tree or in one of the text source files in the source RPM.  Either remove this code point or discuss the situation with the Product Security Team to determine the correct course of action.")
 
+#define REMEDY_UNICODE_PREP_FAILED _("The %prep section of the spec file could not be executed for some reason.  This usually results from a failure in librpmbuild, which is usually tied to archive extraction problems or the filesystem changing while rpminspect is running.  A common cause is removal of the working directory while the program is executing.")
+
 #endif

--- a/include/results.h
+++ b/include/results.h
@@ -179,4 +179,7 @@
 
 #define REMEDY_RUNPATH_BOTH _("Both DT_RPATH and DT_RUNPATH properties were found in an ELF shared object.  This indicates a linker error and should not happen.  ELF objects should only carry DT_RPATH or DT_RUNPATH, never both.")
 
+/* unicode */
+#define REMEDY_UNICODE _("The rpminspect configuration file contains a list of forbidden Unicode code points.  One was found in the extracted and patched source tree or in one of the text source files in the source RPM.  Either remove this code point or discuss the situation with the Product Security Team to determine the correct course of action.")
+
 #endif

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -258,6 +258,7 @@ void output_xunit(const results_t *, const char *, const severity_t);
 int unpack_archive(const char *, const char *, const bool);
 
 /* magic.c */
+char *mime_type(const char *);
 char *get_mime_type(rpmfile_entry_t *);
 bool is_text_file(rpmfile_entry_t *);
 

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -298,6 +298,7 @@ const char *get_after_rel(struct rpminspect *);
 int gather_builds(struct rpminspect *, bool);
 
 /* macros.c */
+void load_macros(struct rpminspect *ri);
 string_list_t *get_macros(const char *);
 int get_specfile_macros(struct rpminspect *, const char *);
 

--- a/include/types.h
+++ b/include/types.h
@@ -31,6 +31,7 @@
 #include <rpm/rpmlib.h>
 #include <rpm/rpmfi.h>
 #include <libkmod.h>
+#include <unicode/utypes.h>
 #include "secrules.h"
 #include "queue.h"
 #include "uthash.h"
@@ -47,6 +48,16 @@ typedef struct _string_entry_t {
 } string_entry_t;
 
 typedef TAILQ_HEAD(string_entry_s, _string_entry_t) string_list_t;
+
+/*
+ * List of UChars.  Used by at least the unicode inspection.
+ */
+typedef struct _UChar_entry_t {
+    UChar data;
+    TAILQ_ENTRY(_UChar_entry_t) items;
+} UChar_entry_t;
+
+typedef TAILQ_HEAD(UChar_entry_s, _UChar_entry_t) UChar_list_t;
 
 /*
  * List of string pairs. Used to later convert in to a newly allocated hash table.
@@ -553,6 +564,11 @@ struct rpminspect {
 
     /* Optional list of expected RPMs with empty payloads */
     string_list_t *expected_empty_rpms;
+
+    /* unicode inspection lists */
+    regex_t *unicode_exclude;
+    string_list_t *unicode_excluded_mime_types;
+    string_list_t *unicode_forbidden_codepoints;
 
     /* Options specified by the user */
     char *before;              /* before build ID arg given on cmdline */

--- a/include/types.h
+++ b/include/types.h
@@ -400,6 +400,7 @@ struct rpminspect {
 
     /* Optional: list of RPM macro file paths */
     string_list_t *macrofiles;
+    bool macros_loaded;
 
     /*
      * Optional: if not NULL, contains list of path prefixes for files

--- a/include/types.h
+++ b/include/types.h
@@ -50,14 +50,14 @@ typedef struct _string_entry_t {
 typedef TAILQ_HEAD(string_entry_s, _string_entry_t) string_list_t;
 
 /*
- * List of UChars.  Used by at least the unicode inspection.
+ * List of UChar32s.  Used by at least the unicode inspection.
  */
-typedef struct _UChar_entry_t {
-    UChar data;
-    TAILQ_ENTRY(_UChar_entry_t) items;
-} UChar_entry_t;
+typedef struct _UChar32_entry_t {
+    UChar32 data;
+    TAILQ_ENTRY(_UChar32_entry_t) items;
+} UChar32_entry_t;
 
-typedef TAILQ_HEAD(UChar_entry_s, _UChar_entry_t) UChar_list_t;
+typedef TAILQ_HEAD(UChar32_entry_s, _UChar32_entry_t) UChar32_list_t;
 
 /*
  * List of string pairs. Used to later convert in to a newly allocated hash table.

--- a/lib/free.c
+++ b/lib/free.c
@@ -259,6 +259,9 @@ void free_rpminspect(struct rpminspect *ri) {
     list_free(ri->runpath_origin_prefix_trim, free);
     free_string_list_map(ri->inspection_ignores);
     list_free(ri->expected_empty_rpms, free);
+    free_regex(ri->unicode_exclude);
+    list_free(ri->unicode_excluded_mime_types, free);
+    list_free(ri->unicode_forbidden_codepoints, free);
 
     free_rpmpeer(ri->peers);
 

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -86,6 +86,7 @@ struct inspect inspections[] = {
     { INSPECT_POLITICS,      "politics",      true,  &inspect_politics },
     { INSPECT_BADFUNCS,      "badfuncs",      true,  &inspect_badfuncs },
     { INSPECT_RUNPATH,       "runpath",       true,  &inspect_runpath },
+    { INSPECT_UNICODE,       "unicode",       true,  &inspect_unicode },
     { 0, NULL, false, NULL }
 };
 
@@ -228,6 +229,8 @@ uint64_t inspection_id(const char *name)
         return INSPECT_BADFUNCS;
     } else if (!strcmp(name, NAME_RUNPATH)) {
         return INSPECT_RUNPATH;
+    } else if (!strcmp(name, NAME_UNICODE)) {
+        return INSPECT_UNICODE;
     } else {
         return INSPECT_NULL;
     }
@@ -327,6 +330,8 @@ const char *inspection_desc(const uint64_t inspection)
             return DESC_BADFUNCS;
         case INSPECT_RUNPATH:
             return DESC_RUNPATH;
+        case INSPECT_UNICODE:
+            return DESC_UNICODE;
         default:
             return NULL;
     }
@@ -426,6 +431,8 @@ const char *inspection_header_to_desc(const char *header)
         i = INSPECT_BADFUNCS;
     } else if (!strcmp(header, NAME_RUNPATH)) {
         i = INSPECT_RUNPATH;
+    } else if (!strcmp(header, NAME_UNICODE)) {
+        i = INSPECT_UNICODE;
     }
 
     return inspection_desc(i);

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -24,9 +24,7 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
-#include <rpm/rpmfileutil.h>
 #include <rpm/rpmmacro.h>
-
 #include "rpminspect.h"
 
 /*
@@ -224,8 +222,6 @@ bool inspect_disttag(struct rpminspect *ri)
 {
     bool result = true;
     bool src = false;
-    char *mf = NULL;
-    char *macropath = NULL;
     rpmpeer_entry_t *peer = NULL;
     rpmfile_entry_t *file = NULL;
     struct result_params params;
@@ -254,23 +250,13 @@ bool inspect_disttag(struct rpminspect *ri)
                 continue;
             }
 
-            /* Initialize the macros */
-            if (ri->macrofiles) {
-                macropath = list_to_string(ri->macrofiles, ":");
-                mf = rpmGetPath(macropath, NULL);
-                rpmInitMacros(NULL, mf);
-                free(macropath);
-                free(mf);
-            }
-
             /* Define the dist macro for rpminspect */
             (void) rpmDefineMacro(NULL, "dist " DIST_TAG_MARKER, 0);
 
             /* Analyze the spec file */
             result = disttag_driver(ri, file);
 
-            /* Clean up and get out */
-            rpmFreeMacros(NULL);
+            /* Done after looking at the spec file */
             break;
         }
     }

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -47,7 +47,7 @@ static bool seen = false;
 static char *build = NULL;
 static struct rpminspect *globalri = NULL;
 static bool globalresult = true;
-static UChar_list_t *forbidden = NULL;
+static UChar32_list_t *forbidden = NULL;
 static const char *globalarch = NULL;
 
 /*
@@ -182,7 +182,7 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
     size_t sz = BUFSIZ;
     size_t linenum = 0;
     size_t colnum = 0;
-    UChar_entry_t *uentry = NULL;
+    UChar32_entry_t *uentry = NULL;
     struct result_params params;
 
     assert(globalri != NULL);
@@ -356,7 +356,7 @@ static bool unicode_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 bool inspect_unicode(struct rpminspect *ri)
 {
     bool result = true;
-    UChar_entry_t *entry = NULL;
+    UChar32_entry_t *entry = NULL;
     string_entry_t *sentry = NULL;
     struct result_params params;
 
@@ -372,6 +372,7 @@ bool inspect_unicode(struct rpminspect *ri)
         TAILQ_FOREACH(sentry, ri->unicode_forbidden_codepoints, items) {
             entry = calloc(1, sizeof(*entry));
             assert(entry != NULL);
+            errno = 0;
             entry->data = strtol(sentry->data, NULL, 16);
 
             if (errno == ERANGE || errno == EINVAL) {

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -1,0 +1,426 @@
+/*
+ * Copyright © 2021 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include <libgen.h>
+#include <errno.h>
+#include <err.h>
+#include <ftw.h>
+#include <rpm/rpmspec.h>
+#include <rpm/rpmbuild.h>
+#include <rpm/rpmlog.h>
+#include <unicode/ustdio.h>
+#include "rpminspect.h"
+
+/* subdirectories to create or link for the rpmbuild structure */
+static char *subdirs[] = { RPMBUILD_BUILDDIR,
+                           RPMBUILD_BUILDROOTDIR,
+                           RPMBUILD_RPMDIR,
+                           RPMBUILD_SOURCEDIR,
+                           RPMBUILD_SPECDIR,
+                           RPMBUILD_SRPMDIR,
+                           NULL };
+
+/* has the SRPM been checked? */
+static bool seen = false;
+
+/* these globals are used by the nftw() helper */
+static char *build = NULL;
+static struct rpminspect *globalri = NULL;
+static bool globalresult = true;
+static UChar_list_t *forbidden = NULL;
+static const char *globalarch = NULL;
+
+/*
+ * Given a spec file for a SRPM, do the equivalent of 'rpmbuild -bp'
+ * to get an extracted and prepared source tree (e.g., patched).
+ * Returns an allocated string containing the path to the rpmbuild
+ * BUILD subdirectory.  The caller is responsible for freeing the
+ * returned string.
+ *
+ * A NULL return value indicates a failure to prepare the source tree.
+ */
+static char *prep_source(struct rpminspect *ri, const rpmfile_entry_t *file)
+{
+    rpmSpec spec = NULL;
+    char *shortname = NULL;
+    char *fullpath = NULL;
+    char *dst = NULL;
+    char *macro = NULL;
+    int i = 0;
+    int mode = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
+    rpmts ts = NULL;
+    BTA_t ba = NULL;
+
+    assert(ri != NULL);
+    assert(file != NULL);
+
+    /* use the already existing source subdirectory */
+    fullpath = strdup(file->fullpath);
+    assert(fullpath != NULL);
+    shortname = dirname(fullpath);
+    assert(shortname != NULL);
+
+    /* create rpmbuild-like directory structure and set macros */
+    xasprintf(&dst, "%s/%s", ri->worksubdir, RPMBUILD_TOPDIR);
+    assert(dst != NULL);
+
+    if (mkdirp(dst, mode) == -1) {
+        free(dst);
+        return NULL;
+    }
+
+    free(dst);
+
+    for (i = 0; subdirs[i] != NULL; i++) {
+        xasprintf(&dst, "%s/%s/%s", ri->worksubdir, RPMBUILD_TOPDIR, subdirs[i]);
+        assert(dst != NULL);
+
+        if (!strcmp(subdirs[i], RPMBUILD_SOURCEDIR) || !strcmp(subdirs[i], RPMBUILD_SPECDIR)) {
+            /* symlinks SOURCES and SPECS to where the SRPM is already extracted */
+            if (symlink(shortname, dst) == -1) {
+                warn("symlink");
+            }
+        } else {
+            if (mkdirp(dst, mode) == -1) {
+                warn("mkdirp");
+            }
+        }
+
+        free(dst);
+    }
+
+    free(fullpath);
+
+    xasprintf(&macro, "_topdir %s/%s", ri->worksubdir, RPMBUILD_TOPDIR);
+    assert(macro != NULL);
+    (void) rpmDefineMacro(NULL, macro, 0);
+    free(macro);
+
+    /* read in the spec file */
+    spec = rpmSpecParse(file->fullpath, RPMBUILD_PREP | RPMSPEC_ANYARCH, NULL);
+
+    /* run through the %prep stage */
+    ba = calloc(1, sizeof(*ba));
+    assert(ba != NULL);
+    ba->buildAmount |= RPMBUILD_PREP;
+
+    ts = rpmtsCreate();
+    (void) rpmtsSetRootDir(ts, ri->worksubdir);
+    rpmtsSetFlags(ts, rpmtsFlags(ts) | RPMTRANS_FLAG_NOPLUGINS);
+
+    rpmSetVerbosity(RPMLOG_WARNING);
+
+    if (rpmSpecBuild(ts, spec, ba)) {
+        build = NULL;
+    } else {
+        xasprintf(&build, "%s/%s/%s", ri->worksubdir, RPMBUILD_TOPDIR, RPMBUILD_BUILDDIR);
+    }
+
+    /* clean up */
+    rpmtsFree(ts);
+    free(ba);
+    rpmSpecFree(spec);
+
+    return build;
+}
+
+/*
+ * Returns true if the UChar is what we consider a line ending.
+ *
+ * This function contains code adapted from this blog post about
+ * Unicode with the ICU library:
+ *
+ * https://begriffs.com/posts/2019-05-23-unicode-icu.html
+ */
+static bool end_of_line(const UChar c)
+{
+    if ((c >= 0xA && c <= 0xD) || c == 0x85 || c == 0x2028 || c == 0x2029) {
+        return true;
+    }
+
+    return false;
+}
+
+/*
+ * nftw() helper used to validate each source file.
+ *
+ * This function contains code adapted from this blog post about
+ * Unicode with the ICU library:
+ *
+ * https://begriffs.com/posts/2019-05-23-unicode-icu.html
+ */
+static int validate_file(const char *fpath, __attribute__((unused)) const struct stat *sb, int tflag, __attribute__((unused)) struct FTW *ftwbuf)
+{
+    char *type = NULL;
+    const char *localpath = fpath;
+    string_entry_t *sentry = NULL;
+    UFILE *src = NULL;
+    UChar c;
+    UChar *line = NULL;
+    UChar *line_new = NULL;
+    size_t i = 0;
+    size_t sz = BUFSIZ;
+    size_t linenum = 0;
+    size_t colnum = 0;
+    UChar_entry_t *uentry = NULL;
+    struct result_params params;
+
+    assert(globalri != NULL);
+
+    /* Only looking at regular files */
+    if (tflag == FTW_D || tflag == FTW_DNR || tflag == FTW_DP || tflag == FTW_NS) {
+        return 0;
+    }
+
+    /* check for exclusion by regular expression */
+    if ((globalri->unicode_exclude != NULL) && (regexec(globalri->unicode_exclude, fpath, 0, NULL, 0) == 0)) {
+        return 0;
+    }
+
+    type = mime_type(fpath);
+
+    /* check for exclusion by MIME type */
+    if (globalri->unicode_excluded_mime_types != NULL && !TAILQ_EMPTY(globalri->unicode_excluded_mime_types)) {
+        TAILQ_FOREACH(sentry, globalri->unicode_excluded_mime_types, items) {
+            if (!strcmp(type, sentry->data)) {
+                free(type);
+                return 0;
+            }
+        }
+    }
+
+    /* ignore any non-text files */
+    if (!strprefix(type, "text/")) {
+        free(type);
+        return 0;
+    }
+
+    free(type);
+
+    /* check for exclusion by ignore list */
+    if (build && strprefix(localpath, build)) {
+        /*
+         * this is a file in the prepared source tree, so trim the
+         * build sub dir and make the path strings look like this:
+         *
+         *     rpminspect-1.47.0/lib/magic.c
+         */
+        localpath += strlen(build);
+
+        while (*localpath == '/' && *localpath != '\0') {
+            localpath++;
+        }
+
+        if (localpath == NULL) {
+            warnx(_("empty localpath on %s"), fpath);
+            return 0;
+        }
+    }
+
+    if (ignore_path(globalri, NAME_UNICODE, localpath, build)) {
+        return 0;
+    }
+
+    /* initialize reporting results */
+    init_result_params(&params);
+    params.severity = RESULT_BAD;
+    params.waiverauth = WAIVABLE_BY_SECURITY;
+    params.header = NAME_UNICODE;
+    params.arch = globalarch;
+    params.file = localpath;
+    params.noun = _("forbidden code point in ${FILE}");
+    params.verb = VERB_FAILED;
+    params.remedy = REMEDY_UNICODE;
+
+    /* Read in the file as Unicode data */
+    src = u_fopen(fpath, "r", NULL, NULL);
+
+    if (src == NULL) {
+        warn("u_fopen");
+        return 0;
+    }
+
+    line = calloc(sz, sizeof(*line));
+    assert(line != NULL);
+    linenum = 1;
+
+    while (!u_feof(src)) {
+        /* read in one whole line of text from the file */
+        for (i = 0; (line[i] = u_fgetc(src)) != U_EOF && !end_of_line(line[i]); i++) {
+            /* increase the buffer size if necessary */
+            if (i >= sz) {
+                sz *= 2;
+                errno = 0;
+                line_new = realloc(line, sz * sizeof(*line));
+
+                if (errno == ENOMEM) {
+                    warn("realloc");
+                    free(line);
+                }
+
+                line = line_new;
+
+                if (line == NULL) {
+                    return 0;
+                }
+            }
+        }
+
+        /* eat newline if terminated by a carriage return */
+        if (line[i] == 0xD && (c = u_fgetc(src)) != 0xA) {
+            u_fungetc(c, src);
+        }
+
+        /* this is either U_EOF or newline, trim it */
+        line[i] = '\0';
+
+        /* check this line for any prohibited characters */
+        for (colnum = 0; line[colnum] != '\0'; colnum++) {
+            TAILQ_FOREACH(uentry, forbidden, items) {
+                if (line[colnum] == uentry->data) {
+                    /* forbidden code point found */
+                    xasprintf(&params.msg, _("A forbidden code point was found in the %s source file on line %ld at column %ld."), localpath, linenum, colnum);
+                    add_result(globalri, &params);
+                    free(params.msg);
+                }
+            }
+        }
+
+        /* advance the line counter */
+        linenum++;
+    }
+
+    u_fclose(src);
+    free(line);
+
+    return 0;
+}
+
+static bool unicode_driver(struct rpminspect *ri, rpmfile_entry_t *file)
+{
+    assert(ri != NULL);
+    assert(file != NULL);
+    assert(ri->workdir != NULL);
+
+    /* skip binary packages */
+    if (!headerIsSource(file->rpm_header)) {
+        return true;
+    }
+
+    /* for reporting results */
+    globalarch = get_rpm_header_arch(file->rpm_header);
+    assert(globalarch != NULL);
+
+    /* when the spec file is found, prepare the source tree and check each file there */
+    if (strsuffix(file->localpath, SPEC_FILENAME_EXTENSION)) {
+        /* for the spec file, examine each file in the prepared source tree */
+        if (prep_source(ri, file) == NULL) {
+            return false;
+        }
+
+        /* our tree dive result is saved in 'globalresult', -1 here is an internal error */
+        if (nftw(build, validate_file, FOPEN_MAX, FTW_MOUNT|FTW_PHYS) == -1) {
+            warn("nftw");
+        }
+
+        free(build);
+    }
+
+    /* check the individual file */
+    (void) validate_file(file->fullpath, NULL, FTW_F, NULL);
+
+    return globalresult;
+}
+
+/*
+ * Main driver for the 'unicode' inspection.
+ */
+bool inspect_unicode(struct rpminspect *ri)
+{
+    bool result = true;
+    UChar_entry_t *entry = NULL;
+    string_entry_t *sentry = NULL;
+    struct result_params params;
+
+    assert(ri != NULL);
+
+    /* only run if there are forbidden code points */
+    if (ri->unicode_forbidden_codepoints != NULL && !TAILQ_EMPTY(ri->unicode_forbidden_codepoints)) {
+        /* convert code points to UChar values */
+        forbidden = calloc(1, sizeof(*forbidden));
+        assert(forbidden != NULL);
+        TAILQ_INIT(forbidden);
+
+        TAILQ_FOREACH(sentry, ri->unicode_forbidden_codepoints, items) {
+            entry = calloc(1, sizeof(*entry));
+            assert(entry != NULL);
+            entry->data = strtol(sentry->data, NULL, 16);
+
+            if (errno == ERANGE || errno == EINVAL) {
+                warn("strtol");
+                free(entry);
+                continue;
+            }
+
+            TAILQ_INSERT_TAIL(forbidden, entry, items);
+        }
+
+        /* so the nftw() helper can report results */
+        globalri = ri;
+
+        /* run the inspection */
+        result = foreach_peer_file(ri, NAME_UNICODE, unicode_driver, false);
+
+        /* free the forbidden list memory */
+        while (!TAILQ_EMPTY(forbidden)) {
+            entry = TAILQ_FIRST(forbidden);
+            TAILQ_REMOVE(forbidden, entry, items);
+            free(entry);
+        }
+
+        free(forbidden);
+    }
+
+    /* report */
+    init_result_params(&params);
+    params.waiverauth = NOT_WAIVABLE;
+    params.header = NAME_UNICODE;
+
+    if (result) {
+        params.severity = RESULT_OK;
+        add_result(ri, &params);
+    } else if (!seen) {
+        params.severity = RESULT_INFO;
+        xasprintf(&params.msg, _("The unicode inspection is only for source packages, skipping."));
+        add_result(ri, &params);
+        free(params.msg);
+
+        /*
+         * There's no reason to fail this test for an informational message.
+         */
+        result = true;
+    }
+
+    free(build);
+    return result;
+}

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -306,6 +306,7 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
                 xasprintf(&params.msg, _("A forbidden code point was found in the %s source file on line %ld at column %ld."), localpath, linenum, colnum);
                 add_result(globalri, &params);
                 free(params.msg);
+                globalresult = false;
             }
         }
 
@@ -345,6 +346,8 @@ static bool unicode_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (nftw(build, validate_file, FOPEN_MAX, FTW_MOUNT|FTW_PHYS) == -1) {
             warn("nftw");
         }
+
+        seen = true;
     }
 
     /* check the individual file */

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -186,9 +186,9 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
     UChar *line_new = NULL;
     size_t i = 0;
     size_t sz = BUFSIZ;
-    size_t linenum = 0;
     UChar *needle = NULL;
-    size_t colnum = 0;
+    long int linenum = 0;
+    long int colnum = 0;
     UChar32_entry_t *uentry = NULL;
     struct result_params params;
 

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -342,8 +342,6 @@ static bool unicode_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (nftw(build, validate_file, FOPEN_MAX, FTW_MOUNT|FTW_PHYS) == -1) {
             warn("nftw");
         }
-
-        free(build);
     }
 
     /* check the individual file */

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -23,8 +23,40 @@
 #include <regex.h>
 #include <assert.h>
 #include <err.h>
+#include <rpm/rpmfileutil.h>
+#include <rpm/rpmmacro.h>
 #include "queue.h"
 #include "rpminspect.h"
+
+/**
+ * Initialize macros for use by librpm calls.  This function should
+ * only be called once for the lifetime of the program run.  The
+ * caller needs to also call rpmFreeMacros() during cleanup as well.
+ * This function can be safely called multiple times as it is guarded
+ * by the macros_loaded boolean.
+ */
+void load_macros(struct rpminspect *ri)
+{
+    char *mf = NULL;
+    char *macropath = NULL;
+
+    assert(ri != NULL);
+
+    if (ri->macros_loaded) {
+        return;
+    }
+
+    if (ri->macrofiles) {
+        macropath = list_to_string(ri->macrofiles, ":");
+        mf = rpmGetPath(macropath, NULL);
+        rpmInitMacros(NULL, mf);
+        free(macropath);
+        free(mf);
+    }
+
+    ri->macros_loaded = true;
+    return;
+}
 
 /**
  * @brief Given an RPM spec file, read all of the macro definitions in

--- a/lib/magic.c
+++ b/lib/magic.c
@@ -28,17 +28,58 @@
 #include "rpminspect.h"
 
 /*
+ * Return the MIME type of the specified file by path.  The caller is
+ * responsible for freeing the returned string.
+ */
+char *mime_type(const char *path)
+{
+    char *type = NULL;
+    char *pos = NULL;
+    const char *tmp = NULL;
+    magic_t cookie;
+
+    if (path == NULL) {
+        return NULL;
+    }
+
+    cookie = magic_open(MAGIC_MIME | MAGIC_CHECK);
+
+    if (cookie == NULL) {
+        warnx(_("unable to initialize the magic library"));
+        return NULL;
+    }
+
+    if (magic_load(cookie, NULL) != 0) {
+        warnx(_("unable to load the magic database: %s"), magic_error(cookie));
+        magic_close(cookie);
+        return NULL;
+    }
+
+    if ((tmp = magic_file(cookie, path)) != NULL) {
+        type = strdup(tmp);
+
+        /*
+         * Trim any trailing metadata after the MIME type, such
+         * as 'charset=binary' and stuff like that.
+         */
+        if ((pos = index(type, ';')) != NULL) {
+            *pos = '\0';
+            type = realloc(type, strlen(type) + 1);
+        }
+    }
+
+    magic_close(cookie);
+    return type;
+}
+
+/*
  * Return the MIME type of the specified file.  The type is cached in the
  * rpmfile_entry_t.  If that is not NULL, this function returns that value.
  * Otherwise it gets the MIME type, caches it, and returns the value.
  * The caller should not free the pointer returned.
  */
-char *get_mime_type(rpmfile_entry_t *file) {
-    char *ret = NULL;
-    char *pos = NULL;
-    const char *tmp = NULL;
-    magic_t cookie;
-
+char *get_mime_type(rpmfile_entry_t *file)
+{
     assert(file != NULL);
 
     /* MIME type is cached, return it */
@@ -48,33 +89,8 @@ char *get_mime_type(rpmfile_entry_t *file) {
 
     /* Get and cache MIME type */
     assert(file->fullpath != NULL);
-    cookie = magic_open(MAGIC_MIME | MAGIC_CHECK);
+    file->type = mime_type(file->fullpath);
 
-    if (cookie == NULL) {
-        warnx(_("unable to initialize the magic library"));
-        return ret;
-    }
-
-    if (magic_load(cookie, NULL) != 0) {
-        warnx(_("unable to load the magic database: %s"), magic_error(cookie));
-        magic_close(cookie);
-        return ret;
-    }
-
-    if ((tmp = magic_file(cookie, file->fullpath)) != NULL) {
-        file->type = strdup(tmp);
-
-        /*
-         * Trim any trailing metadata after the MIME type, such
-         * as 'charset=binary' and stuff like that.
-         */
-        if ((pos = index(file->type, ';')) != NULL) {
-            *pos = '\0';
-            file->type = realloc(file->type, strlen(file->type) + 1);
-        }
-    }
-
-    magic_close(cookie);
     return file->type;
 }
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -69,6 +69,7 @@ librpminspect_sources = [
     'inspect_subpackages.c',
     'inspect_symlinks.c',
     'inspect_types.c',
+    'inspect_unicode.c',
     'inspect_upstream.c',
     'inspect_virus.c',
     'inspect_xml.c',
@@ -113,6 +114,7 @@ librpminspect = library(
         xmlrpc_client,
         libxml,
         rpm,
+        rpmbuild,
         libarchive,
         libelf,
         libkmod,
@@ -125,5 +127,7 @@ librpminspect = library(
         magic,
         clamav,
         dl,
+        icu_uc,
+        icu_io,
     ]
 )

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,15 @@ libcurl = dependency('libcurl', required : true)
 zlib = dependency('zlib', required : true)
 yaml = dependency('yaml-0.1', required : true)
 clamav = dependency('libclamav', required : true)
+icu_uc = dependency('icu-uc', required : true)
+icu_io = dependency('icu-io', required : true)
+
+# librpmbuild
+if not cc.has_function('rpmSpecParse', args : ['-lrpmbuild'])
+    error('*** unable to find rpmSpecParse() in librpmbuild')
+else
+    rpmbuild = declare_dependency(link_args : ['-lrpmbuild'])
+endif
 
 # libarchive (need to check for specific functions)
 libarchive = dependency('libarchive', required : true)

--- a/osdeps/fedora-rawhide.i686/reqs.txt
+++ b/osdeps/fedora-rawhide.i686/reqs.txt
@@ -31,6 +31,7 @@ libcap-devel.i686
 libcurl-devel.i686
 /usr/include/ffi-x86_64.h
 libffi-devel.i686
+libicu-devel.i686
 libmandoc-devel.i686
 libxml2-devel.i686
 libyaml-devel.i686

--- a/osdeps/fedora-rawhide/reqs.txt
+++ b/osdeps/fedora-rawhide/reqs.txt
@@ -30,6 +30,7 @@ libarchive-devel
 libcap-devel
 libcurl-devel
 libffi-devel
+libicu-devel
 libmandoc-devel
 libxml2-devel
 libyaml-devel

--- a/osdeps/fedora.i686/reqs.txt
+++ b/osdeps/fedora.i686/reqs.txt
@@ -30,6 +30,7 @@ libcap-devel.i686
 libcurl-devel.i686
 /usr/include/ffi-x86_64.h
 libffi-devel.i686
+libicu-devel.i686
 libmandoc-devel.i686
 libxml2-devel.i686
 libyaml-devel.i686

--- a/osdeps/fedora/reqs.txt
+++ b/osdeps/fedora/reqs.txt
@@ -29,6 +29,7 @@ libarchive-devel
 libcap-devel
 libcurl-devel
 libffi-devel
+libicu-devel
 libmandoc-devel
 libxml2-devel
 libyaml-devel

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -65,6 +65,7 @@ lib/inspect_specname.c
 lib/inspect_subpackages.c
 lib/inspect_symlinks.c
 lib/inspect_types.c
+lib/inspect_unicode.c
 lib/inspect_upstream.c
 lib/inspect_virus.c
 lib/inspect_xml.c

--- a/po/rpminspect.pot
+++ b/po/rpminspect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rpminspect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-01 10:40-0400\n"
+"POT-Creation-Date: 2021-10-28 13:32-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: include/inspect.h:610
+#: include/inspect.h:621
 msgid ""
 "Verify the string specified in the License tag of the RPM metadata describes "
 "permissible software licenses as defined by the license database. Also "
@@ -25,20 +25,20 @@ msgid ""
 "defined in the configuration file."
 msgstr ""
 
-#: include/inspect.h:612
+#: include/inspect.h:623
 msgid ""
 "Check all binary RPMs in the build for any empty payloads. When comparing "
 "two builds, report new packages in the after build with empty payloads."
 msgstr ""
 
-#: include/inspect.h:614
+#: include/inspect.h:625
 msgid ""
 "Check all binary RPMs in the before and after builds for any empty payloads. "
 "Packages that lost payload data from the before build to the after build are "
 "reported."
 msgstr ""
 
-#: include/inspect.h:616
+#: include/inspect.h:627
 msgid ""
 "Perform some RPM header checks. First, check that the Vendor contains the "
 "expected string as defined in the configuration file. Second, check that the "
@@ -49,18 +49,18 @@ msgid ""
 "build values of the previous RPM header values and report them."
 msgstr ""
 
-#: include/inspect.h:618
+#: include/inspect.h:629
 msgid ""
 "Perform some checks on man pages in the RPM payload. First, check that each "
 "man page is compressed. Second, check that each man page contains valid "
 "content. Lastly, check that each man page is installed to the correct path."
 msgstr ""
 
-#: include/inspect.h:620
+#: include/inspect.h:631
 msgid "Check that XML files included in the RPM payload are well-formed."
 msgstr ""
 
-#: include/inspect.h:622
+#: include/inspect.h:633
 msgid ""
 "Perform several checks on ELF files. First, check that ELF objects do not "
 "contain an executable stack. Second, check that ELF objects do not contain "
@@ -71,29 +71,29 @@ msgid ""
 "make sure nothing uses them."
 msgstr ""
 
-#: include/inspect.h:624
+#: include/inspect.h:635
 msgid ""
 "Perform syntax and file reference checks on *.desktop files. Syntax errors "
 "and invalid file references are reported as errors."
 msgstr ""
 
-#: include/inspect.h:626
+#: include/inspect.h:637
 msgid ""
 "Check that the 'Release' tag in the RPM spec file includes the %{?dist} "
 "directive."
 msgstr ""
 
-#: include/inspect.h:628
+#: include/inspect.h:639
 msgid "Ensure the spec file name conforms to the NAME.spec naming format."
 msgstr ""
 
-#: include/inspect.h:630
+#: include/inspect.h:641
 msgid ""
 "Ensure compliance with modularity build and packaging policies (only valid "
 "for module builds, no-op otherwise)."
 msgstr ""
 
-#: include/inspect.h:632
+#: include/inspect.h:643
 msgid ""
 "Check minimum required Java bytecode version in class files, report bytecode "
 "version changes between builds, and report if bytecode versions are "
@@ -101,7 +101,7 @@ msgid ""
 "in the configuration file."
 msgstr ""
 
-#: include/inspect.h:634
+#: include/inspect.h:645
 msgid ""
 "Report changed files from the before build to the after build.  Certain file "
 "changes will raise additional warnings if the concern is more critical than "
@@ -113,7 +113,7 @@ msgid ""
 "changes with diff output are included in the results."
 msgstr ""
 
-#: include/inspect.h:636
+#: include/inspect.h:647
 msgid ""
 "Report files that have moved installation paths or across subpackages "
 "between builds.  Files moved with a security path prefix generate special "
@@ -122,7 +122,7 @@ msgid ""
 "the VERIFY level or higher."
 msgstr ""
 
-#: include/inspect.h:638
+#: include/inspect.h:649
 msgid ""
 "Report removed files from the before build to the after build.  Shared "
 "libraries get additional reporting output as they may be unexpected "
@@ -133,7 +133,7 @@ msgid ""
 "the VERIFY level or higher."
 msgstr ""
 
-#: include/inspect.h:640
+#: include/inspect.h:651
 msgid ""
 "Report added files from the before build to the after build.  Debuginfo "
 "files are ignored as are files that match the patterns defined in the "
@@ -144,7 +144,7 @@ msgid ""
 "packages report them at the VERIFY level or higher."
 msgstr ""
 
-#: include/inspect.h:642
+#: include/inspect.h:653
 msgid ""
 "Report Source archives defined in the RPM spec file changing content between "
 "the before and after build. If the source archives change and the package is "
@@ -152,14 +152,14 @@ msgid ""
 "the change is reported as a rebase of the package and requires inspection."
 msgstr ""
 
-#: include/inspect.h:644
+#: include/inspect.h:655
 msgid ""
 "Report files and directories owned by unexpected users and groups. Check to "
 "make sure executables are owned by the correct user and group. If a before "
 "and after build have been specified, also report ownership changes."
 msgstr ""
 
-#: include/inspect.h:646
+#: include/inspect.h:657
 msgid ""
 "For all shell scripts in the build, perform a syntax check on it using the "
 "shell defined in its #! line (shell must also be listed in shell section of "
@@ -169,7 +169,7 @@ msgid ""
 "passing the syntax check."
 msgstr ""
 
-#: include/inspect.h:648
+#: include/inspect.h:659
 msgid ""
 "Perform annocheck tests defined in the configuration file on all ELF files "
 "in the build.  A single build specified will perform an analysis only.  Two "
@@ -178,27 +178,27 @@ msgid ""
 "inspection is skipped."
 msgstr ""
 
-#: include/inspect.h:650
+#: include/inspect.h:661
 msgid ""
 "Compare DT_NEEDED entries in dynamic ELF executables and shared libraries "
 "between the before and after build and report changes."
 msgstr ""
 
-#: include/inspect.h:652
+#: include/inspect.h:663
 msgid ""
 "Report file size changes between builds.  If empty files became non-empty or "
 "non-empty files became empty, report those as results needing verification.  "
 "Report file change percentages as info-only."
 msgstr ""
 
-#: include/inspect.h:654
+#: include/inspect.h:665
 msgid ""
 "Report stat(2) mode changes between builds.  Checks against the fileinfo "
 "list for the product release specified or determined.  Any setuid or setgid "
 "changes will raise a message requiring Security Team review."
 msgstr ""
 
-#: include/inspect.h:656
+#: include/inspect.h:667
 msgid ""
 "Report capabilities(7) changes between builds.  Checks against the "
 "capabilities list for the product release specified or determined.  Any "
@@ -206,7 +206,7 @@ msgid ""
 "review."
 msgstr ""
 
-#: include/inspect.h:658
+#: include/inspect.h:669
 msgid ""
 "Report kernel module parameter, dependency, PCI ID, or symbol differences "
 "between builds.  Added and removed parameters are reported and if the "
@@ -214,7 +214,7 @@ msgid ""
 "same is true module dependencies, PCI IDs, and symbols."
 msgstr ""
 
-#: include/inspect.h:660
+#: include/inspect.h:671
 msgid ""
 "Report RPM architectures that appear and disappear between the before and "
 "after builds.  This inspection does not report the loss of noarch packages.  "
@@ -223,13 +223,13 @@ msgid ""
 "after build."
 msgstr ""
 
-#: include/inspect.h:662
+#: include/inspect.h:673
 msgid ""
 "Report RPM subpackages that appear and disappear between the before and "
 "after builds."
 msgstr ""
 
-#: include/inspect.h:664
+#: include/inspect.h:675
 #, c-format
 msgid ""
 "Ensure packages contain an entry in the %changelog for the version built.  "
@@ -237,7 +237,7 @@ msgid ""
 "that the new entry contains new text entries."
 msgstr ""
 
-#: include/inspect.h:666
+#: include/inspect.h:677
 msgid ""
 "Report files that are packaged in directories that are no longer used by the "
 "product.  Usually this means a package has not been updated to account for "
@@ -245,7 +245,7 @@ msgid ""
 "migrating to /usr/sbin."
 msgstr ""
 
-#: include/inspect.h:668
+#: include/inspect.h:679
 msgid ""
 "Link Time Optimization (LTO) produces smaller and faster shared ELF "
 "executables and libraries.  LTO bytecode is not stable from one release of "
@@ -254,26 +254,26 @@ msgid ""
 "ELF relocatable objects and reports if any is present."
 msgstr ""
 
-#: include/inspect.h:670
+#: include/inspect.h:681
 msgid ""
 "Symbolic links must be resolvable on the installed system.  This inspection "
 "ensures absolute and relative symlinks are valid.  It also checks for any "
 "symlink usage that will cause problems for RPM."
 msgstr ""
 
-#: include/inspect.h:672
+#: include/inspect.h:683
 #, c-format
 msgid ""
 "Check %files sections in the spec file for any forbidden path references."
 msgstr ""
 
-#: include/inspect.h:674
+#: include/inspect.h:685
 msgid ""
 "Compare MIME types of files between builds and report any changes for "
 "verification."
 msgstr ""
 
-#: include/inspect.h:676
+#: include/inspect.h:687
 msgid ""
 "When comparing two builds or two packages, compare ELF files using "
 "abidiff(1) from the libabigail project.  Differences are reported.  If the "
@@ -285,7 +285,7 @@ msgid ""
 "rebaseable list."
 msgstr ""
 
-#: include/inspect.h:678
+#: include/inspect.h:689
 msgid ""
 "kmidiff compares the binary Kernel Module Interfaces of two Linux kernel "
 "trees.  The binary KMI is the interface that the Linux kernel exposes to its "
@@ -295,7 +295,7 @@ msgid ""
 "verification."
 msgstr ""
 
-#: include/inspect.h:680
+#: include/inspect.h:691
 #, c-format
 msgid ""
 "Check for and report differences in configuration files marked with %config "
@@ -304,14 +304,14 @@ msgid ""
 "at the VERIFY level unless the comparison is between rebased packages."
 msgstr ""
 
-#: include/inspect.h:682
+#: include/inspect.h:693
 #, c-format
 msgid ""
 "Report changes in %doc marked files.  Files that have been added or removed "
 "as documentation files, for instance."
 msgstr ""
 
-#: include/inspect.h:684
+#: include/inspect.h:695
 msgid ""
 "Inspects all patches defined in the spec file and reports changes between "
 "builds.  At the INFO level, rpminspect reports diffstat(1) and patch size "
@@ -322,14 +322,14 @@ msgid ""
 "inspection."
 msgstr ""
 
-#: include/inspect.h:686
+#: include/inspect.h:697
 msgid ""
 "Performs a virus scan on every file in the build using libclamav.  Anything "
 "found by libclamav will fail the inspection.  The ignore_path rules are not "
 "used in this inspection.  All files are scanned."
 msgstr ""
 
-#: include/inspect.h:688
+#: include/inspect.h:699
 msgid ""
 "Check for known politically sensitive files in packages and report if they "
 "are allowed or prohibited.  The rules come from the politics/ subdirectory "
@@ -338,7 +338,7 @@ msgid ""
 "define the politically sensitive allow and deny rules for that release."
 msgstr ""
 
-#: include/inspect.h:690
+#: include/inspect.h:701
 msgid ""
 "Check for forbidden functions in ELF files.  Forbidden functions are defined "
 "in the runtime configuration files.  Usually this inspection is used to "
@@ -346,10 +346,17 @@ msgid ""
 "built packages to conform to replacement APIs."
 msgstr ""
 
-#: include/inspect.h:692
+#: include/inspect.h:703
 msgid ""
 "Check for forbidden paths in both the DT_RPATH and DT_RUNPATH settings in "
 "ELF shared objects."
+msgstr ""
+
+#: include/inspect.h:705
+msgid ""
+"Scan extracted and patched source code files, scripts, and RPM spec files "
+"for any prohibited Unicode code points, as defined in the configuration "
+"file.  Any prohibited code points are reported as a possible security risk."
 msgstr ""
 
 #: include/results.h:33
@@ -505,8 +512,8 @@ msgstr ""
 msgid ""
 "Unexpected file additions were found.  Verify these changes are correct.  If "
 "they are not, adjust the build to prevent the file additions between "
-"builds.  If they are correct, update %s and send a patch to the project "
-"owning that file so rpminspect knows to expect this change."
+"builds.  If they are correct, update %s and send a patch to the rpminspect "
+"data project owning that file so rpminspect knows to expect this change."
 msgstr ""
 
 #: include/results.h:93
@@ -806,6 +813,25 @@ msgid ""
 "only carry DT_RPATH or DT_RUNPATH, never both."
 msgstr ""
 
+#: include/results.h:183
+msgid ""
+"The rpminspect configuration file contains a list of forbidden Unicode code "
+"points.  One was found in the extracted and patched source tree or in one of "
+"the text source files in the source RPM.  Either remove this code point or "
+"discuss the situation with the Product Security Team to determine the "
+"correct course of action."
+msgstr ""
+
+#: include/results.h:185
+#, c-format
+msgid ""
+"The %prep section of the spec file could not be executed for some reason.  "
+"This usually results from a failure in librpmbuild, which is usually tied to "
+"archive extraction problems or the filesystem changing while rpminspect is "
+"running.  A common cause is removal of the working directory while the "
+"program is executing."
+msgstr ""
+
 #: lib/abi.c:163
 #, c-format
 msgid "malformed ABI level identifier: %s"
@@ -835,40 +861,40 @@ msgstr ""
 msgid "unknown workdir type %d"
 msgstr ""
 
-#: lib/builds.c:196
+#: lib/builds.c:194
 #, c-format
 msgid "unable to read %s, skipping"
 msgstr ""
 
-#: lib/builds.c:231
+#: lib/builds.c:229
 #, c-format
 msgid "unknown directory member encountered: %s"
 msgstr ""
 
-#: lib/builds.c:487
+#: lib/builds.c:483
 msgid "Downloading module"
 msgstr ""
 
-#: lib/builds.c:489
+#: lib/builds.c:485
 msgid "Downloading RPM build"
 msgstr ""
 
-#: lib/builds.c:565
+#: lib/builds.c:561
 #, c-format
 msgid "ignoring malformed module metadata file: %s"
 msgstr ""
 
-#: lib/builds.c:918
+#: lib/builds.c:914
 #, c-format
 msgid "`%s' already exists"
 msgstr ""
 
-#: lib/builds.c:960
+#: lib/builds.c:956
 #, c-format
 msgid "unable to find after build: %s"
 msgstr ""
 
-#: lib/builds.c:1012
+#: lib/builds.c:1008
 #, c-format
 msgid "unable to find before build: %s"
 msgstr ""
@@ -887,43 +913,43 @@ msgstr ""
 msgid ", overwriting"
 msgstr ""
 
-#: lib/fileinfo.c:75
+#: lib/fileinfo.c:72
 #, c-format
 msgid "%s in %s on %s carries expected mode %04o"
 msgstr ""
 
-#: lib/fileinfo.c:87
+#: lib/fileinfo.c:84
 #, c-format
 msgid ""
 "%s in %s on %s carries unexpected mode %04o; expected mode %04o; requires "
 "inspection by the Security Team"
 msgstr ""
 
-#: lib/fileinfo.c:108
+#: lib/fileinfo.c:105
 #, c-format
 msgid ""
 "%s in %s on %s carries insecure mode %04o, Security Team review may be "
 "required"
 msgstr ""
 
-#: lib/fileinfo.c:163
+#: lib/fileinfo.c:160
 #, c-format
 msgid "%s in %s on %s carries expected owner '%s'"
 msgstr ""
 
-#: lib/fileinfo.c:175
+#: lib/fileinfo.c:172
 #, c-format
 msgid ""
 "%s in %s on %s carries unexpected owner '%s'; expected owner '%s'; requires "
 "inspection by the Security Team"
 msgstr ""
 
-#: lib/fileinfo.c:234
+#: lib/fileinfo.c:231
 #, c-format
 msgid "%s in %s on %s carries expected group '%s'"
 msgstr ""
 
-#: lib/fileinfo.c:246
+#: lib/fileinfo.c:243
 #, c-format
 msgid ""
 "%s in %s on %s carries group unexpected '%s'; expected group '%s'; requires "
@@ -935,155 +961,154 @@ msgstr ""
 msgid "*** payload path %s not in RPM metadata"
 msgstr ""
 
-#: lib/init.c:259
+#: lib/init.c:266
 #, c-format
 msgid "*** ignore found in %d, value `%s'"
 msgstr ""
 
-#: lib/init.c:354
+#: lib/init.c:361
 #, c-format
 msgid "invalid input string `%s`"
 msgstr ""
 
-#: lib/init.c:381 lib/init.c:390 lib/init.c:398 lib/init.c:410 lib/init.c:419
-#: lib/init.c:427 lib/init.c:439 lib/init.c:448 lib/init.c:456 lib/init.c:468
+#: lib/init.c:388 lib/init.c:397 lib/init.c:405 lib/init.c:417 lib/init.c:426
+#: lib/init.c:434 lib/init.c:446 lib/init.c:455 lib/init.c:463 lib/init.c:475
 #, c-format
 msgid "*** invalid mode string: %s"
 msgstr ""
 
-#: lib/init.c:514
+#: lib/init.c:521
 #, c-format
 msgid "ignoring malformed %s configuration file: %s"
 msgstr ""
 
-#: lib/init.c:973
+#: lib/init.c:1004
 #, c-format
 msgid "*** unknown specname match setting '%s', defaulting to 'full'"
 msgstr ""
 
-#: lib/init.c:982
+#: lib/init.c:1013
 #, c-format
 msgid "*** unknown specname primary setting '%s', defaulting to 'name'"
 msgstr ""
 
-#: lib/init.c:993
+#: lib/init.c:1024
 msgid "error reading elf include path"
 msgstr ""
 
-#: lib/init.c:1002
+#: lib/init.c:1033
 msgid "error reading elf exclude path"
 msgstr ""
 
-#: lib/init.c:1013
+#: lib/init.c:1044
 msgid "error reading man page include path"
 msgstr ""
 
-#: lib/init.c:1022
+#: lib/init.c:1053
 msgid "error reading man page exclude path"
 msgstr ""
 
-#: lib/init.c:1033
+#: lib/init.c:1064
 msgid "error reading xml include path"
 msgstr ""
 
-#: lib/init.c:1042
+#: lib/init.c:1073
 msgid "error reading xml exclude path"
 msgstr ""
 
-#: lib/init.c:1086
+#: lib/init.c:1117
 #, c-format
 msgid "*** inspection flag must be 'on' or 'off', ignoring for '%s'"
 msgstr ""
 
-#: lib/init.c:1090 src/rpminspect.c:280
+#: lib/init.c:1121 src/rpminspect.c:281
 #, c-format
 msgid "*** Unknown inspection: `%s`"
 msgstr ""
 
-#: lib/init.c:1314
+#: lib/init.c:1179
+msgid "error reading unicode exclude regular expression"
+msgstr ""
+
+#: lib/init.c:1355
 #, c-format
 msgid "*** Invalid filename in the fileinfo list: %s"
 msgstr ""
 
-#: lib/init.c:1315
+#: lib/init.c:1356
 msgid "*** From this invalid line:"
 msgstr ""
 
-#: lib/init.c:1316
+#: lib/init.c:1357
 #, c-format
 msgid "***     %s"
 msgstr ""
 
-#: lib/init.c:1727
+#: lib/init.c:1768
 #, c-format
 msgid "*** invalid security rule: %s"
 msgstr ""
 
-#: lib/init.c:1761
+#: lib/init.c:1802
 #, c-format
 msgid "*** unknown security rule: %s"
 msgstr ""
 
-#: lib/init.c:1781
+#: lib/init.c:1822
 #, c-format
 msgid "*** unknown security action: %s"
 msgstr ""
 
-#: lib/init.c:1807
+#: lib/init.c:1848
 #, c-format
 msgid "*** malformed security line: %s"
 msgstr ""
 
-#: lib/init.c:1898 lib/init.c:1919
+#: lib/init.c:2001 lib/init.c:2022
 #, c-format
 msgid "*** error reading '%s'\n"
 msgstr ""
 
-#: lib/init.c:1914
+#: lib/init.c:2017
 #, c-format
 msgid "*** unable to read profile '%s' from %s\n"
 msgstr ""
 
-#: lib/inspect_abidiff.c:220 lib/inspect_kmidiff.c:295
-#, c-format
-msgid "Command: %s"
-msgstr ""
-
-#: lib/inspect_abidiff.c:221
-msgid "ABI comparison ended unexpectedly."
-msgstr ""
-
-#: lib/inspect_abidiff.c:238 lib/inspect_abidiff.c:245
+#: lib/inspect_abidiff.c:210 lib/inspect_abidiff.c:215
 msgid "ABI"
 msgstr ""
 
-#: lib/inspect_abidiff.c:257
+#: lib/inspect_abidiff.c:227
 #, c-format
 msgid ""
 "Comparing old vs. new version of %s in package %s with ABI compatibility "
 "level %ld on %s revealed ABI differences."
 msgstr ""
 
-#: lib/inspect_abidiff.c:259
+#: lib/inspect_abidiff.c:229
 #, c-format
 msgid ""
 "Comparing old vs. new version of %s in package %s on %s revealed ABI "
 "differences."
 msgstr ""
 
-#: lib/inspect_abidiff.c:263
+#: lib/inspect_abidiff.c:233
 #, c-format
 msgid ""
 "Comparing from %s to %s in package %s with ABI compatibility level %ld on %s "
 "revealed ABI differences."
 msgstr ""
 
-#: lib/inspect_abidiff.c:265
+#: lib/inspect_abidiff.c:235
 #, c-format
 msgid "Comparing from %s to %s in package %s on %s revealed ABI differences."
 msgstr ""
 
-#: lib/inspect_abidiff.c:273 lib/inspect_kmidiff.c:339
+#: lib/inspect_abidiff.c:242
+msgid "ABI comparison ended unexpectedly."
+msgstr ""
+
+#: lib/inspect_abidiff.c:248 lib/inspect_kmidiff.c:293
 #, c-format
 msgid ""
 "Command: %s\n"
@@ -1121,22 +1146,22 @@ msgstr ""
 msgid "`%s` added on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:105 lib/inspect_annocheck.c:121
+#: lib/inspect_annocheck.c:151 lib/inspect_annocheck.c:167
 #, c-format
 msgid "annocheck '%s' test passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:107
+#: lib/inspect_annocheck.c:153
 #, c-format
 msgid "annocheck '%s' test now passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:109
+#: lib/inspect_annocheck.c:155
 #, c-format
 msgid "annocheck '%s' test now fails for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:114 lib/inspect_annocheck.c:123
+#: lib/inspect_annocheck.c:160 lib/inspect_annocheck.c:169
 #, c-format
 msgid "annocheck '%s' test fails for %s on %s"
 msgstr ""
@@ -1205,7 +1230,8 @@ msgstr ""
 
 #: lib/inspect_capabilities.c:153
 #, c-format
-msgid "File capabilities for %s not found on the capabilities list on %s\n"
+msgid ""
+"File capabilities for %s (%s) not found on the capabilities list on %s\n"
 msgstr ""
 
 #: lib/inspect_capabilities.c:167
@@ -1239,7 +1265,7 @@ msgid "Message catalog %s changed content on %s"
 msgstr ""
 
 #: lib/inspect_changedfiles.c:369 lib/inspect_changedfiles.c:433
-#: lib/inspect_changedfiles.c:454 lib/inspect_desktop.c:405
+#: lib/inspect_changedfiles.c:454 lib/inspect_desktop.c:449
 #: lib/inspect_manpage.c:308
 msgid "${FILE}"
 msgstr ""
@@ -1316,14 +1342,14 @@ msgstr ""
 msgid "not "
 msgstr ""
 
-#: lib/inspect_desktop.c:271
+#: lib/inspect_desktop.c:284
 #, c-format
 msgid ""
 "Desktop file %s on %s references executable %s but %s is not executable by "
 "all"
 msgstr ""
 
-#: lib/inspect_desktop.c:286
+#: lib/inspect_desktop.c:307
 #, c-format
 msgid ""
 "Desktop file %s on %s references executable %s; no subpackages contain an "
@@ -1331,71 +1357,65 @@ msgid ""
 "in case %s does not exist"
 msgstr ""
 
-#: lib/inspect_desktop.c:293
+#: lib/inspect_desktop.c:314
 #, c-format
 msgid ""
 "Desktop file %s on %s references executable %s but no subpackages contain an "
 "executable of that name"
 msgstr ""
 
-#: lib/inspect_desktop.c:324
+#: lib/inspect_desktop.c:358
 #, c-format
 msgid "Desktop file %s on %s references icon %s but %s is not readable by all"
 msgstr ""
 
-#: lib/inspect_desktop.c:334
+#: lib/inspect_desktop.c:378
 #, c-format
 msgid "Desktop file %s on %s references icon %s but no subpackages contain %s"
 msgstr ""
 
-#: lib/inspect_desktop.c:408
+#: lib/inspect_desktop.c:452
 #, c-format
 msgid ""
 "File %s is no longer a valid desktop entry file on %s; desktop-file-validate "
 "reports:"
 msgstr ""
 
-#: lib/inspect_desktop.c:410
+#: lib/inspect_desktop.c:454
 #, c-format
 msgid ""
 "New file %s is not a valid desktop file on %s; desktop-file-validate reports:"
 msgstr ""
 
-#: lib/inspect_desktop.c:412
+#: lib/inspect_desktop.c:456
 #, c-format
 msgid ""
 "File %s is not a valid desktop file on %s; desktop-file-validate reports:"
 msgstr ""
 
-#: lib/inspect_disttag.c:192
+#: lib/inspect_disttag.c:197
 #, c-format
 msgid "The %s file is missing the %s tag."
 msgstr ""
 
-#: lib/inspect_disttag.c:194
+#: lib/inspect_disttag.c:199
 msgid "Release: tag"
 msgstr ""
 
-#: lib/inspect_disttag.c:198
+#: lib/inspect_disttag.c:205
 #, c-format
 msgid ""
-"The dist tag should be of the form '%s' in the %s tag or in a macro used in "
-"the %s tag."
+"The %s tag value is missing the dist tag in the proper form. The dist tag "
+"should be of the form '%s' in the %s tag or in a macro used in the %s tag. "
+"After RPM macro expansion, no dist tag was found in this %s tag value."
 msgstr ""
 
-#: lib/inspect_disttag.c:200 lib/inspect_disttag.c:206
+#: lib/inspect_disttag.c:207
 #, c-format
 msgid "'%%{?dist}' tag"
 msgstr ""
 
-#: lib/inspect_disttag.c:204
-#, c-format
-msgid ""
-"The %s tag does not seem to contain '%s' or a macro that expands to include "
-"the '%s' tag."
-msgstr ""
-
-#: lib/inspect_disttag.c:261
+#: lib/inspect_disttag.c:275
 msgid "Specified package is not a source RPM, skipping."
 msgstr ""
 
@@ -1567,14 +1587,14 @@ msgstr ""
 msgid "%s in %s has TEXTREL relocations on %s"
 msgstr ""
 
-#: lib/inspect_emptyrpm.c:90
+#: lib/inspect_emptyrpm.c:91
 #, c-format
 msgid ""
 "New package %s is empty (no payloads); this is expected per the "
 "configuration file"
 msgstr ""
 
-#: lib/inspect_emptyrpm.c:95
+#: lib/inspect_emptyrpm.c:97
 #, c-format
 msgid "New package %s is empty (no payloads)"
 msgstr ""
@@ -1651,26 +1671,26 @@ msgstr ""
 msgid "strtol"
 msgstr ""
 
-#: lib/inspect_kmidiff.c:296
-msgid "KMI comparison ended unexpectedly."
-msgstr ""
-
-#: lib/inspect_kmidiff.c:313 lib/inspect_kmidiff.c:320
+#: lib/inspect_kmidiff.c:264 lib/inspect_kmidiff.c:269
 msgid "KMI"
 msgstr ""
 
-#: lib/inspect_kmidiff.c:330
+#: lib/inspect_kmidiff.c:279
 #, c-format
 msgid ""
 "Comparing old vs. new version of %s in package %s on %s revealed Kernel "
 "Module Interface (KMI) differences."
 msgstr ""
 
-#: lib/inspect_kmidiff.c:332
+#: lib/inspect_kmidiff.c:281
 #, c-format
 msgid ""
 "Comparing from %s to %s in package %s on %s revealed Kernel Module Interface "
 "(KMI) differences."
+msgstr ""
+
+#: lib/inspect_kmidiff.c:287
+msgid "KMI comparison ended unexpectedly."
 msgstr ""
 
 #: lib/inspect_kmod.c:44
@@ -2191,6 +2211,36 @@ msgstr ""
 msgid "MIME type on %s was %s and became %s on %s"
 msgstr ""
 
+#: lib/inspect_unicode.c:242
+#, c-format
+msgid "empty localpath on %s"
+msgstr ""
+
+#: lib/inspect_unicode.c:258
+msgid "forbidden code point in ${FILE}"
+msgstr ""
+
+#: lib/inspect_unicode.c:311
+#, c-format
+msgid ""
+"A forbidden code point was found in the %s source file on line %ld at column "
+"%ld."
+msgstr ""
+
+#: lib/inspect_unicode.c:356
+#, c-format
+msgid "unable to run %prep in ${FILE}"
+msgstr ""
+
+#: lib/inspect_unicode.c:359
+#, c-format
+msgid "Unable to run through the %%prep section %s for further scanning."
+msgstr ""
+
+#: lib/inspect_unicode.c:441
+msgid "The unicode inspection is only for source packages, skipping."
+msgstr ""
+
 #: lib/inspect_upstream.c:76
 #, c-format
 msgid "New upstream source file `%s` appeared"
@@ -2215,17 +2265,17 @@ msgid "Source file `%s` removed"
 msgstr ""
 
 #: lib/inspect_virus.c:56
-msgid "cl_engine_new() returned NULL, check clamav library"
+msgid "cl_engine_new returned NULL, check clamav library"
 msgstr ""
 
 #: lib/inspect_virus.c:64
 #, c-format
-msgid "cl_load(): %s"
+msgid "cl_load: %s"
 msgstr ""
 
 #: lib/inspect_virus.c:72
 #, c-format
-msgid "cl_engine_compile(): %s"
+msgid "cl_engine_compile: %s"
 msgstr ""
 
 #: lib/inspect_virus.c:102
@@ -2240,7 +2290,7 @@ msgstr ""
 
 #: lib/inspect_virus.c:129
 #, c-format
-msgid "cl_init(): %s"
+msgid "cl_init: %s"
 msgstr ""
 
 #: lib/inspect_virus.c:140
@@ -2276,11 +2326,11 @@ msgstr ""
 msgid "XML-RPC Fault: %s (%d)"
 msgstr ""
 
-#: lib/magic.c:54
+#: lib/magic.c:48
 msgid "unable to initialize the magic library"
 msgstr ""
 
-#: lib/magic.c:59
+#: lib/magic.c:53
 #, c-format
 msgid "unable to load the magic database: %s"
 msgstr ""
@@ -2357,7 +2407,7 @@ msgstr ""
 
 #: lib/rpm.c:78
 #, c-format
-msgid "Fopen() failed for %s: %s"
+msgid "Fopen failed for %s: %s"
 msgstr ""
 
 #: lib/rpm.c:261
@@ -2365,14 +2415,27 @@ msgstr ""
 msgid "*** file index %d is out of bounds for %s"
 msgstr ""
 
-#: lib/runcmd.c:86
+#: lib/runcmd.c:188
 #, c-format
-msgid "error running `%s`"
+msgid "%d"
 msgstr ""
 
-#: lib/runcmd.c:121
+#: lib/runcmd.c:190
 #, c-format
-msgid "error closing `%s`"
+msgid "%d (%s)"
+msgstr ""
+
+#: lib/runcmd.c:195
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"%s tried to run the command and it received signal %s"
+msgstr ""
+
+#: lib/runcmd.c:199
+#, c-format
+msgid "%s tried to run the command and it received signal %s"
 msgstr ""
 
 #: lib/strfuncs.c:257 lib/strfuncs.c:286
@@ -2447,304 +2510,304 @@ msgstr ""
 msgid "UNKNOWN"
 msgstr ""
 
-#: src/rpminspect.c:53
+#: src/rpminspect.c:54
 #, c-format
 msgid ""
 "Compare package builds for policy compliance and consistency.\n"
 "\n"
 msgstr ""
 
-#: src/rpminspect.c:54
+#: src/rpminspect.c:55
 #, c-format
 msgid "Usage: %s [OPTIONS] [before build] [after build]\n"
 msgstr ""
 
-#: src/rpminspect.c:55
+#: src/rpminspect.c:56
 #, c-format
 msgid "Options:\n"
 msgstr ""
 
-#: src/rpminspect.c:56
+#: src/rpminspect.c:57
 #, c-format
 msgid "  -c FILE, --config=FILE   Configuration file to use\n"
 msgstr ""
 
-#: src/rpminspect.c:57
+#: src/rpminspect.c:58
 #, c-format
 msgid "  -p NAME, --profile=NAME  Configuration profile to use\n"
 msgstr ""
 
-#: src/rpminspect.c:58
+#: src/rpminspect.c:59
 #, c-format
 msgid "  -T LIST, --tests=LIST    List of tests to run\n"
 msgstr ""
 
-#: src/rpminspect.c:59
+#: src/rpminspect.c:60
 #, c-format
 msgid "                             (default: ALL)\n"
 msgstr ""
 
-#: src/rpminspect.c:60
+#: src/rpminspect.c:61
 #, c-format
 msgid "  -E LIST, --exclude=LIST  List of tests to exclude\n"
 msgstr ""
 
-#: src/rpminspect.c:61
+#: src/rpminspect.c:62
 #, c-format
 msgid "                             (default: none)\n"
 msgstr ""
 
-#: src/rpminspect.c:62
+#: src/rpminspect.c:63
 #, c-format
 msgid "  -a LIST, --arches=LIST   List of architectures to check\n"
 msgstr ""
 
-#: src/rpminspect.c:63
+#: src/rpminspect.c:64
 #, c-format
 msgid "  -r STR, --release=STR    Product release string\n"
 msgstr ""
 
-#: src/rpminspect.c:64
+#: src/rpminspect.c:65
 #, c-format
 msgid "  -n, --no-rebase          Disable build rebase detection\n"
 msgstr ""
 
-#: src/rpminspect.c:65
+#: src/rpminspect.c:66
 #, c-format
 msgid "  -o FILE, --output=FILE   Write results to FILE\n"
 msgstr ""
 
-#: src/rpminspect.c:66
+#: src/rpminspect.c:67
 #, c-format
 msgid "                             (default: stdout)\n"
 msgstr ""
 
-#: src/rpminspect.c:67
+#: src/rpminspect.c:68
 #, c-format
 msgid "  -F TYPE, --format=TYPE   Format output results as TYPE\n"
 msgstr ""
 
-#: src/rpminspect.c:68
+#: src/rpminspect.c:69
 #, c-format
 msgid "                             (default: text)\n"
 msgstr ""
 
-#: src/rpminspect.c:69
+#: src/rpminspect.c:70
 #, c-format
 msgid "  -t TAG, --threshold=TAG  Result threshold triggering exit\n"
 msgstr ""
 
-#: src/rpminspect.c:70
+#: src/rpminspect.c:71
 #, c-format
 msgid "                           failure (default: VERIFY)\n"
 msgstr ""
 
-#: src/rpminspect.c:71
+#: src/rpminspect.c:72
 #, c-format
 msgid "  -l, --list               List available tests and formats\n"
 msgstr ""
 
-#: src/rpminspect.c:72
+#: src/rpminspect.c:73
 #, c-format
 msgid "  -w PATH, --workdir=PATH  Temporary directory to use\n"
 msgstr ""
 
-#: src/rpminspect.c:73
+#: src/rpminspect.c:74
 #, c-format
 msgid "                             (default: %s)\n"
 msgstr ""
 
-#: src/rpminspect.c:74
+#: src/rpminspect.c:75
 #, c-format
 msgid ""
 "  -f, --fetch-only         Fetch builds only, do not perform inspections\n"
 msgstr ""
 
-#: src/rpminspect.c:75
+#: src/rpminspect.c:76
 #, c-format
 msgid "                             (implies -k)\n"
 msgstr ""
 
-#: src/rpminspect.c:76
+#: src/rpminspect.c:77
 #, c-format
 msgid "  -k, --keep               Do not remove the comparison working files\n"
 msgstr ""
 
-#: src/rpminspect.c:77
+#: src/rpminspect.c:78
 #, c-format
 msgid "  -d, --debug              Debugging mode output\n"
 msgstr ""
 
-#: src/rpminspect.c:78
+#: src/rpminspect.c:79
 #, c-format
 msgid ""
 "  -D, --dump-config        Dump configuration settings used (in YAML "
 "format)\n"
 msgstr ""
 
-#: src/rpminspect.c:79
+#: src/rpminspect.c:80
 #, c-format
 msgid "  -v, --verbose            Verbose inspection output\n"
 msgstr ""
 
-#: src/rpminspect.c:80
+#: src/rpminspect.c:81
 #, c-format
 msgid "                           when finished, display full path\n"
 msgstr ""
 
-#: src/rpminspect.c:81
+#: src/rpminspect.c:82
 #, c-format
 msgid "  -?, --help               Display usage information\n"
 msgstr ""
 
-#: src/rpminspect.c:82
+#: src/rpminspect.c:83
 #, c-format
 msgid "  -V, --version            Display program version\n"
 msgstr ""
 
-#: src/rpminspect.c:83
+#: src/rpminspect.c:84
 #, c-format
 msgid ""
 "\n"
 "See the rpminspect(1) man page for more information.\n"
 msgstr ""
 
-#: src/rpminspect.c:114 src/rpminspect.c:125
+#: src/rpminspect.c:115 src/rpminspect.c:126
 #, c-format
 msgid "*** Product release for after build (%s) is empty"
 msgstr ""
 
-#: src/rpminspect.c:140 src/rpminspect.c:149
+#: src/rpminspect.c:141 src/rpminspect.c:150
 #, c-format
 msgid "*** Product release for before build (%s) is empty"
 msgstr ""
 
-#: src/rpminspect.c:187
+#: src/rpminspect.c:188
 #, c-format
 msgid "*** unable to compile product release regular expression: %s"
 msgstr ""
 
-#: src/rpminspect.c:249
+#: src/rpminspect.c:250
 #, c-format
 msgid "*** Unable to determine product release for %s and %s"
 msgstr ""
 
-#: src/rpminspect.c:264
+#: src/rpminspect.c:265
 msgid "*** The -T and -E options are mutually exclusive"
 msgstr ""
 
-#: src/rpminspect.c:265 src/rpminspect.c:281 src/rpminspect.c:646
-#: src/rpminspect.c:684
+#: src/rpminspect.c:266 src/rpminspect.c:282 src/rpminspect.c:647
+#: src/rpminspect.c:688
 #, c-format
 msgid "*** See `%s --help` for more information."
 msgstr ""
 
-#: src/rpminspect.c:435
+#: src/rpminspect.c:436
 #, c-format
 msgid "*** Invalid output format: `%s`."
 msgstr ""
 
-#: src/rpminspect.c:450
+#: src/rpminspect.c:451
 #, c-format
 msgid "*** Unable to expand workdir: `%s`"
 msgstr ""
 
-#: src/rpminspect.c:482
+#: src/rpminspect.c:483
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: src/rpminspect.c:485
+#: src/rpminspect.c:486
 #, c-format
 msgid "?? getopt returned character code 0%o ??"
 msgstr ""
 
-#: src/rpminspect.c:492
+#: src/rpminspect.c:493
 #, c-format
 msgid "Available output formats:\n"
 msgstr ""
 
-#: src/rpminspect.c:509
+#: src/rpminspect.c:510
 #, c-format
 msgid ""
 "\n"
 "Available inspections:\n"
 msgstr ""
 
-#: src/rpminspect.c:546 src/rpminspect.c:554 src/rpminspect.c:567
+#: src/rpminspect.c:547 src/rpminspect.c:555 src/rpminspect.c:568
 #, c-format
 msgid "Failed to read configuration file %s"
 msgstr ""
 
-#: src/rpminspect.c:573
+#: src/rpminspect.c:574
 #, c-format
 msgid "Please specify a configuration file using '-c' or supply ./%s"
 msgstr ""
 
-#: src/rpminspect.c:645
+#: src/rpminspect.c:646
 msgid "*** Invalid before and after build specification."
 msgstr ""
 
-#: src/rpminspect.c:653
+#: src/rpminspect.c:654
 msgid "*** unable to read RPM configuration"
 msgstr ""
 
-#: src/rpminspect.c:683
+#: src/rpminspect.c:687
 #, c-format
 msgid "*** Unsupported architecture specified: `%s`"
 msgstr ""
 
-#: src/rpminspect.c:706
+#: src/rpminspect.c:710
 #, c-format
 msgid "*** Unable to create directory %s"
 msgstr ""
 
-#: src/rpminspect.c:719 src/rpminspect.c:735
+#: src/rpminspect.c:723 src/rpminspect.c:739
 msgid "*** failed to gather specified builds."
 msgstr ""
 
-#: src/rpminspect.c:742
+#: src/rpminspect.c:746
 msgid "diagnostics"
 msgstr ""
 
-#: src/rpminspect.c:748
+#: src/rpminspect.c:752
 #, c-format
 msgid ""
 "Version information for libraries and programs used by %s.  This result is "
 "for informational and diagnostic purposes only."
 msgstr ""
 
-#: src/rpminspect.c:756
+#: src/rpminspect.c:760
 #, c-format
 msgid "Command line arguments used to invoke %s."
 msgstr ""
 
-#: src/rpminspect.c:787
+#: src/rpminspect.c:791
 msgid "*** No peers, ensure packages exist for specified architecture(s)."
 msgstr ""
 
-#: src/rpminspect.c:795
+#: src/rpminspect.c:799
 msgid "invalid after RPM"
 msgstr ""
 
-#: src/rpminspect.c:803
+#: src/rpminspect.c:807
 msgid "invalid before RPM"
 msgstr ""
 
-#: src/rpminspect.c:828
+#: src/rpminspect.c:832
 #, c-format
 msgid "Running %s inspection..."
 msgstr ""
 
-#: src/rpminspect.c:837
+#: src/rpminspect.c:841
 msgid "pass"
 msgstr ""
 
-#: src/rpminspect.c:837
+#: src/rpminspect.c:841
 msgid "FAIL"
 msgstr ""
 
-#: src/rpminspect.c:859
+#: src/rpminspect.c:863
 #, c-format
 msgid ""
 "\n"

--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -36,6 +36,7 @@ BuildRequires:  gettext-devel
 BuildRequires:  clamav-devel
 BuildRequires:  libmandoc-devel >= 1.14.5
 BuildRequires:  gnupg2
+BuildRequires:  libicu-devel
 
 
 %description

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -33,7 +33,8 @@
 #include <zlib.h>
 #include <magic.h>
 #include <clamav.h>
-
+#include <rpm/rpmlib.h>
+#include <rpm/rpmmacro.h>
 #include "rpminspect.h"
 
 void sigabrt_handler(__attribute__ ((unused)) int i)
@@ -653,6 +654,9 @@ int main(int argc, char **argv)
         errx(RI_PROGRAM_ERROR, _("*** unable to read RPM configuration"));
     }
 
+    /* load macros for librpm */
+    load_macros(ri);
+
     /* if an architecture list is specified, validate it */
     if (archopt) {
         /* initialize the list of allowed architectures */
@@ -864,6 +868,7 @@ int main(int argc, char **argv)
     }
 
     free_rpminspect(ri);
+    rpmFreeMacros(NULL);
     rpmFreeRpmrc();
 
     return ret;

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -270,6 +270,7 @@ class TestSRPM(RequiresRpminspect):
         )
 
     def tearDown(self):
+        super().tearDown()
         self.rpm.clean()
 
 
@@ -367,6 +368,7 @@ class TestCompareSRPM(RequiresRpminspect):
         )
 
     def tearDown(self):
+        super().tearDown()
         self.before_rpm.clean()
         self.after_rpm.clean()
 
@@ -435,9 +437,6 @@ class TestRPMs(TestSRPM):
                 self.waiver_auth,
             )
 
-    def tearDown(self):
-        self.rpm.clean()
-
 
 # Base test case class that compares before and after built RPMs
 class TestCompareRPMs(TestCompareSRPM):
@@ -504,10 +503,6 @@ class TestCompareRPMs(TestCompareSRPM):
                 self.waiver_auth,
                 message=self.message,
             )
-
-    def tearDown(self):
-        self.before_rpm.clean()
-        self.after_rpm.clean()
 
 
 # Base test case class that tests a fake Koji build
@@ -587,9 +582,6 @@ class TestKoji(TestSRPM):
                 self.waiver_auth,
                 message=self.message,
             )
-
-    def tearDown(self):
-        self.rpm.clean()
 
 
 # Base test case class that compares before and after Koji builds
@@ -683,7 +675,3 @@ class TestCompareKoji(TestCompareSRPM):
                 )
             except AssertionError:
                 self.dumpResults()
-
-    def tearDown(self):
-        self.before_rpm.clean()
-        self.after_rpm.clean()

--- a/test/data/unicode/Makefile
+++ b/test/data/unicode/Makefile
@@ -1,0 +1,5 @@
+all:
+	echo "Nothing to build"
+
+install:
+	install -D -m 0755 status.sh $(DESTDIR)/usr/bin/status

--- a/test/data/unicode/bad.c
+++ b/test/data/unicode/bad.c
@@ -1,8 +1,15 @@
-#include <stdio.h>
-#include <stdlib.h>
 
-int main(int argc, char **argv)
-{
-    printf("Hello,‮ world!\n");
-    return⁨ EXIT_SUCCESS;
-}
+  void he‮oll‬ ()
+  {
+    __builtin_printf ("hah, gotcha!\n");
+  }
+
+  void hello ()
+  {
+    __builtin_printf ("Hello world\n");
+  }
+  int main ()
+  {
+    he‮oll‬ ();
+    return 0;
+  }

--- a/test/data/unicode/bad.c
+++ b/test/data/unicode/bad.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    printf("Hello,‮ world!\n");
+    return⁨ EXIT_SUCCESS;
+}

--- a/test/data/unicode/bad.s
+++ b/test/data/unicode/bad.s
@@ -1,0 +1,69 @@
+	.file	"trick-hello.c"
+	.text
+	.section	.rodata
+.LC0:
+	.string	"hah, gotcha!"
+	.text
+	.globl	he‮oll‬
+	.type	he‮oll‬, @function
+he‮oll‬:
+.LFB0:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movl	$.LC0, %edi
+	call	puts
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE0:
+	.size	he‮oll‬, .-he‮oll‬
+	.section	.rodata
+.LC1:
+	.string	"Hello world"
+	.text
+	.globl	hello
+	.type	hello, @function
+hello:
+.LFB1:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movl	$.LC1, %edi
+	call	puts
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE1:
+	.size	hello, .-hello
+	.globl	main
+	.type	main, @function
+main:
+.LFB2:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movl	$0, %eax
+	call	he‮oll‬
+	movl	$0, %eax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE2:
+	.size	main, .-main
+	.ident	"GCC: (GNU) 11.2.1 20210728 (Red Hat 11.2.1-1)"
+	.section	.note.GNU-stack,"",@progbits

--- a/test/data/unicode/commenting-out-new.c
+++ b/test/data/unicode/commenting-out-new.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+int main() {
+    bool isAdmin = false;
+    /*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */
+        printf("You are an admin.\n");
+    /* end admins only ‮ { ⁦*/
+    return 0;
+}

--- a/test/data/unicode/early-return-new.c
+++ b/test/data/unicode/early-return-new.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main() {
+    /* Say hello; newline⁧/*/ return 0 ;
+    printf("Hello world.\n");
+    return 0;
+}

--- a/test/data/unicode/good.c
+++ b/test/data/unicode/good.c
@@ -1,8 +1,9 @@
-#include <stdio.h>
-#include <stdlib.h>
-
-int main(int argc, char **argv)
-{
-    printf("Hello, world!\n");
-    return EXIT_SUCCESS;
-}
+  void hello ()
+  {
+    __builtin_printf ("Hello world\n");
+  }
+  int main ()
+  {
+    hello ();
+    return 0;
+  }

--- a/test/data/unicode/good.c
+++ b/test/data/unicode/good.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    printf("Hello, world!\n");
+    return EXIT_SUCCESS;
+}

--- a/test/data/unicode/status.sh
+++ b/test/data/unicode/status.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Show me some status
+/bin/cat /proc/cpuinfo /proc/meminfo

--- a/test/data/unicode/stretched-string-new.c
+++ b/test/data/unicode/stretched-string-new.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <string.h>
+
+int main() {
+    char* access_level = "user";
+    if (strcmp(access_level, "user‮ ⁦// Check if admin⁩ ⁦")) {
+        printf("You are an admin.\n");
+    }
+    return 0;
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -146,6 +146,7 @@ if python.found()
         'test_specname.py',
         'test_symlinks.py',
         'test_types.py',
+        'test_unicode.py',
         'test_upstream.py',
         'test_virus.py',
         'test_xml.py'

--- a/test/test_unicode.py
+++ b/test/test_unicode.py
@@ -19,6 +19,8 @@
 import os
 import rpmfluff
 
+from baseclass import BEFORE_NAME, BEFORE_VER, AFTER_NAME, AFTER_VER
+
 from baseclass import (
     TestSRPM,
     TestRPMs,
@@ -29,8 +31,9 @@ from baseclass import (
 )
 
 datadir = os.environ["RPMINSPECT_TEST_DATA_PATH"]
-good_src = open(os.path.join(datadir, "unicode", "good.c")).read()
-bad_src = open(os.path.join(datadir, "unicode", "bad.c")).read()
+good_c_src = open(os.path.join(datadir, "unicode", "good.c")).read()
+bad_c_src = open(os.path.join(datadir, "unicode", "bad.c")).read()
+bad_asm_src = open(os.path.join(datadir, "unicode", "bad.s")).read()
 status_src = open(os.path.join(datadir, "unicode", "status.sh")).read()
 makefile_src = open(os.path.join(datadir, "unicode", "Makefile")).read()
 
@@ -47,7 +50,7 @@ class UnicodeGoodSourceSRPM(TestSRPM):
         )
 
         # drop our known good source file directly in the SRPM
-        self.rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+        self.rpm.add_source(rpmfluff.SourceFile("good.c", good_c_src))
 
         self.inspection = "unicode"
         self.result = "OK"
@@ -63,7 +66,7 @@ class UnicodeGoodSourceRPMs(TestRPMs):
         )
 
         # drop our known good source file directly in the SRPM
-        self.rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+        self.rpm.add_source(rpmfluff.SourceFile("good.c", good_c_src))
 
         self.inspection = "unicode"
         self.result = "OK"
@@ -79,7 +82,7 @@ class UnicodeGoodSourceKoji(TestKoji):
         )
 
         # drop our known good source file directly in the SRPM
-        self.rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+        self.rpm.add_source(rpmfluff.SourceFile("good.c", good_c_src))
 
         self.inspection = "unicode"
         self.result = "OK"
@@ -98,8 +101,8 @@ class UnicodeGoodSourceCompareSRPM(TestCompareSRPM):
         )
 
         # drop our known good source file directly in the SRPM
-        self.before_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
-        self.after_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+        self.before_rpm.add_source(rpmfluff.SourceFile("good.c", good_c_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("good.c", good_c_src))
 
         self.inspection = "unicode"
         self.result = "OK"
@@ -118,8 +121,8 @@ class UnicodeGoodSourceCompareRPMs(TestCompareRPMs):
         )
 
         # drop our known good source file directly in the SRPM
-        self.before_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
-        self.after_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+        self.before_rpm.add_source(rpmfluff.SourceFile("good.c", good_c_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("good.c", good_c_src))
 
         self.inspection = "unicode"
         self.result = "OK"
@@ -138,8 +141,8 @@ class UnicodeGoodSourceCompareKoji(TestCompareKoji):
         )
 
         # drop our known good source file directly in the SRPM
-        self.before_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
-        self.after_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+        self.before_rpm.add_source(rpmfluff.SourceFile("good.c", good_c_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("good.c", good_c_src))
 
         self.inspection = "unicode"
         self.result = "OK"
@@ -147,37 +150,219 @@ class UnicodeGoodSourceCompareKoji(TestCompareKoji):
 
 # The following tests run the unicode inspection with a known good source
 # file in a tarball in the SRPM.  All of the results for these should be 'OK'.
-# class UnicodeGoodSourceArchiveSRPM(TestSRPM):
-#    def setUp(self):
-#        super().setUp()
-#
-#        self.rpm.add_source(
-#            rpmfluff.GeneratedTarball("%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
-#                                      "%s-%s" % (AFTER_NAME, AFTER_VER),
-#                                      [rpmfluff.SourceFile("Makefile", makefile_src),
-#                                       rpmfluff.SourceFile("good.c", good_src),
-#                                       rpmfluff.SourceFile("status.sh", status_src)])
-#        )
-#        self.rpm.section_prep = "%setup\n"
-#        self.rpm.section_build += "make\n"
-#        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
-#        sub = self.rpm.get_subpackage(None)
-#        sub.section_files += "%attr(0755,root,root) /usr/bin/status\n"
-#
-#        self.inspection = "unicode"
-#        self.result = "OK"
+class UnicodeGoodSourceArchiveSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("good.c", good_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.result = "OK"
 
 
-# class UnicodeGoodSourceArchiveRPMs(TestRPMs):
-# class UnicodeGoodSourceArchiveKoji(TestKoji):
-# class UnicodeGoodSourceArchiveCompareSRPM(TestCompareSRPM):
-# class UnicodeGoodSourceArchiveCompareRPMs(TestCompareRPMs):
-# class UnicodeGoodSourceArchiveCompareKoji(TestCompareKoji):
+class UnicodeGoodSourceArchiveRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("good.c", good_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeGoodSourceArchiveKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("good.c", good_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeGoodSourceArchiveCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("good.c", good_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("good.c", good_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeGoodSourceArchiveCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("good.c", good_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("good.c", good_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeGoodSourceArchiveCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("good.c", good_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("good.c", good_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.result = "OK"
 
 
 # The following tests run the unicode inspection with a known bad source file
 # in the SRPM.  All of the results for these should be 'BAD' with a waiver
-# authorization of "Security".
+# authorization of "Security" except for the jobs that lack any SRPM file.
 class UnicodeBadSourceSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
@@ -187,8 +372,9 @@ class UnicodeBadSourceSRPM(TestSRPM):
             "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
         )
 
-        # drop our known bad source file directly in the SRPM
-        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
         self.waiver_auth = "Security"
@@ -204,12 +390,15 @@ class UnicodeBadSourceRPMs(TestRPMs):
             "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
         )
 
-        # drop our known bad source file directly in the SRPM
-        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
-        self.waiver_auth = "Security"
-        self.result = "BAD"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
 
 
 class UnicodeBadSourceKoji(TestKoji):
@@ -221,8 +410,9 @@ class UnicodeBadSourceKoji(TestKoji):
             "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
         )
 
-        # drop our known bad source file directly in the SRPM
-        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
         self.waiver_auth = "Security"
@@ -241,9 +431,11 @@ class UnicodeBadSourceCompareSRPM(TestCompareSRPM):
             "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
         )
 
-        # drop our known bad source file directly in the SRPM
-        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
-        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
         self.waiver_auth = "Security"
@@ -262,13 +454,17 @@ class UnicodeBadSourceCompareRPMs(TestCompareRPMs):
             "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
         )
 
-        # drop our known bad source file directly in the SRPM
-        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
-        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
-        self.waiver_auth = "Security"
-        self.result = "BAD"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
 
 
 class UnicodeBadSourceCompareKoji(TestCompareKoji):
@@ -283,18 +479,244 @@ class UnicodeBadSourceCompareKoji(TestCompareKoji):
             "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
         )
 
-        # drop our known bad source file directly in the SRPM
-        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
-        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
 
-# class UnicodeBadSourceArchiveSRPM(TestSRPM):
-# class UnicodeBadSourceArchiveRPMs(TestRPMs):
-# class UnicodeBadSourceArchiveKoji(TestKoji):
-# class UnicodeBadSourceArchiveCompareSRPM(TestCompareSRPM):
-# class UnicodeBadSourceArchiveCompareRPMs(TestCompareRPMs):
-# class UnicodeBadSourceArchiveCompareKoji(TestCompareKoji):
+# The following tests run the unicode inspection with known bad source
+# files in a tarball in the SRPM.  All of the results for these should be 'OK'
+# except for the jobs that lack any SRPM file.
+class UnicodeBadSourceArchiveSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadSourceArchiveRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadSourceArchiveKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadSourceArchiveCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadSourceArchiveCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadSourceArchiveCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"

--- a/test/test_unicode.py
+++ b/test/test_unicode.py
@@ -1,0 +1,300 @@
+#
+# Copyright © 2021 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+import rpmfluff
+
+from baseclass import (
+    TestSRPM,
+    TestRPMs,
+    TestKoji,
+    TestCompareSRPM,
+    TestCompareRPMs,
+    TestCompareKoji,
+)
+
+datadir = os.environ["RPMINSPECT_TEST_DATA_PATH"]
+good_src = open(os.path.join(datadir, "unicode", "good.c")).read()
+bad_src = open(os.path.join(datadir, "unicode", "bad.c")).read()
+status_src = open(os.path.join(datadir, "unicode", "status.sh")).read()
+makefile_src = open(os.path.join(datadir, "unicode", "Makefile")).read()
+
+
+# The following tests run the unicode inspection with a known good source
+# file in the SRPM.  All of the results for these should be 'OK'.
+class UnicodeGoodSourceSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known good source file directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeGoodSourceRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known good source file directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeGoodSourceKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known good source file directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeGoodSourceCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known good source file directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeGoodSourceCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known good source file directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeGoodSourceCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known good source file directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("good.c", good_src))
+
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+# The following tests run the unicode inspection with a known good source
+# file in a tarball in the SRPM.  All of the results for these should be 'OK'.
+# class UnicodeGoodSourceArchiveSRPM(TestSRPM):
+#    def setUp(self):
+#        super().setUp()
+#
+#        self.rpm.add_source(
+#            rpmfluff.GeneratedTarball("%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+#                                      "%s-%s" % (AFTER_NAME, AFTER_VER),
+#                                      [rpmfluff.SourceFile("Makefile", makefile_src),
+#                                       rpmfluff.SourceFile("good.c", good_src),
+#                                       rpmfluff.SourceFile("status.sh", status_src)])
+#        )
+#        self.rpm.section_prep = "%setup\n"
+#        self.rpm.section_build += "make\n"
+#        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+#        sub = self.rpm.get_subpackage(None)
+#        sub.section_files += "%attr(0755,root,root) /usr/bin/status\n"
+#
+#        self.inspection = "unicode"
+#        self.result = "OK"
+
+
+# class UnicodeGoodSourceArchiveRPMs(TestRPMs):
+# class UnicodeGoodSourceArchiveKoji(TestKoji):
+# class UnicodeGoodSourceArchiveCompareSRPM(TestCompareSRPM):
+# class UnicodeGoodSourceArchiveCompareRPMs(TestCompareRPMs):
+# class UnicodeGoodSourceArchiveCompareKoji(TestCompareKoji):
+
+
+# The following tests run the unicode inspection with a known bad source file
+# in the SRPM.  All of the results for these should be 'BAD' with a waiver
+# authorization of "Security".
+class UnicodeBadSourceSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source file directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadSourceRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source file directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadSourceKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source file directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadSourceCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source file directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadSourceCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source file directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadSourceCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source file directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+# class UnicodeBadSourceArchiveSRPM(TestSRPM):
+# class UnicodeBadSourceArchiveRPMs(TestRPMs):
+# class UnicodeBadSourceArchiveKoji(TestKoji):
+# class UnicodeBadSourceArchiveCompareSRPM(TestCompareSRPM):
+# class UnicodeBadSourceArchiveCompareRPMs(TestCompareRPMs):
+# class UnicodeBadSourceArchiveCompareKoji(TestCompareKoji):

--- a/test/test_unicode.py
+++ b/test/test_unicode.py
@@ -37,10 +37,20 @@ bad_asm_src = open(os.path.join(datadir, "unicode", "bad.s")).read()
 status_src = open(os.path.join(datadir, "unicode", "status.sh")).read()
 makefile_src = open(os.path.join(datadir, "unicode", "Makefile")).read()
 
+commenting_out_new_src = open(
+    os.path.join(datadir, "unicode", "commenting-out-new.c")
+).read()
+early_return_new_src = open(
+    os.path.join(datadir, "unicode", "early-return-new.c")
+).read()
+stretched_string_new_src = open(
+    os.path.join(datadir, "unicode", "stretched-string-new.c")
+).read()
+
 
 # The following tests run the unicode inspection with a known good source
 # file in the SRPM.  All of the results for these should be 'OK'.
-class UnicodeGoodSourceSRPM(TestSRPM):
+class UnicodeGoodCSourceSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
 
@@ -56,7 +66,7 @@ class UnicodeGoodSourceSRPM(TestSRPM):
         self.result = "OK"
 
 
-class UnicodeGoodSourceRPMs(TestRPMs):
+class UnicodeGoodCSourceRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
 
@@ -72,7 +82,7 @@ class UnicodeGoodSourceRPMs(TestRPMs):
         self.result = "OK"
 
 
-class UnicodeGoodSourceKoji(TestKoji):
+class UnicodeGoodCSourceKoji(TestKoji):
     def setUp(self):
         super().setUp()
 
@@ -88,7 +98,7 @@ class UnicodeGoodSourceKoji(TestKoji):
         self.result = "OK"
 
 
-class UnicodeGoodSourceCompareSRPM(TestCompareSRPM):
+class UnicodeGoodCSourceCompareSRPM(TestCompareSRPM):
     def setUp(self):
         super().setUp()
 
@@ -108,7 +118,7 @@ class UnicodeGoodSourceCompareSRPM(TestCompareSRPM):
         self.result = "OK"
 
 
-class UnicodeGoodSourceCompareRPMs(TestCompareRPMs):
+class UnicodeGoodCSourceCompareRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
 
@@ -128,7 +138,7 @@ class UnicodeGoodSourceCompareRPMs(TestCompareRPMs):
         self.result = "OK"
 
 
-class UnicodeGoodSourceCompareKoji(TestCompareKoji):
+class UnicodeGoodCSourceCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
 
@@ -150,7 +160,7 @@ class UnicodeGoodSourceCompareKoji(TestCompareKoji):
 
 # The following tests run the unicode inspection with a known good source
 # file in a tarball in the SRPM.  All of the results for these should be 'OK'.
-class UnicodeGoodSourceArchiveSRPM(TestSRPM):
+class UnicodeGoodCSourceArchiveSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
 
@@ -176,7 +186,7 @@ class UnicodeGoodSourceArchiveSRPM(TestSRPM):
         self.result = "OK"
 
 
-class UnicodeGoodSourceArchiveRPMs(TestRPMs):
+class UnicodeGoodCSourceArchiveRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
 
@@ -202,7 +212,7 @@ class UnicodeGoodSourceArchiveRPMs(TestRPMs):
         self.result = "OK"
 
 
-class UnicodeGoodSourceArchiveKoji(TestKoji):
+class UnicodeGoodCSourceArchiveKoji(TestKoji):
     def setUp(self):
         super().setUp()
 
@@ -228,7 +238,7 @@ class UnicodeGoodSourceArchiveKoji(TestKoji):
         self.result = "OK"
 
 
-class UnicodeGoodSourceArchiveCompareSRPM(TestCompareSRPM):
+class UnicodeGoodCSourceArchiveCompareSRPM(TestCompareSRPM):
     def setUp(self):
         super().setUp()
 
@@ -272,7 +282,7 @@ class UnicodeGoodSourceArchiveCompareSRPM(TestCompareSRPM):
         self.result = "OK"
 
 
-class UnicodeGoodSourceArchiveCompareRPMs(TestCompareRPMs):
+class UnicodeGoodCSourceArchiveCompareRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
 
@@ -316,7 +326,7 @@ class UnicodeGoodSourceArchiveCompareRPMs(TestCompareRPMs):
         self.result = "OK"
 
 
-class UnicodeGoodSourceArchiveCompareKoji(TestCompareKoji):
+class UnicodeGoodCSourceArchiveCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
 
@@ -363,7 +373,7 @@ class UnicodeGoodSourceArchiveCompareKoji(TestCompareKoji):
 # The following tests run the unicode inspection with a known bad source file
 # in the SRPM.  All of the results for these should be 'BAD' with a waiver
 # authorization of "Security" except for the jobs that lack any SRPM file.
-class UnicodeBadSourceSRPM(TestSRPM):
+class UnicodeBadCSourceSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
 
@@ -374,14 +384,13 @@ class UnicodeBadSourceSRPM(TestSRPM):
 
         # drop our known bad source files directly in the SRPM
         self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
-        self.rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
         self.waiver_auth = "Security"
         self.result = "BAD"
 
 
-class UnicodeBadSourceRPMs(TestRPMs):
+class UnicodeBadCSourceRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
 
@@ -392,7 +401,6 @@ class UnicodeBadSourceRPMs(TestRPMs):
 
         # drop our known bad source files directly in the SRPM
         self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
-        self.rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
 
@@ -401,7 +409,7 @@ class UnicodeBadSourceRPMs(TestRPMs):
         self.result = "OK"
 
 
-class UnicodeBadSourceKoji(TestKoji):
+class UnicodeBadCSourceKoji(TestKoji):
     def setUp(self):
         super().setUp()
 
@@ -412,6 +420,349 @@ class UnicodeBadSourceKoji(TestKoji):
 
         # drop our known bad source files directly in the SRPM
         self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCSourceCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCSourceCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadCSourceCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+# The following tests run the unicode inspection with known bad source
+# files in a tarball in the SRPM.  All of the results for these should be 'OK'
+# except for the jobs that lack any SRPM file.
+class UnicodeBadCSourceArchiveSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCSourceArchiveRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadCSourceArchiveKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCSourceArchiveCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCSourceArchiveCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadCSourceArchiveCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", bad_c_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+# The following tests run the unicode inspection with a known bad source file
+# in the SRPM.  All of the results for these should be 'BAD' with a waiver
+# authorization of "Security" except for the jobs that lack any SRPM file.
+class UnicodeBadAsmSourceSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadAsmSourceRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadAsmSourceKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
         self.rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
@@ -419,7 +770,7 @@ class UnicodeBadSourceKoji(TestKoji):
         self.result = "BAD"
 
 
-class UnicodeBadSourceCompareSRPM(TestCompareSRPM):
+class UnicodeBadAsmSourceCompareSRPM(TestCompareSRPM):
     def setUp(self):
         super().setUp()
 
@@ -432,9 +783,7 @@ class UnicodeBadSourceCompareSRPM(TestCompareSRPM):
         )
 
         # drop our known bad source files directly in the SRPM
-        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
         self.before_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
-        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
         self.after_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
@@ -442,7 +791,7 @@ class UnicodeBadSourceCompareSRPM(TestCompareSRPM):
         self.result = "BAD"
 
 
-class UnicodeBadSourceCompareRPMs(TestCompareRPMs):
+class UnicodeBadAsmSourceCompareRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
 
@@ -455,9 +804,7 @@ class UnicodeBadSourceCompareRPMs(TestCompareRPMs):
         )
 
         # drop our known bad source files directly in the SRPM
-        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
         self.before_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
-        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
         self.after_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
@@ -467,7 +814,7 @@ class UnicodeBadSourceCompareRPMs(TestCompareRPMs):
         self.result = "OK"
 
 
-class UnicodeBadSourceCompareKoji(TestCompareKoji):
+class UnicodeBadAsmSourceCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
 
@@ -480,9 +827,7 @@ class UnicodeBadSourceCompareKoji(TestCompareKoji):
         )
 
         # drop our known bad source files directly in the SRPM
-        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
         self.before_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
-        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
         self.after_rpm.add_source(rpmfluff.SourceFile("bad.s", bad_asm_src))
 
         self.inspection = "unicode"
@@ -493,7 +838,7 @@ class UnicodeBadSourceCompareKoji(TestCompareKoji):
 # The following tests run the unicode inspection with known bad source
 # files in a tarball in the SRPM.  All of the results for these should be 'OK'
 # except for the jobs that lack any SRPM file.
-class UnicodeBadSourceArchiveSRPM(TestSRPM):
+class UnicodeBadAsmSourceArchiveSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
 
@@ -504,7 +849,6 @@ class UnicodeBadSourceArchiveSRPM(TestSRPM):
                 "%s-%s" % (AFTER_NAME, AFTER_VER),
                 [
                     rpmfluff.SourceFile("Makefile", makefile_src),
-                    rpmfluff.SourceFile("bad.c", bad_c_src),
                     rpmfluff.SourceFile("bad.s", bad_asm_src),
                     rpmfluff.SourceFile("status.sh", status_src),
                 ],
@@ -521,7 +865,7 @@ class UnicodeBadSourceArchiveSRPM(TestSRPM):
         self.result = "BAD"
 
 
-class UnicodeBadSourceArchiveRPMs(TestRPMs):
+class UnicodeBadAsmSourceArchiveRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
 
@@ -532,7 +876,6 @@ class UnicodeBadSourceArchiveRPMs(TestRPMs):
                 "%s-%s" % (AFTER_NAME, AFTER_VER),
                 [
                     rpmfluff.SourceFile("Makefile", makefile_src),
-                    rpmfluff.SourceFile("bad.c", bad_c_src),
                     rpmfluff.SourceFile("bad.s", bad_asm_src),
                     rpmfluff.SourceFile("status.sh", status_src),
                 ],
@@ -551,7 +894,7 @@ class UnicodeBadSourceArchiveRPMs(TestRPMs):
         self.result = "OK"
 
 
-class UnicodeBadSourceArchiveKoji(TestKoji):
+class UnicodeBadAsmSourceArchiveKoji(TestKoji):
     def setUp(self):
         super().setUp()
 
@@ -562,7 +905,6 @@ class UnicodeBadSourceArchiveKoji(TestKoji):
                 "%s-%s" % (AFTER_NAME, AFTER_VER),
                 [
                     rpmfluff.SourceFile("Makefile", makefile_src),
-                    rpmfluff.SourceFile("bad.c", bad_c_src),
                     rpmfluff.SourceFile("bad.s", bad_asm_src),
                     rpmfluff.SourceFile("status.sh", status_src),
                 ],
@@ -579,7 +921,7 @@ class UnicodeBadSourceArchiveKoji(TestKoji):
         self.result = "BAD"
 
 
-class UnicodeBadSourceArchiveCompareSRPM(TestCompareSRPM):
+class UnicodeBadAsmSourceArchiveCompareSRPM(TestCompareSRPM):
     def setUp(self):
         super().setUp()
 
@@ -590,7 +932,6 @@ class UnicodeBadSourceArchiveCompareSRPM(TestCompareSRPM):
                 "%s-%s" % (BEFORE_NAME, BEFORE_VER),
                 [
                     rpmfluff.SourceFile("Makefile", makefile_src),
-                    rpmfluff.SourceFile("bad.c", bad_c_src),
                     rpmfluff.SourceFile("bad.s", bad_asm_src),
                     rpmfluff.SourceFile("status.sh", status_src),
                 ],
@@ -609,7 +950,6 @@ class UnicodeBadSourceArchiveCompareSRPM(TestCompareSRPM):
                 "%s-%s" % (AFTER_NAME, AFTER_VER),
                 [
                     rpmfluff.SourceFile("Makefile", makefile_src),
-                    rpmfluff.SourceFile("bad.c", bad_c_src),
                     rpmfluff.SourceFile("bad.s", bad_asm_src),
                     rpmfluff.SourceFile("status.sh", status_src),
                 ],
@@ -626,7 +966,7 @@ class UnicodeBadSourceArchiveCompareSRPM(TestCompareSRPM):
         self.result = "BAD"
 
 
-class UnicodeBadSourceArchiveCompareRPMs(TestCompareRPMs):
+class UnicodeBadAsmSourceArchiveCompareRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
 
@@ -637,7 +977,6 @@ class UnicodeBadSourceArchiveCompareRPMs(TestCompareRPMs):
                 "%s-%s" % (BEFORE_NAME, BEFORE_VER),
                 [
                     rpmfluff.SourceFile("Makefile", makefile_src),
-                    rpmfluff.SourceFile("bad.c", bad_c_src),
                     rpmfluff.SourceFile("bad.s", bad_asm_src),
                     rpmfluff.SourceFile("status.sh", status_src),
                 ],
@@ -656,7 +995,6 @@ class UnicodeBadSourceArchiveCompareRPMs(TestCompareRPMs):
                 "%s-%s" % (AFTER_NAME, AFTER_VER),
                 [
                     rpmfluff.SourceFile("Makefile", makefile_src),
-                    rpmfluff.SourceFile("bad.c", bad_c_src),
                     rpmfluff.SourceFile("bad.s", bad_asm_src),
                     rpmfluff.SourceFile("status.sh", status_src),
                 ],
@@ -675,7 +1013,7 @@ class UnicodeBadSourceArchiveCompareRPMs(TestCompareRPMs):
         self.result = "OK"
 
 
-class UnicodeBadSourceArchiveCompareKoji(TestCompareKoji):
+class UnicodeBadAsmSourceArchiveCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
 
@@ -686,7 +1024,6 @@ class UnicodeBadSourceArchiveCompareKoji(TestCompareKoji):
                 "%s-%s" % (BEFORE_NAME, BEFORE_VER),
                 [
                     rpmfluff.SourceFile("Makefile", makefile_src),
-                    rpmfluff.SourceFile("bad.c", bad_c_src),
                     rpmfluff.SourceFile("bad.s", bad_asm_src),
                     rpmfluff.SourceFile("status.sh", status_src),
                 ],
@@ -705,8 +1042,1051 @@ class UnicodeBadSourceArchiveCompareKoji(TestCompareKoji):
                 "%s-%s" % (AFTER_NAME, AFTER_VER),
                 [
                     rpmfluff.SourceFile("Makefile", makefile_src),
-                    rpmfluff.SourceFile("bad.c", bad_c_src),
                     rpmfluff.SourceFile("bad.s", bad_asm_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+# The following tests run the unicode inspection with a known bad source file
+# in the SRPM.  All of the results for these should be 'BAD' with a waiver
+# authorization of "Security" except for the jobs that lack any SRPM file.
+class UnicodeBadCommentingOutSourceSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCommentingOutSourceRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", bad_c_src))
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadCommentingOutSourceKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", commenting_out_new_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCommentingOutSourceCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", commenting_out_new_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", commenting_out_new_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCommentingOutSourceCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", commenting_out_new_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", commenting_out_new_src))
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadCommentingOutSourceCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", commenting_out_new_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", commenting_out_new_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+# The following tests run the unicode inspection with known bad source
+# files in a tarball in the SRPM.  All of the results for these should be 'OK'
+# except for the jobs that lack any SRPM file.
+class UnicodeBadCommentingOutSourceArchiveSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", commenting_out_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCommentingOutSourceArchiveRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", commenting_out_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadCommentingOutSourceArchiveKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", commenting_out_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCommentingOutSourceArchiveCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", commenting_out_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", commenting_out_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCommentingOutSourceArchiveCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", commenting_out_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", commenting_out_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadCommentingOutSourceArchiveCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", commenting_out_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", commenting_out_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+# The following tests run the unicode inspection with a known bad source file
+# in the SRPM.  All of the results for these should be 'BAD' with a waiver
+# authorization of "Security" except for the jobs that lack any SRPM file.
+class UnicodeBadEarlyReturnSourceSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", early_return_new_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadEarlyReturnSourceRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", early_return_new_src))
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadEarlyReturnSourceKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", early_return_new_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadEarlyReturnSourceCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", early_return_new_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", early_return_new_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadEarlyReturnSourceCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", early_return_new_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", early_return_new_src))
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadEarlyReturnSourceCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(rpmfluff.SourceFile("bad.c", early_return_new_src))
+        self.after_rpm.add_source(rpmfluff.SourceFile("bad.c", early_return_new_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+# The following tests run the unicode inspection with known bad source
+# files in a tarball in the SRPM.  All of the results for these should be 'OK'
+# except for the jobs that lack any SRPM file.
+class UnicodeBadEarlyReturnSourceArchiveSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", early_return_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadEarlyReturnSourceArchiveRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", early_return_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadEarlyReturnSourceArchiveKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", early_return_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadEarlyReturnSourceArchiveCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", early_return_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", early_return_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadEarlyReturnSourceArchiveCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", early_return_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", early_return_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadEarlyReturnSourceArchiveCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", early_return_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", early_return_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+# The following tests run the unicode inspection with a known bad source file
+# in the SRPM.  All of the results for these should be 'BAD' with a waiver
+# authorization of "Security" except for the jobs that lack any SRPM file.
+class UnicodeBadStretchStringSourceSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", stretched_string_new_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadStretchStringSourceRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", stretched_string_new_src))
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadStretchStringSourceKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(rpmfluff.SourceFile("bad.c", stretched_string_new_src))
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadStretchStringSourceCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            rpmfluff.SourceFile("bad.c", stretched_string_new_src)
+        )
+        self.after_rpm.add_source(
+            rpmfluff.SourceFile("bad.c", stretched_string_new_src)
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadStretchStringSourceCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            rpmfluff.SourceFile("bad.c", stretched_string_new_src)
+        )
+        self.after_rpm.add_source(
+            rpmfluff.SourceFile("bad.c", stretched_string_new_src)
+        )
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadStretchStringSourceCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status", rpmfluff.SourceFile("status.sh", status_src), mode=755
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            rpmfluff.SourceFile("bad.c", stretched_string_new_src)
+        )
+        self.after_rpm.add_source(
+            rpmfluff.SourceFile("bad.c", stretched_string_new_src)
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+# The following tests run the unicode inspection with known bad source
+# files in a tarball in the SRPM.  All of the results for these should be 'OK'
+# except for the jobs that lack any SRPM file.
+class UnicodeBadStretchStringSourceArchiveSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", stretched_string_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadStretchStringSourceArchiveRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", stretched_string_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadStretchStringSourceArchiveKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += "\n%define debug_package %{nil}\n"
+        self.rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", stretched_string_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.rpm.section_prep = "%setup\n"
+        self.rpm.section_build += "make\n"
+        self.rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadStretchStringSourceArchiveCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", stretched_string_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", stretched_string_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadStretchStringSourceArchiveCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", stretched_string_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", stretched_string_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.after_rpm.section_prep = "%setup\n"
+        self.after_rpm.section_build += "make\n"
+        self.after_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.after_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.inspection = "unicode"
+
+        # the result here is OK because the unicode inspection only works on SRPMs and
+        # if we don't have those it is a no-op inspection that returns OK
+        self.result = "OK"
+
+
+class UnicodeBadStretchStringSourceArchiveCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += "\n%define debug_package %{nil}\n"
+        self.before_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (BEFORE_NAME, BEFORE_VER),
+                "%s-%s" % (BEFORE_NAME, BEFORE_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", stretched_string_new_src),
+                    rpmfluff.SourceFile("status.sh", status_src),
+                ],
+            )
+        )
+        self.before_rpm.section_prep = "%setup\n"
+        self.before_rpm.section_build += "make\n"
+        self.before_rpm.section_install += "make install DESTDIR=%{buildroot}\n"
+        sub = self.before_rpm.get_subpackage(None)
+        sub.section_files += "/usr/bin/status\n"
+
+        self.after_rpm.header += "\n%define debug_package %{nil}\n"
+        self.after_rpm.add_source(
+            rpmfluff.GeneratedTarball(
+                "%s-%s.tar.gz" % (AFTER_NAME, AFTER_VER),
+                "%s-%s" % (AFTER_NAME, AFTER_VER),
+                [
+                    rpmfluff.SourceFile("Makefile", makefile_src),
+                    rpmfluff.SourceFile("bad.c", stretched_string_new_src),
                     rpmfluff.SourceFile("status.sh", status_src),
                 ],
             )


### PR DESCRIPTION
CVE-2021-42574 and CVE-2021-42694 led to the creation of the 'unicode' inspection in librpminspect.  This inspection checks %prep'ed source trees and all text files in source RPM packages for forbidden Unicode code points as defined in the rpminspect configuration file.