### PR TITLE
[ci] icu -> icu-dev in reqs.txt for Alpine Linux

### DIFF
--- a/osdeps/alpine/reqs.txt
+++ b/osdeps/alpine/reqs.txt
@@ -20,7 +20,7 @@ gcc
 gcovr
 gettext
 git
-icu
+icu-dev
 json-c-dev
 kmod-dev
 libffi-dev


### PR DESCRIPTION
Adjust the package name that brings in the icu library and header
files for development.

Signed-off-by: David Cantrell <dcantrell@redhat.com>