### PR TITLE
[fix] Fallback on fedora_name only if the _abbrev fields are empty

### DIFF
--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -120,6 +120,15 @@ static bool check_license_abbrev(const char *lic)
             }
         }
 
+        /* handle "commented out" fields */
+        if (strlen(fedora_abbrev) > 0 && *fedora_abbrev == '#') {
+            fedora_abbrev = "";
+        }
+
+        if (strlen(spdx_abbrev) > 0 && *spdx_abbrev == '#') {
+            spdx_abbrev = "";
+        }
+
         /*
          * no full tag match and no abbreviations, license entry invalid
          */


### PR DESCRIPTION
In the license inspection, fallback on the fedora_name field if it
contains text and both fedora_abbrev and spdx_abbrev are empty.  An
abbrev field with text that begins with '#' is considered a comment
and the field is treated as empty in the code.

Fixes: #546

Signed-off-by: David Cantrell <dcantrell@redhat.com>