### PR TITLE
run desktop-file-validate with --no-hints

### DIFF
--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -412,14 +412,14 @@ static bool desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
 
     /* Validate the desktop file */
-    params.details = run_cmd(&after_code, ri->worksubdir, ri->commands.desktop_file_validate, file->fullpath, NULL);
+    params.details = run_cmd(&after_code, ri->worksubdir, ri->commands.desktop_file_validate, "--no-hints", file->fullpath, NULL);
     tmpbuf = strreplace(params.details, file->fullpath, file->localpath);
     free(params.details);
     params.details = tmpbuf;
 
     if (file->peer_file && is_desktop_entry_file(ri->desktop_entry_files_dir, file->peer_file)) {
         /* if we have a before peer, validate the corresponding desktop file */
-        before_out = run_cmd(NULL, ri->worksubdir, ri->commands.desktop_file_validate, file->peer_file->fullpath, NULL);
+        before_out = run_cmd(NULL, ri->worksubdir, ri->commands.desktop_file_validate, "--no-hints", file->peer_file->fullpath, NULL);
         tmpbuf = strreplace(before_out, file->peer_file->fullpath, file->peer_file->localpath);
         free(before_out);
         before_out = tmpbuf;


### PR DESCRIPTION
Only display unambiguous warnings, not additional helpful tips "about things that might be improved"

f.e.
libreoffice-math.desktop: hint: value "Office;Education;Science;Math;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu