### PR TITLE
[lib] Convert RPM header cache to a hash table, fix leak

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -274,13 +274,11 @@ typedef enum _specname_primary_t {
 } specname_primary_t;
 
 /* RPM header cache so we don't balloon out our memory */
-typedef struct _header_cache_entry_t {
+typedef struct _header_cache_t {
     char *pkg;
     Header hdr;
-    TAILQ_ENTRY(_header_cache_entry_t) items;
-} header_cache_entry_t;
-
-typedef TAILQ_HEAD(header_cache_entry_s, _header_cache_entry_t) header_cache_t;
+    UT_hash_handle hh;
+} header_cache_t;
 
 /* Product release string favoring */
 typedef enum _favor_release_t {

--- a/lib/free.c
+++ b/lib/free.c
@@ -80,7 +80,8 @@ void free_rpminspect(struct rpminspect *ri) {
     fileinfo_entry_t *fientry = NULL;
     caps_entry_t *centry = NULL;
     caps_filelist_entry_t *cflentry = NULL;
-    header_cache_entry_t *hentry = NULL;
+    header_cache_t *hentry = NULL;
+    header_cache_t *tmp_hentry = NULL;
     politics_entry_t *pentry = NULL;
     security_entry_t *sentry = NULL;
     secrule_t *srentry = NULL;
@@ -265,16 +266,11 @@ void free_rpminspect(struct rpminspect *ri) {
 
     free_rpmpeer(ri->peers);
 
-    if (ri->header_cache != NULL) {
-        while (!TAILQ_EMPTY(ri->header_cache)) {
-            hentry = TAILQ_FIRST(ri->header_cache);
-            TAILQ_REMOVE(ri->header_cache, hentry, items);
-            free(hentry->pkg);
-            headerFree(hentry->hdr);
-            free(hentry);
-        }
-
-        free(ri->header_cache);
+    HASH_ITER(hh, ri->header_cache, hentry, tmp_hentry) {
+        HASH_DEL(ri->header_cache, hentry);
+        free(hentry->pkg);
+        headerFree(hentry->hdr);
+        free(hentry);
     }
 
     free(ri->before_rel);

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -683,6 +683,7 @@ int main(int argc, char **argv)
 
             if (!found) {
                 free_rpminspect(ri);
+                rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
                 warnx(_("*** Unsupported architecture specified: `%s`"), token);
                 errx(RI_PROGRAM_ERROR, _("*** See `%s --help` for more information."), COMMAND_NAME);
@@ -706,6 +707,7 @@ int main(int argc, char **argv)
     /* create the working directory */
     if (mkdirp(ri->workdir, mode)) {
         free_rpminspect(ri);
+        rpmFreeMacros(NULL);
         rpmFreeRpmrc();
         errx(RI_PROGRAM_ERROR, _("*** Unable to create directory %s"), ri->workdir);
     }
@@ -719,6 +721,7 @@ int main(int argc, char **argv)
 
             if (gather_builds(ri, true)) {
                 free_rpminspect(ri);
+                rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
                 errx(RI_PROGRAM_ERROR, _("*** failed to gather specified builds."));
             }
@@ -730,11 +733,13 @@ int main(int argc, char **argv)
         }
 
         free_rpminspect(ri);
+            rpmFreeMacros(NULL);
         rpmFreeRpmrc();
         return RI_INSPECTION_SUCCESS;
     } else {
         if (gather_builds(ri, false)) {
             free_rpminspect(ri);
+            rpmFreeMacros(NULL);
             rpmFreeRpmrc();
             errx(RI_PROGRAM_ERROR, _("*** failed to gather specified builds."));
         }


### PR DESCRIPTION
The header cache was a tailq, but convert it to a hash table since the
package name is used as a key anyway.  Also fix a small memory leak.

Signed-off-by: David Cantrell <dcantrell@redhat.com>