### PR TITLE
[fix] Remove hardcoded maximum version check on Java bytecode

### DIFF
--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -119,7 +119,7 @@ static bool check_class_file(struct rpminspect *ri, const char *fullpath,
     /* basic checks on the most recent build */
     if (major == -1 && !strsuffix(localpath, CLASS_FILENAME_EXTENSION)) {
         return true;
-    } else if (major < 0 || major > 60) {
+    } else if (major < 0) {
         xasprintf(&params.msg, _("File %s (%s), Java byte code version %d is incorrect (wrong endianness? corrupted file? space JDK?)"), localpath, container, major);
         add_result(ri, &params);
         free(params.msg);


### PR DESCRIPTION
The maximum version check of 60 for Java bytecode now fails when
encountering valid bytecode from Java 17 (61) or Java 18 (62).  As
Java releases now occur on a six-month cycle, retaining the current
version check would mean bumping this line a couple of times a year.

It seems better to just remove the check as a maximum bound check is
already performed against supported_major, which can be configured
externally without rebuilding rpminspect.