### PR TITLE
Create SimpleSrpmBuild class in the test suite and update tests

### DIFF
--- a/lib/builds.c
+++ b/lib/builds.c
@@ -895,7 +895,8 @@ static bool is_remote_rpm(const char *url)
  * @param fo True if '-f' (fetch only) specified, false otherwise.
  * @return 0 on success, non-zero on failure.
  */
-int gather_builds(struct rpminspect *ri, bool fo) {
+int gather_builds(struct rpminspect *ri, bool fo)
+{
     struct koji_build *build = NULL;
     struct koji_task *task = NULL;
 

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -733,7 +733,7 @@ int main(int argc, char **argv)
         }
 
         free_rpminspect(ri);
-            rpmFreeMacros(NULL);
+        rpmFreeMacros(NULL);
         rpmFreeRpmrc();
         return RI_INSPECTION_SUCCESS;
     } else {

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -26,7 +26,7 @@ echo nope
 
 class SameTypeCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(installPath="/usr/bin/rpminspect")
         self.after_rpm.add_simple_compilation(installPath="/usr/bin/rpminspect")
 
@@ -36,7 +36,7 @@ class SameTypeCompareSRPM(TestCompareSRPM):
 
 class SameTypeCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(installPath="/usr/bin/rpminspect")
         self.after_rpm.add_simple_compilation(installPath="/usr/bin/rpminspect")
 
@@ -46,7 +46,7 @@ class SameTypeCompareRPMs(TestCompareRPMs):
 
 class SameTypeCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(installPath="/usr/bin/rpminspect")
         self.after_rpm.add_simple_compilation(installPath="/usr/bin/rpminspect")
 
@@ -56,7 +56,7 @@ class SameTypeCompareKoji(TestCompareKoji):
 
 class ChangedTypeCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/vaporware/rpminspect",
             rpmfluff.SourceFile("rpminspect.source", rpminspect_sh),
@@ -73,7 +73,7 @@ class ChangedTypeCompareSRPM(TestCompareSRPM):
 
 class ChangedTypeCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/vaporware/rpminspect",
             rpmfluff.SourceFile("rpminspect.sh", rpminspect_sh),
@@ -90,7 +90,7 @@ class ChangedTypeCompareRPMs(TestCompareRPMs):
 
 class ChangedTypeCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/vaporware/rpminspect",
             rpmfluff.SourceFile("rpminspect.sh", rpminspect_sh),


### PR DESCRIPTION
rpmfluff provides SimpleRpmBuild which the test suite uses extensively.  But there are some test cases that just need to create an SRPM, or more importantly a bad SRPM.  I created the SimpleSrpmBuild class that inherits from SimpleRpmBuild but only creates an SRPM for use in the test cases.  This adjusts the class inheritance in baseclass.py but everything should still work as expected.  The SRPM-specific test cases throughout the test suite will now just have an SRPM built instead of all of the packages.