### PR TITLE
[fix] Exit the manual_prep_source() child process correctly

### DIFF
--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -206,6 +206,15 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
         rpmtsFree(ts);
         free(ba);
 
+        /*
+         * perform the same cleanup that happens from rpminspect(1)
+         * since this is a child process and we have copies of all of
+         * these allocations
+         */
+        free_rpminspect(ri);
+        rpmFreeMacros(NULL);
+        rpmFreeRpmrc();
+
         _exit(status);
     } else if (proc == -1) {
         /* failure */


### PR DESCRIPTION
In the unicode inspection, make sure librpm and librpminspect have
proper cleanups done on exit so we don't get valgrind errors.

Signed-off-by: David Cantrell <dcantrell@redhat.com>