### PR TITLE
[fix] Report removed files at INFO level in rebase comparisons

### DIFF
--- a/lib/rebase.c
+++ b/lib/rebase.c
@@ -61,7 +61,7 @@ bool is_rebase(struct rpminspect *ri)
         return false;
     }
 
-    /*  run the rebase detection */
+    /* run the rebase detection */
     if (ri->rebase_build == 0) {
         ri->rebase_build = -1;
 
@@ -90,7 +90,7 @@ bool is_rebase(struct rpminspect *ri)
     }
 
     /* if the package name is on the rebaseable list, it's valid */
-    if (init_rebaseable(ri) && list_contains(ri->rebaseable, bn) && list_contains(ri->rebaseable, an)) {
+    if (ri->rebase_build == -1 && init_rebaseable(ri) && !strcmp(bn, an) && list_contains(ri->rebaseable, an)) {
         return true;
     }
 


### PR DESCRIPTION
When comparing rebased builds, any files found by the removedfiles
inspection should be reported at the INFO level.

Fixes: #561

Signed-off-by: David Cantrell <dcantrell@redhat.com>