### PR TITLE
[lib] Expand the emptyrpm inspection to handle %ghost entries

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -230,7 +230,6 @@ rpmfile_t * extract_rpm(const char *, Header, char **output_dir);
 bool process_file_path(const rpmfile_entry_t *, regex_t *, regex_t *);
 void find_file_peers(rpmfile_t *, rpmfile_t *);
 bool is_debug_or_build_path(const char *);
-bool is_payload_empty(rpmfile_t *);
 
 /* tty.c */
 size_t tty_width(void);

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -138,7 +138,8 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 /*
  * Main driver for the 'doc' inspection.
  */
-bool inspect_doc(struct rpminspect *ri) {
+bool inspect_doc(struct rpminspect *ri)
+{
     bool result = true;
     struct result_params params;
 

--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -77,8 +77,8 @@ bool inspect_lostpayload(struct rpminspect *ri) {
             continue;
         }
 
-        if (is_payload_empty(peer->after_files)) {
-            if (is_payload_empty(peer->before_files)) {
+        if (peer->after_files == NULL || TAILQ_EMPTY(peer->after_files)) {
+            if (peer->before_files == NULL || TAILQ_EMPTY(peer->before_files)) {
                 xasprintf(&params.msg, _("Package %s continues to be empty (no payloads)"), basename(peer->after_rpm));
                 params.severity = RESULT_INFO;
                 params.waiverauth = NOT_WAIVABLE;

--- a/test/test_emptyrpm.py
+++ b/test/test_emptyrpm.py
@@ -51,8 +51,8 @@ class PkgHasEmptyPayload(TestRPMs):
     def setUp(self):
         TestRPMs.setUp(self)
         self.inspection = "emptyrpm"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Packages in Koji build have empty payloads (VERIFY)
@@ -60,5 +60,5 @@ class KojiBuildHaveEmptyPayloads(TestKoji):
     def setUp(self):
         TestKoji.setUp(self)
         self.inspection = "emptyrpm"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
Packages that contain only %ghost entries in their %files section will
have an empty payload, but that is expected.  Expand the emptyrpm
inspection to honor this state so that you do not need to list it in
the rpminspect.yaml file as an expected empty payload.  The empty
payload will still be reported at the INFO level.

Fixes: #564

Signed-off-by: David Cantrell <dcantrell@redhat.com>