### PR TITLE
[fix] Handle single build runs in is_rebase()

### DIFF
--- a/lib/rebase.c
+++ b/lib/rebase.c
@@ -90,7 +90,7 @@ bool is_rebase(struct rpminspect *ri)
     }
 
     /* if the package name is on the rebaseable list, it's valid */
-    if (ri->rebase_build == -1 && init_rebaseable(ri) && !strcmp(bn, an) && list_contains(ri->rebaseable, an)) {
+    if (ri->rebase_build == -1 && init_rebaseable(ri) && list_contains(ri->rebaseable, an) && ((bn && !strcmp(bn, an)) || bn == NULL)) {
         return true;
     }
 


### PR DESCRIPTION
Followup to previous fix for the emptyrpm inspection.  The bn string
may be NULL, but if it isn't then an must match it.

Signed-off-by: David Cantrell <dcantrell@redhat.com>