### PR TITLE
[fix] Handle the -w option correctly for fetch and non-fetch modes

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -154,7 +154,7 @@ bool list_contains(const string_list_t *, const char *);
 string_list_t *list_add(string_list_t *list, const char *s);
 
 /* local.c */
-bool is_local_build(const char *);
+bool is_local_build(const char *workdir, const char *build, const bool fetch_only);
 bool is_local_rpm(struct rpminspect *, const char *);
 
 /* koji.c */

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -136,7 +136,8 @@ static void get_rpm_info(const char *pkg)
 /*
  * Walk a local build tree and prune empty arch subdirectories.
  */
-static void prune_local(const int whichbuild) {
+static void prune_local(const int whichbuild)
+{
     char *lpath = NULL;
     char *apath = NULL;
     DIR *d = NULL;
@@ -910,9 +911,9 @@ int gather_builds(struct rpminspect *ri, bool fo)
     if (ri->after != NULL) {
         whichbuild = AFTER_BUILD;
 
-        if (is_local_build(ri->after) || is_local_rpm(ri, ri->after)) {
+        if (is_local_build(ri->workdir, ri->after, fetch_only) || is_local_rpm(ri, ri->after)) {
             if (fetch_only) {
-                warnx(_("`%s' already exists"), ri->after);
+                warnx(_("`%s' already exists in %s"), ri->after, ri->workdir);
                 return -1;
             }
 
@@ -967,7 +968,7 @@ int gather_builds(struct rpminspect *ri, bool fo)
     whichbuild = BEFORE_BUILD;
 
     /* before build specified, find it */
-    if (is_local_build(ri->before) || is_local_rpm(ri, ri->before)) {
+    if (is_local_build(ri->workdir, ri->before, fetch_only) || is_local_rpm(ri, ri->before)) {
         set_worksubdir(ri, LOCAL_WORKDIR, NULL, NULL);
 
         /* copy before tree */

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -635,9 +635,10 @@ class TestCompareRPMs(RequiresRpminspect):
             )
 
     def tearDown(self):
-        super().tearDown()
-        self.before_rpm.clean()
-        self.after_rpm.clean()
+        if not KEEP_RESULTS:
+            super().tearDown()
+            self.before_rpm.clean()
+            self.after_rpm.clean()
 
 
 # Base test case class that tests a fake Koji build
@@ -717,6 +718,9 @@ class TestKoji(TestRPMs):
                 self.waiver_auth,
                 message=self.message,
             )
+
+            if KEEP_RESULTS:
+                print("Test builds: %s" % kojidir)
 
 
 # Base test case class that compares before and after Koji builds
@@ -810,3 +814,7 @@ class TestCompareKoji(TestCompareRPMs):
                 )
             except AssertionError:
                 self.dumpResults()
+
+            # show where results are
+            if KEEP_RESULTS:
+                print("Test builds: %s" % kojidir)


### PR DESCRIPTION
The -w option was added a while ago to allow users to specify an
alternate working directory.  This is most useful for the fetch mode
(-f).  However, it becomes a little clumsy if you fetch a build to
your current directory and then try to run rpminspect using that
locally cached build as input.  rpminspect actually downloads it
again...sometimes.

This patch sorts out the directory handling for fetch and non-fetch
modes of operation in rpminspect so the correct behavior happens.

Fixes: #529

Signed-off-by: David Cantrell <dcantrell@redhat.com>