### PR TITLE
[lib] Replace direct use of "diagnostics" with NAME_DIAGNOSTICS

### DIFF
--- a/include/inspect.h
+++ b/include/inspect.h
@@ -617,6 +617,9 @@ bool inspect_unicode(struct rpminspect *ri);
 #define NAME_RUNPATH                        "runpath"
 #define NAME_UNICODE                        "unicode"
 
+/* not an actual inspection */
+#define NAME_DIAGNOSTICS                    "diagnostics"
+
 /* Long descriptions for the inspections */
 #define DESC_LICENSE _("Verify the string specified in the License tag of the RPM metadata describes permissible software licenses as defined by the license database. Also checks to see if the License tag contains any unprofessional words as defined in the configuration file.")
 

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -748,7 +748,7 @@ int main(int argc, char **argv)
     /* general information in the results */
     init_result_params(&params);
     params.severity = RESULT_INFO;
-    params.header = _("diagnostics");
+    params.header = NAME_DIAGNOSTICS;
 
     /* gather version information for dependent programs and libraries */
     diags = gather_diags(ri, COMMAND_NAME, PACKAGE_VERSION);


### PR DESCRIPTION
Brings it more in line with the other inspection reporting even though
the diagnostics reporting isn't strictly an inspection.

Signed-off-by: David Cantrell <dcantrell@redhat.com>