### PR TITLE
[fix] Read ABI level blocks with "level N" or "level-N" names

### DIFF
--- a/lib/abi.c
+++ b/lib/abi.c
@@ -152,7 +152,7 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
         }
 
         /* determine if we are reading a new level or not */
-        if (strprefix(line->data, "[") && strsuffix(line->data, "]") && strcasestr(line->data, "level-")) {
+        if (strprefix(line->data, "[") && strsuffix(line->data, "]") && (strcasestr(line->data, "level-") || strcasestr(line->data, "level "))) {
             /* new compat level section */
 
             /*


### PR DESCRIPTION
In the ABI files, honor blocks that begin with either "[level N]" or
"[level-N]".  The hyphen was required and that's sometimes left off in
the configuration file, but it's not strictly required.

Signed-off-by: David Cantrell <dcantrell@redhat.com>