### PR TITLE
[lib] Add new 'summary' output mode (#26)

### DIFF
--- a/include/output.h
+++ b/include/output.h
@@ -26,8 +26,9 @@
  * Output formats are reference by a constant.
  */
 
-#define FORMAT_TEXT  0
-#define FORMAT_JSON  1
-#define FORMAT_XUNIT 2
+#define FORMAT_TEXT    0
+#define FORMAT_JSON    1
+#define FORMAT_XUNIT   2
+#define FORMAT_SUMMARY 3
 
 #endif

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -253,6 +253,9 @@ void output_json(const results_t *, const char *, const severity_t);
 /* output_xunit.c */
 void output_xunit(const results_t *, const char *, const severity_t);
 
+/* output_summary.c */
+void output_summary(const results_t *results, const char *dest, const severity_t threshold);
+
 /* unpack.c */
 int unpack_archive(const char *, const char *, const bool);
 

--- a/include/types.h
+++ b/include/types.h
@@ -163,7 +163,8 @@ typedef enum _verb_t {
     VERB_ADDED = 1,     /* new file or metadata */
     VERB_REMOVED = 2,   /* removed file or metadata */
     VERB_CHANGED = 3,   /* changed file or metadata */
-    VERB_FAILED = 4     /* check failing */
+    VERB_FAILED = 4,    /* check failing */
+    VERB_OK = 5         /* the everything is ok alarm */
 } verb_t;
 
 /*

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -82,6 +82,7 @@ librpminspect_sources = [
     'mkdirp.c',
     'output.c',
     'output_json.c',
+    'output_summary.c',
     'output_text.c',
     'output_xunit.c',
     'pairfuncs.c',

--- a/lib/output.c
+++ b/lib/output.c
@@ -27,9 +27,10 @@
  */
 
 struct format formats[] = {
-    { FORMAT_TEXT,  "text",  &output_text },
-    { FORMAT_JSON,  "json",  &output_json },
-    { FORMAT_XUNIT, "xunit", &output_xunit },
+    { FORMAT_TEXT,    "text",    &output_text },
+    { FORMAT_JSON,    "json",    &output_json },
+    { FORMAT_XUNIT,   "xunit",   &output_xunit },
+    { FORMAT_SUMMARY, "summary", &output_summary },
     { -1, NULL, NULL }
 };
 
@@ -37,11 +38,13 @@ const char *format_desc(unsigned int format)
 {
     switch (format) {
         case FORMAT_TEXT:
-            return _("Plain text suitable for the console and piping through paging programs.");
+            return _("Detailed results suitable for the console and piping through paging programs.");
         case FORMAT_JSON:
             return _("Results organized as a JSON data structure suitable for reading by web applications and other frontend tools.");
         case FORMAT_XUNIT:
             return _("Results organized as an XUnit data structure suitable for use with Jenkins and other XUnit-enabled services.");
+        case FORMAT_SUMMARY:
+            return _("Results summarized with one result per line, suitable for console viewing with a paging program.");
         default:
             return NULL;
     }

--- a/lib/output_summary.c
+++ b/lib/output_summary.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <err.h>
+#include <assert.h>
+
+#include "rpminspect.h"
+
+/*
+ * Output a results_t in summary text format.
+ */
+void output_summary(const results_t *results, const char *dest, __attribute__((unused)) const severity_t threshold)
+{
+    results_entry_t *result = NULL;
+    int r = 0;
+    FILE *fp = NULL;
+    char *verb = NULL;
+    char *msg = NULL;
+    char *tmp = NULL;
+    size_t width = tty_width();
+
+    /* default to stdout unless a filename was specified */
+    if (dest == NULL) {
+        fp = stdout;
+    } else {
+        fp = fopen(dest, "w");
+
+        if (fp == NULL) {
+            warn(_("error opening %s for writing"), dest);
+            return;
+        }
+    }
+
+    /* output the results */
+    TAILQ_FOREACH(result, results, items) {
+        /* skip conditions */
+        if (!strcmp(result->header, NAME_DIAGNOSTICS)) {
+            continue;
+        }
+
+        /* get a string representing the verb */
+        if (result->verb == VERB_ADDED) {
+            verb = _("added");
+        } else if (result->verb == VERB_REMOVED) {
+            verb = _("removed");
+        } else if (result->verb == VERB_CHANGED) {
+            verb = _("changed");
+        } else if (result->verb == VERB_FAILED) {
+            verb = _("FAILED");
+        } else if (result->verb == VERB_OK) {
+            verb = _("ok");
+        } else {
+            verb = _("unknown");
+        }
+
+        /* construct the basic message */
+        xasprintf(&msg, "%-12s %s (%s)\n", verb, result->noun, result->header);
+
+        /* replace ${FILE} */
+        if (strstr(msg, "${FILE}") && result->file != NULL) {
+            tmp = strreplace(msg, "${FILE}", result->file);
+            free(msg);
+            msg = tmp;
+        }
+
+        /* replace ${ARCH} */
+        if (strstr(msg, "${ARCH}") && result->arch != NULL) {
+            tmp = strreplace(msg, "${ARCH}", result->arch);
+            free(msg);
+            msg = tmp;
+        }
+
+        /* print the result */
+        if (width) {
+            printwrap(msg, width, 0, fp);
+        } else {
+            fprintf(fp, "%s", msg);
+        }
+
+        /* clean up */
+        free(msg);
+    }
+
+    /* tidy up and return */
+    r = fflush(fp);
+    assert(r == 0);
+
+    if (dest != NULL) {
+        r = fclose(fp);
+        assert(r == 0);
+    }
+
+    return;
+}


### PR DESCRIPTION
This commits adds a fourth output mode for rpminspect.  This one is
called 'summary' because each result is displayed on a single line
with the main thing that happened in the left most column followed by
a description of what happened (this may include the file in question
and/or the architecture) and finally the name of the inspection where
it happened in parens.

Originally requested as an enhancement in issue #26, this patch tries
to provide a similar functionality to the example rpmlint output shown
in that issue.

Signed-off-by: David Cantrell <dcantrell@redhat.com>