### PR TITLE
[fix] Ensure summary mode output works for a number of inspections

### DIFF
--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -126,6 +126,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.remedy = REMEDY_ANNOCHECK;
     params.arch = arch;
     params.file = file->localpath;
+    params.verb = VERB_OK;
 
     /* Run each annocheck test and report the results */
     HASH_ITER(hh, ri->annocheck, hentry, tmp_hentry) {
@@ -230,6 +231,7 @@ bool inspect_annocheck(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_ANNOCHECK;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -131,7 +131,9 @@ static bool badfuncs_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     params.remedy = REMEDY_BADFUNCS;
     params.details = output_buffer;
     params.verb = VERB_FAILED;
-    params.noun = _("forbidden functions found in ${FILE}");
+    params.noun = _("forbidden functions in ${FILE} on ${ARCH}");
+    params.file = after->localpath;
+    params.arch = arch;
     add_result(ri, &params);
     free(params.msg);
     free(output_buffer);

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -286,6 +286,8 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
                     xasprintf(&params.msg, _("Desktop file %s on %s references executable %s but %s is not executable by all"), file->localpath, arch, tmp, tmp);
                     params.severity = RESULT_VERIFY;
                     params.waiverauth = WAIVABLE_BY_ANYONE;
+                    params.verb = VERB_FAILED;
+                    params.noun = _("${FILE} references non-executable file on ${ARCH}");
                     add_result(ri, &params);
                     free(params.msg);
                     result = false;
@@ -309,6 +311,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
                xasprintf(&params.msg, _("Desktop file %s on %s references executable %s; no subpackages contain an executable of that name, however it has a TryExec key so it may be ignored in case %s does not exist"), file->localpath, arch, tmp, key_tryexec);
                 params.severity = RESULT_INFO;
                 params.waiverauth = NOT_WAIVABLE;
+                params.verb = VERB_OK;
                 add_result(ri, &params);
                 free(params.msg);
                 result = false;
@@ -316,6 +319,8 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
                 xasprintf(&params.msg, _("Desktop file %s on %s references executable %s but no subpackages contain an executable of that name"), file->localpath, arch, tmp);
                 params.severity = RESULT_VERIFY;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
+                params.verb = VERB_FAILED;
+                params.noun = _("${FILE} references missing executable on ${ARCH}");
                 add_result(ri, &params);
                 free(params.msg);
                 result = false;
@@ -360,6 +365,8 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
                     xasprintf(&params.msg, _("Desktop file %s on %s references icon %s but %s is not readable by all"), file->localpath, arch, key_icon, key_icon);
                     params.severity = RESULT_VERIFY;
                     params.waiverauth = WAIVABLE_BY_ANYONE;
+                    params.verb = VERB_FAILED;
+                    params.noun = _("${FILE} references unreadble icon on ${ARCH}");
                     add_result(ri, &params);
                     free(params.msg);
                     result = false;
@@ -380,6 +387,8 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
             xasprintf(&params.msg, _("Desktop file %s on %s references icon %s but no subpackages contain %s"), file->localpath, arch, key_icon, key_icon);
             params.severity = RESULT_VERIFY;
             params.waiverauth = WAIVABLE_BY_ANYONE;
+            params.verb = VERB_FAILED;
+            params.noun = _("${FILE} references missing icon on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
             result = false;
@@ -448,7 +457,7 @@ static bool desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.arch = arch;
     params.file = file->localpath;
     params.verb = VERB_CHANGED;
-    params.noun = _("${FILE}");
+    params.noun = _("${FILE} is not valid on ${ARCH}");
 
     if (file->peer_file && before_out == NULL && params.details != NULL) {
         xasprintf(&params.msg, _("File %s is no longer a valid desktop entry file on %s; desktop-file-validate reports:"), file->localpath, arch);
@@ -498,6 +507,7 @@ bool inspect_desktop(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_DESKTOP;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -196,7 +196,7 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (release == NULL) {
         xasprintf(&params.msg, _("The %s file is missing the %s tag."), file->localpath, SPEC_TAG_RELEASE);
         params.verb = VERB_REMOVED;
-        params.noun = _("Release: tag");
+        params.noun = _("${FILE} missing Release tag");
         add_result(ri, &params);
         result = false;
     } else if (strstr(release, SPEC_DISTTAG) || strstr(expanded_release, DIST_TAG_MARKER)) {
@@ -204,7 +204,7 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     } else if (!check_release_macros(macrocount, ri->macros, release, SPEC_DISTTAG)) {
         xasprintf(&params.msg, _("The %s tag value is missing the dist tag in the proper form. The dist tag should be of the form '%s' in the %s tag or in a macro used in the %s tag. After RPM macro expansion, no dist tag was found in this %s tag value."), SPEC_TAG_RELEASE, SPEC_DISTTAG, SPEC_TAG_RELEASE, SPEC_TAG_RELEASE, SPEC_TAG_RELEASE);
         params.verb = VERB_FAILED;
-        params.noun = _("'%%{?dist}' tag");
+        params.noun = _("${FILE} does not use '%%{?dist}' in Release");
         add_result(ri, &params);
         result = false;
     }
@@ -265,6 +265,7 @@ bool inspect_disttag(struct rpminspect *ri)
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_DISTTAG;
+    params.verb = VERB_OK;
 
     /* If we never saw an SRPM, tell the user. */
     if (result && src) {

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -478,7 +478,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
             params.remedy = REMEDY_ELF_EXECSTACK_MISSING;
             params.verb = VERB_CHANGED;
-            params.noun = _("GNU_STACK on ${FILE}");
+            params.noun = _("GNU_STACK in ${FILE} on ${ARCH}");
             add_result(ri, &params);
             result = false;
         }
@@ -540,7 +540,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
             if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
                 params.remedy = REMEDY_ELF_EXECSTACK_INVALID;
                 params.verb = VERB_FAILED;
-                params.noun = _("execstack on ${FILE}");
+                params.noun = _("execstack in ${FILE} on ${ARCH}");
                 add_result(ri, &params);
                 result = false;
             }
@@ -570,7 +570,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
             params.remedy = REMEDY_ELF_EXECSTACK_EXECUTABLE;
             params.verb = VERB_FAILED;
-            params.noun = _("execstack on ${FILE}");
+            params.noun = _("execstack in ${FILE} on ${ARCH}");
             add_result(ri, &params);
             result = false;
         }
@@ -608,7 +608,7 @@ static bool check_relro(struct rpminspect *ri, Elf *before_elf, Elf *after_elf, 
         params.arch = arch;
         params.file = file->localpath;
         params.verb = VERB_REMOVED;
-        params.noun = _("GNU_RELRO on ${FILE}");
+        params.noun = _("lost GNU_RELRO in ${FILE} on ${ARCH}");
 
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
             add_result(ri, &params);
@@ -728,7 +728,7 @@ static bool check_fortified(struct rpminspect *ri, Elf *before_elf, Elf *after_e
     params.arch = arch;
     params.file = file->localpath;
     params.verb = VERB_REMOVED;
-    params.noun = _("-D_FORTIFY_SOURCE on ${FILE}");
+    params.noun = _("lost -D_FORTIFY_SOURCE in ${FILE} on ${ARCH}");
     params.severity = get_secrule_result_severity(ri, file, SECRULE_FORTIFYSOURCE);
 
     if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
@@ -954,7 +954,7 @@ static bool elf_archive_tests(struct rpminspect *ri, Elf *after_elf, int after_e
     params.arch = arch;
     params.file = file->localpath;
     params.verb = VERB_REMOVED;
-    params.noun = _("-fPIC on ${FILE}");
+    params.noun = _("missing -fPIC in ${FILE} on ${ARCH}");
     params.severity = get_secrule_result_severity(ri, file, SECRULE_PIC);
 
     if (!result && params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
@@ -991,7 +991,7 @@ static bool elf_regular_tests(struct rpminspect *ri, Elf *after_elf, Elf *before
     params.remedy = REMEDY_ELF_TEXTREL;
     params.arch = arch;
     params.file = file->localpath;
-    params.noun = _("TEXTREL relocations on ${FILE}");
+    params.noun = _("TEXTREL relocations in ${FILE} on ${ARCH}");
 
     /* skip kernel eBPF machine type objects */
     if (get_elf_machine(after_elf) == EM_BPF) {
@@ -1117,6 +1117,7 @@ bool inspect_elf(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_ELF;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -78,6 +78,7 @@ bool inspect_emptyrpm(struct rpminspect *ri)
     rpmpeer_entry_t *peer = NULL;
     const char *name = NULL;
     char *bn = NULL;
+    char *an = NULL;
     struct result_params params;
 
     assert(ri != NULL);
@@ -109,18 +110,31 @@ bool inspect_emptyrpm(struct rpminspect *ri)
                 xasprintf(&params.msg, _("New package %s is empty (no payloads); this is expected per the rpminspect configuration"), bn);
                 params.severity = RESULT_INFO;
                 params.waiverauth = NOT_WAIVABLE;
+                params.verb = VERB_OK;
+                params.noun = NULL;
+                params.file = NULL;
+                params.arch = NULL;
                 params.remedy = NULL;
                 reported = true;
             } else if (payload_only_ghosts(peer->after_hdr)) {
                 xasprintf(&params.msg, _("New package %s is empty (no payloads); this is expected because the package only contains %%ghost entries"), bn);
                 params.severity = RESULT_INFO;
                 params.waiverauth = NOT_WAIVABLE;
+                params.verb = VERB_OK;
+                params.noun = NULL;
+                params.file = NULL;
+                params.arch = NULL;
                 params.remedy = NULL;
                 reported = true;
             } else {
-                xasprintf(&params.msg, _("New package %s is empty (no payloads)"), basename(peer->after_rpm));
+                an = basename(peer->after_rpm);
+                xasprintf(&params.msg, _("New package %s is empty (no payloads)"), an);
                 params.severity = RESULT_VERIFY;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
+                params.verb = VERB_FAILED;
+                params.noun = _("${FILE} has empty payload");
+                params.file = an;
+                params.arch = get_rpm_header_arch(peer->after_hdr);
                 params.remedy = REMEDY_EMPTYRPM;
                 good = false;
                 reported = true;
@@ -134,6 +148,10 @@ bool inspect_emptyrpm(struct rpminspect *ri)
     if (good & !reported) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_OK;
+        params.noun = NULL;
+        params.file = NULL;
+        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -73,6 +73,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.header = NAME_FILESIZE;
     params.arch = arch;
     params.file = file->localpath;
+    params.verb = VERB_OK;
 
     /* Size checks and messaging */
     if (file->st.st_size > 0 && file->peer_file->st.st_size == 0) {
@@ -80,7 +81,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         xasprintf(&params.msg, _("%s became a non-empty file on %s"), file->localpath, arch);
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.verb = VERB_CHANGED;
+        params.verb = VERB_FAILED;
         params.noun = _("non-empty ${FILE}");
         result = false;
     } else if (file->st.st_size == 0 && file->peer_file->st.st_size > 0) {
@@ -88,7 +89,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         xasprintf(&params.msg, _("%s became an empty file on %s"), file->localpath, arch);
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.verb = VERB_CHANGED;
+        params.verb = VERB_FAILED;
         params.noun = _("empty ${FILE}");
         result = false;
     } else {

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -382,11 +382,15 @@ static int check_peer_license(struct rpminspect *ri, struct result_params *param
     nevra = get_nevra(hdr);
     assert(nevra != NULL);
     license = headerGetString(hdr, RPMTAG_LICENSE);
+    params->file = nevra;
+    params->arch = get_rpm_header_arch(hdr);
 
     if (license == NULL) {
         xasprintf(&params->msg, _("Empty License Tag in %s"), nevra);
         params->severity = RESULT_BAD;
         params->remedy = REMEDY_LICENSE;
+        params->verb = VERB_FAILED;
+        params->noun = _("missing License tag in ${FILE}");
         add_result(ri, params);
         free(params->msg);
         ret = 1;
@@ -398,6 +402,10 @@ static int check_peer_license(struct rpminspect *ri, struct result_params *param
             xasprintf(&params->msg, _("Valid License Tag in %s: %s"), nevra, license);
             params->severity = RESULT_INFO;
             params->remedy = NULL;
+            params->verb = VERB_OK;
+            params->noun = NULL;
+            params->file = NULL;
+            params->arch = NULL;
             add_result(ri, params);
             free(params->msg);
             ret = 1;
@@ -408,6 +416,8 @@ static int check_peer_license(struct rpminspect *ri, struct result_params *param
             xasprintf(&params->msg, _("License Tag contains unprofessional language in %s: %s"), nevra, license);
             params->severity = RESULT_BAD;
             params->remedy = REMEDY_LICENSE;
+            params->verb = VERB_FAILED;
+            params->noun = _("unprofessional language in License tag in ${FILE}");
             add_result(ri, params);
             free(params->msg);
             ret = 1;
@@ -474,6 +484,10 @@ bool inspect_license(struct rpminspect *ri)
         xasprintf(&params.msg, _("Missing license database: %s: %s"), actual_licensedb, strerror(errno));
         params.severity = RESULT_BAD;
         params.remedy = REMEDY_LICENSEDB;
+        params.verb = VERB_FAILED;
+        params.noun = _("missing license database");
+        params.file = NULL;
+        params.arch = NULL;
         add_result(ri, &params);
         free(params.msg);
         free(actual_licensedb);

--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -45,6 +45,7 @@ bool inspect_lostpayload(struct rpminspect *ri) {
     bool good = true;
     bool messaged = false;
     rpmpeer_entry_t *peer = NULL;
+    char *an = NULL;
     struct result_params params;
 
     assert(ri != NULL);
@@ -69,6 +70,10 @@ bool inspect_lostpayload(struct rpminspect *ri) {
             xasprintf(&params.msg, _("Existing subpackage %s is now missing"), headerGetString(peer->before_hdr, RPMTAG_NAME));
             params.severity = RESULT_VERIFY;
             params.waiverauth = WAIVABLE_BY_ANYONE;
+            params.verb = VERB_FAILED;
+            params.noun = _("missing subpackage ${FILE} on ${ARCH}");
+            params.file = headerGetString(peer->before_hdr, RPMTAG_NAME);
+            params.arch = get_rpm_header_arch(peer->before_hdr);
             params.remedy = REMEDY_LOSTPAYLOAD;
             add_result(ri, &params);
             free(params.msg);
@@ -82,13 +87,22 @@ bool inspect_lostpayload(struct rpminspect *ri) {
                 xasprintf(&params.msg, _("Package %s continues to be empty (no payloads)"), basename(peer->after_rpm));
                 params.severity = RESULT_INFO;
                 params.waiverauth = NOT_WAIVABLE;
+                params.verb = VERB_OK;
+                params.noun = NULL;
+                params.file = NULL;
+                params.arch = NULL;
                 params.remedy = REMEDY_LOSTPAYLOAD;
                 add_result(ri, &params);
                 free(params.msg);
             } else {
-                xasprintf(&params.msg, _("Package %s became empty (no payloads)"), basename(peer->after_rpm));
+                an = basename(peer->after_rpm);
+                xasprintf(&params.msg, _("Package %s became empty (no payloads)"), an);
                 params.severity = RESULT_VERIFY;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
+                params.verb = VERB_FAILED;
+                params.noun = _("subpackage ${FILE} on ${ARCH} now has empty payload");
+                params.file = an;
+                params.arch = get_rpm_header_arch(peer->after_hdr);
                 params.remedy = REMEDY_LOSTPAYLOAD;
                 add_result(ri, &params);
                 free(params.msg);
@@ -102,6 +116,10 @@ bool inspect_lostpayload(struct rpminspect *ri) {
     if (!messaged) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_OK;
+        params.noun = NULL;
+        params.file = NULL;
+        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -305,7 +305,6 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.arch = get_rpm_header_arch(file->rpm_header);
     params.file = file->localpath;
     params.verb = VERB_FAILED;
-    params.noun = _("${FILE}");
 
     /* check for empty man pages */
     uncompressed_man_page = uncompress_file(ri, file->fullpath, NAME_MANPAGE);
@@ -316,6 +315,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("Man page %s is possibly empty on %s in %s"), file->localpath, params.arch, pkg);
             params.remedy = REMEDY_MAN_ERRORS;
             params.details = NULL;
+            params.noun = _("empty man page ${FILE} on ${ARCH}");
             add_result(ri, &params);
             result = false;
             free(params.msg);
@@ -331,6 +331,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         xasprintf(&params.msg, _("Man page checker reported problems with %s on %s in %s"), file->localpath, params.arch, pkg);
         params.remedy = REMEDY_MAN_ERRORS;
         params.details = manpage_errors;
+        params.noun = _("man page ${FILE} on ${ARCH} has errors");
         add_result(ri, &params);
         free(params.msg);
         free(manpage_errors);
@@ -342,6 +343,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         xasprintf(&params.msg, _("Man page %s has incorrect path on %s in %s"), file->localpath, params.arch, pkg);
         params.remedy = REMEDY_MAN_PATH;
         params.details = NULL;
+        params.noun = _("man page ${FILE} on ${ARCH} has incorrect path");
         add_result(ri, &params);
         free(params.msg);
         result = false;
@@ -364,6 +366,7 @@ bool inspect_manpage(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_MANPAGE;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_metadata.c
+++ b/lib/inspect_metadata.c
@@ -28,7 +28,8 @@
 /*
  * Validate the metadata tags in the RPM headers.
  */
-static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const Header after_hdr) {
+static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const Header after_hdr)
+{
     bool ret = true;
     bool valid_subdomain = false;
     bool rebase = false;
@@ -55,6 +56,10 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         xasprintf(&params.msg, _("Vendor not set in the rpminspect configuration, ignoring Package Vendor \"%s\" in %s"), after_vendor, after_nevra);
         params.severity = RESULT_INFO;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_OK;
+        params.noun = NULL;
+        params.file = NULL;
+        params.arch = NULL;
         params.remedy = REMEDY_VENDOR;
         add_result(ri, &params);
         free(params.msg);
@@ -62,6 +67,10 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         xasprintf(&params.msg, _("Package Vendor \"%s\" is not \"%s\" in %s"), after_vendor, ri->vendor, after_nevra);
         params.severity = RESULT_BAD;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_FAILED;
+        params.noun = _("invalid vendor ${FILE} on ${ARCH}");
+        params.file = after_vendor;
+        params.arch = get_rpm_header_arch(after_hdr);
         params.remedy = REMEDY_VENDOR;
         add_result(ri, &params);
         free(params.msg);
@@ -83,6 +92,10 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
             xasprintf(&params.msg, _("Package Build Host \"%s\" is not within an expected build host subdomain in %s"), after_buildhost, after_nevra);
             params.severity = RESULT_BAD;
             params.waiverauth = NOT_WAIVABLE;
+            params.verb = VERB_FAILED;
+            params.noun = _("invalid build host ${FILE} on ${ARCH}");
+            params.file = after_buildhost;
+            params.arch = get_rpm_header_arch(after_hdr);
             params.remedy = REMEDY_BUILDHOST;
             add_result(ri, &params);
             free(params.msg);
@@ -96,6 +109,10 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         xasprintf(&params.details, _("Summary: %s"), after_summary);
         params.severity = RESULT_BAD;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_FAILED;
+        params.noun = _("Summary contains unprofessional words on ${ARCH}");
+        params.file = NULL;
+        params.arch = get_rpm_header_arch(after_hdr);
         params.remedy = REMEDY_BADWORDS;
         add_result(ri, &params);
         free(params.msg);
@@ -109,6 +126,10 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         xasprintf(&params.details, "%s", after_description);
         params.severity = RESULT_BAD;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_FAILED;
+        params.noun = _("Description contains unprofessional words on ${ARCH}");
+        params.file = NULL;
+        params.arch = get_rpm_header_arch(after_hdr);
         params.remedy = REMEDY_BADWORDS;
         add_result(ri, &params);
         free(params.msg);
@@ -151,6 +172,10 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
             xasprintf(&params.msg, _("Package Summary change from \"%s\" to \"%s\" in %s"), before_summary, after_summary, after_name);
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
+            params.verb = VERB_OK;
+            params.noun = NULL;
+            params.file = NULL;
+            params.arch = NULL;
             params.remedy = NULL;
             add_result(ri, &params);
             free(params.msg);
@@ -162,6 +187,10 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
             xasprintf(&params.details, _("from:\n\n%s\n\nto:\n\n%s"), before_description, after_description);
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
+            params.verb = VERB_OK;
+            params.noun = NULL;
+            params.file = NULL;
+            params.arch = NULL;
             params.remedy = NULL;
             add_result(ri, &params);
             free(params.msg);
@@ -176,7 +205,8 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
 /*
  * Main driver for the 'metadata' inspection.
  */
-bool inspect_metadata(struct rpminspect *ri) {
+bool inspect_metadata(struct rpminspect *ri)
+{
     bool good = true;
     rpmpeer_entry_t *peer = NULL;
     struct result_params params;
@@ -210,6 +240,10 @@ bool inspect_metadata(struct rpminspect *ri) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_METADATA;
+        params.verb = VERB_OK;
+        params.noun = NULL;
+        params.file = NULL;
+        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -142,12 +142,17 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("Possible politically sensitive file (%s) found in %s on %s: rules allow this file."), file->localpath, name, params.arch);
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
+            params.verb = VERB_OK;
+            params.noun = NULL;
+            params.file = NULL;
+            params.arch = NULL;
         } else {
             xasprintf(&params.msg, _("Possible politically sensitive file (%s) found in %s on %s: rules prohibit this file."), file->localpath, name, params.arch);
             params.severity = RESULT_BAD;
             params.waiverauth = NOT_WAIVABLE;
             params.verb = VERB_FAILED;
             params.noun = _("${FILE} is politically sensitive");
+            params.file = file->localpath;
             result = false;
         }
 
@@ -177,6 +182,10 @@ bool inspect_politics(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_POLITICS;
+        params.verb = VERB_OK;
+        params.noun = NULL;
+        params.file = NULL;
+        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -461,7 +461,7 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
     params.header = NAME_UNICODE;
     params.arch = globalarch;
     params.file = localpath;
-    params.noun = _("forbidden code point in ${FILE}");
+    params.noun = _("forbidden code point in ${FILE} on ${ARCH}");
     params.verb = VERB_FAILED;
     params.remedy = REMEDY_UNICODE;
 
@@ -652,6 +652,7 @@ bool inspect_unicode(struct rpminspect *ri)
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_UNICODE;
+    params.verb = VERB_OK;
 
     if (result) {
         params.severity = RESULT_OK;

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -180,6 +180,10 @@ bool inspect_virus(struct rpminspect *ri)
         warn("closedir");
     }
 
+    params.verb = VERB_OK;
+    params.noun = NULL;
+    params.file = NULL;
+    params.arch = NULL;
     add_result(ri, &params);
     free(params.msg);
 
@@ -188,7 +192,7 @@ bool inspect_virus(struct rpminspect *ri)
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_VIRUS;
     params.verb = VERB_FAILED;
-    params.noun = _("virus or malware in ${FILE}");
+    params.noun = _("virus or malware in ${FILE} on ${ARCH}");
     result = foreach_peer_file(ri, NAME_VIRUS, virus_driver, false);
 
     /* hope the result is always this */
@@ -197,6 +201,10 @@ bool inspect_virus(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_VIRUS;
+        params.verb = VERB_OK;
+        params.noun = NULL;
+        params.file = NULL;
+        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -204,6 +204,7 @@ static bool xml_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         xasprintf(&params.msg, _("%s is a well-formed XML file in %s on %s, but is not a valid XML file"), file->localpath, pkg, params.arch);
         params.severity = RESULT_INFO;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_OK;
         add_result(ri, &params);
         free(params.msg);
         free(params.details);
@@ -211,6 +212,8 @@ static bool xml_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         xasprintf(&params.msg, _("%s is not a well-formed XML file in %s on %s"), file->localpath, pkg, params.arch);
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
+        params.verb = VERB_FAILED;
+        params.noun = _("${FILE} is not well-formed XML on ${ARCH}");
         add_result(ri, &params);
         free(params.msg);
         free(params.details);
@@ -232,6 +235,7 @@ bool inspect_xml(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_XML;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 


### PR DESCRIPTION
I am having to go back and make sure all the add_result() calls set
fields used by the summary output mode.  I am working through those
now.  The output is functional, but you might see lines that begin
with "unknown" or contain "(null)" and stuff like that.  I'm just
working through those.

Signed-off-by: David Cantrell <dcantrell@redhat.com>