### PR TITLE
[lib] Final update for librpminspect inspections and summary mode

### DIFF
--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -198,21 +198,22 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.remedy = REMEDY_ABIDIFF;
     params.arch = arch;
+    params.file = file->localpath;
 
     if ((exitcode & ABIDIFF_ERROR) || (exitcode & ABIDIFF_USAGE_ERROR)) {
         params.severity = RESULT_VERIFY;
         params.verb = VERB_FAILED;
-        params.noun = ri->commands.abidiff;
+        params.noun = _("abidiff usage error");;
         report = true;
     } else if (!rebase && (exitcode & ABIDIFF_ABI_CHANGE)) {
         params.severity = RESULT_VERIFY;
         params.verb = VERB_CHANGED;
-        params.noun = _("ABI");
+        params.noun = _("ABI change in ${FILE} on ${ARCH}");
         report = true;
     } else if (!rebase && (exitcode & ABIDIFF_ABI_INCOMPATIBLE_CHANGE)) {
         params.severity = RESULT_BAD;
         params.verb = VERB_CHANGED;
-        params.noun = _("ABI");
+        params.noun = _("ABI incompatible change in ${FILE} on ${ARCH}");
         report = true;
     }
 
@@ -241,7 +242,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (exitcode && output) {
             params.msg = strdup(_("ABI comparison ended unexpectedly."));
             params.verb = VERB_FAILED;
-            params.noun = ri->commands.abidiff;
+            params.noun = _("abidff unexpected exit");
         }
 
         params.file = file->localpath;
@@ -262,7 +263,8 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 /*
  * Main driver for the 'abidiff' inspection.
  */
-bool inspect_abidiff(struct rpminspect *ri) {
+bool inspect_abidiff(struct rpminspect *ri)
+{
     bool result = false;
     size_t num_arches = 0;
     struct result_params params;
@@ -311,6 +313,7 @@ bool inspect_abidiff(struct rpminspect *ri) {
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_ABIDIFF;
         params.severity = RESULT_OK;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -95,7 +95,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 xasprintf(&params.remedy, REMEDY_CAPABILITIES, ri->caps_filename);
                 params.waiverauth = WAIVABLE_BY_SECURITY;
                 params.verb = VERB_CHANGED;
-                params.noun = _("${FILE} capabilities");
+                params.noun = _("${FILE} capabilities on ${ARCH}");
                 add_result(ri, &params);
                 free(params.msg);
                 free(params.remedy);
@@ -105,6 +105,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("File capabilities found for %s: '%s' on %s\n"), file->localpath, after, arch);
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
+            params.verb = VERB_OK;
             add_result(ri, &params);
             free(params.msg);
         }
@@ -129,6 +130,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("File capabilities list entry found for %s: '%s' on %s, matches package\n"), file->localpath, flcaps->caps, arch);
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
+            params.verb = VERB_OK;
             add_result(ri, &params);
             free(params.msg);
         } else if (cap_compare(aftercap, expected) && (ri->tests & INSPECT_CAPABILITIES)) {
@@ -139,7 +141,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 xasprintf(&params.remedy, REMEDY_CAPABILITIES, ri->caps_filename);
                 params.waiverauth = WAIVABLE_BY_SECURITY;
                 params.verb = VERB_FAILED;
-                params.noun = _("${FILE} capabilities list");
+                params.noun = _("${FILE} capabilities list on ${ARCH}");
                 add_result(ri, &params);
                 free(params.msg);
                 free(params.remedy);
@@ -154,7 +156,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.remedy, REMEDY_CAPABILITIES, ri->caps_filename);
             params.waiverauth = WAIVABLE_BY_SECURITY;
             params.verb = VERB_REMOVED;
-            params.noun = _("${FILE} capabilities list");
+            params.noun = _("${FILE} capabilities list on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
             free(params.remedy);
@@ -168,7 +170,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.remedy, REMEDY_CAPABILITIES, ri->caps_filename);
             params.waiverauth = WAIVABLE_BY_SECURITY;
             params.verb = VERB_FAILED;
-            params.noun = _("${FILE} capabilities list");
+            params.noun = _("${FILE} capabilities list on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
             free(params.remedy);
@@ -201,6 +203,7 @@ bool inspect_capabilities(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_CAPABILITIES;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -169,6 +169,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                     xasprintf(&params.msg, _("%%config file content change for %s in %s on %s (comments/whitespace only)"), file->localpath, name, arch);
                     params.severity = RESULT_INFO;
                     params.waiverauth = NOT_WAIVABLE;
+                    params.verb = VERB_OK;
                     result = true;
                 } else {
                     xasprintf(&params.msg, _("%%config file content change for %s in %s on %s"), file->localpath, name, arch);
@@ -199,7 +200,8 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 /*
  * Main driver for the 'config' inspection.
  */
-bool inspect_config(struct rpminspect *ri) {
+bool inspect_config(struct rpminspect *ri)
+{
     bool result = true;
     struct result_params params;
 
@@ -212,6 +214,7 @@ bool inspect_config(struct rpminspect *ri) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_CONFIG;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -69,8 +69,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Skip files in the debug path and debug source path */
-    if (strprefix(file->localpath, DEBUG_PATH) ||
-        strprefix(file->localpath, DEBUG_SRC_PATH)) {
+    if (strprefix(file->localpath, DEBUG_PATH) || strprefix(file->localpath, DEBUG_SRC_PATH)) {
         return true;
     }
 
@@ -166,7 +165,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (removed != NULL && !TAILQ_EMPTY(removed)) {
         xasprintf(&params.msg, _("DT_NEEDED symbol(s) removed from %s on %s"), file->localpath, arch);
         params.verb = VERB_REMOVED;
-        params.noun = _("DT_NEEDED symbol(s) in ${FILE}");
+        params.noun = _("DT_NEEDED symbol(s) in ${FILE} on ${ARCH}");
 
         TAILQ_FOREACH(entry, removed, items) {
             xasprintf(&tmp, "%s\n", entry->data);
@@ -183,7 +182,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (added != NULL && !TAILQ_EMPTY(added)) {
         xasprintf(&params.msg, _("DT_NEEDED symbol(s) added to %s on %s"), file->localpath, arch);
         params.verb = VERB_ADDED;
-        params.noun = _("DT_NEEDED symbol(s) in ${FILE}");
+        params.noun = _("DT_NEEDED symbol(s) in ${FILE} on ${ARCH}");
 
         TAILQ_FOREACH(entry, added, items) {
             xasprintf(&tmp, "%s\n", entry->data);
@@ -219,7 +218,8 @@ done:
 /*
  * Main driver for the dsodeps inspection.
  */
-bool inspect_dsodeps(struct rpminspect *ri) {
+bool inspect_dsodeps(struct rpminspect *ri)
+{
     bool result;
     struct result_params params;
 
@@ -234,6 +234,7 @@ bool inspect_dsodeps(struct rpminspect *ri) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_DSODEPS;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -82,7 +82,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
-        params.noun = _("non-empty ${FILE}");
+        params.noun = _("non-empty ${FILE} on ${ARCH}");
         result = false;
     } else if (file->st.st_size == 0 && file->peer_file->st.st_size > 0) {
         /* became empty */
@@ -90,7 +90,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
-        params.noun = _("empty ${FILE}");
+        params.noun = _("empty ${FILE} on ${ARCH}");
         result = false;
     } else {
         change = ((file->st.st_size - file->peer_file->st.st_size) * 100 / file->peer_file->st.st_size);
@@ -108,17 +108,18 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (change > 0) {
             /* file grew */
             xasprintf(&params.msg, _("%s grew by %lld%% on %s"), file->localpath, llabs(change), arch);
-            params.noun = _("${FILE} size grew");
+            params.noun = _("${FILE} size grew on ${ARCH}");
         } else if (change < 0) {
             /* file shrank */
             xasprintf(&params.msg, _("%s shrank by %lld%% on %s"), file->localpath, llabs(change), arch);
-            params.noun = _("${FILE} size shrank");
+            params.noun = _("${FILE} size shrank on ${ARCH}");
         }
     }
 
     /* info reporting if user configured that */
     if (ri->size_threshold == -1) {
         params.severity = RESULT_INFO;
+        params.verb = VERB_OK;
     }
 
     /* Reporting */
@@ -133,7 +134,8 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 /*
  * Main driver for the 'filesize' inspection.
  */
-bool inspect_filesize(struct rpminspect *ri) {
+bool inspect_filesize(struct rpminspect *ri)
+{
     bool result;
     struct result_params params;
 
@@ -148,6 +150,7 @@ bool inspect_filesize(struct rpminspect *ri) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_FILESIZE;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -252,21 +252,22 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.remedy = REMEDY_KMIDIFF;
     params.arch = arch;
+    params.file = file->localpath;
 
     if ((exitcode & ABIDIFF_ERROR) || (exitcode & ABIDIFF_USAGE_ERROR)) {
         params.severity = RESULT_VERIFY;
         params.verb = VERB_FAILED;
-        params.noun = ri->commands.kmidiff;
+        params.noun = _("kmidiff usage error");
         report = true;
     } else if (!rebase && (exitcode & ABIDIFF_ABI_CHANGE)) {
         params.severity = RESULT_VERIFY;
         params.verb = VERB_CHANGED;
-        params.noun = _("KMI");
+        params.noun = _("KMI change in ${FILE} on ${ARCH}");
         report = true;
     } else if (!rebase && (exitcode & ABIDIFF_ABI_INCOMPATIBLE_CHANGE)) {
         params.severity = RESULT_BAD;
         params.verb = VERB_CHANGED;
-        params.noun = _("KMI");
+        params.noun = _("KMI incompatible change in ${FILE} on ${ARCH}");
         report = true;
     }
 
@@ -286,7 +287,7 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (exitcode && output) {
             params.msg = strdup(_("KMI comparison ended unexpectedly."));
             params.verb = VERB_FAILED;
-            params.noun = ri->commands.abidiff;
+            params.noun = _("kmidiff unexpected exit");
         }
 
         params.file = file->localpath;
@@ -307,7 +308,8 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 /*
  * Main driver for the 'kmidiff' inspection.
  */
-bool inspect_kmidiff(struct rpminspect *ri) {
+bool inspect_kmidiff(struct rpminspect *ri)
+{
     bool result = true;
     rpmpeer_entry_t *peer = NULL;
     rpmfile_entry_t *file = NULL;
@@ -377,6 +379,7 @@ bool inspect_kmidiff(struct rpminspect *ri) {
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_KMIDIFF;
         params.severity = RESULT_OK;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -41,7 +41,7 @@ static void lost_alias(const char *alias, const string_list_t *before_modules, c
     assert(ri != NULL);
 
     params.remedy = REMEDY_KMOD_ALIAS;
-    params.noun = _("${FILE} kernel module alias");
+    params.noun = _("${FILE} kernel module alias on ${ARCH}");
 
     TAILQ_FOREACH(entry, before_modules, items) {
         xasprintf(&params.msg, _("Kernel module '%s' lost alias '%s'"), entry->data, alias);
@@ -206,8 +206,9 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("Kernel module %s removes parameter '%s'"), file->localpath, entry->data);
             params.remedy = REMEDY_KMOD_PARM;
             params.verb = VERB_REMOVED;
-            params.noun = _("${FILE} kernel module parameter");
+            params.noun = _("${FILE} kernel module parameter on ${ARCH}");
             params.file = file->localpath;
+            params.arch = get_rpm_header_arch(file->rpm_header);
             add_result(ri, &params);
             free(params.msg);
             params.msg = NULL;
@@ -224,8 +225,9 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.waiverauth = NOT_WAIVABLE;
             params.remedy = NULL;
             params.verb = VERB_ADDED;
-            params.noun = _("${FILE} kernel module parameter");
+            params.noun = _("${FILE} kernel module parameter on ${ARCH}");
             params.file = file->localpath;
+            params.arch = get_rpm_header_arch(file->rpm_header);
             add_result(ri, &params);
             free(params.msg);
             params.msg = NULL;
@@ -244,8 +246,9 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("Kernel module %s removes dependency '%s'"), file->localpath, entry->data);
             params.remedy = REMEDY_KMOD_DEPS;
             params.verb = VERB_REMOVED;
-            params.noun = _("${FILE} kernel module dependency");
+            params.noun = _("${FILE} kernel module dependency on ${ARCH}");
             params.file = file->localpath;
+            params.arch = get_rpm_header_arch(file->rpm_header);
             add_result(ri, &params);
             free(params.msg);
             params.msg = NULL;
@@ -294,7 +297,8 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 /*
  * Main driver for the 'kmod' inspection.
  */
-bool inspect_kmod(struct rpminspect *ri) {
+bool inspect_kmod(struct rpminspect *ri)
+{
     bool result;
 
     assert(ri != NULL);
@@ -304,12 +308,14 @@ bool inspect_kmod(struct rpminspect *ri) {
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_KMOD;
+    params.verb = VERB_OK;
     result = foreach_peer_file(ri, NAME_KMOD, kmod_driver, true);
 
     /* if everything was fine, just say so */
     if (result) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -117,7 +117,8 @@ static bool find_lto_symbols(Elf *elf, string_list_t **user_data)
  * @param file The file the function is asked to examine
  * @return True if the file passes, false otherwise
  */
-static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
+static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file)
+{
     bool result = true;
     Elf *elf = NULL;
     int fd = -1;
@@ -150,6 +151,7 @@ static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     params.verb = VERB_FAILED;
     params.arch = arch;
     params.file = file->localpath;
+    params.noun = _("${FILE} not portable on ${ARCH}");
 
     if ((elf = get_elf_archive(file->fullpath, &fd)) != NULL) {
         /* we found an ELF static library */
@@ -220,6 +222,7 @@ bool inspect_lto(struct rpminspect *ri) {
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_LTO;
         params.severity = RESULT_OK;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -22,9 +22,12 @@
 #include <assert.h>
 #include "rpminspect.h"
 
-static bool movedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
+static bool movedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
+{
     bool rebase = false;
     struct result_params params;
+    const char *arch = NULL;
+    char *noun = NULL;
 
     assert(ri != NULL);
     assert(file != NULL);
@@ -42,27 +45,40 @@ static bool movedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     /* determine if this is a rebase build */
     rebase = is_rebase(ri);
 
+    /* package architecture */
+    arch = get_rpm_header_arch(file->rpm_header);
+
     init_result_params(&params);
     params.header = NAME_MOVEDFILES;
+    params.file = file->localpath;
+    params.arch = arch;
 
     if (rebase) {
         params.severity = RESULT_INFO;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_OK;
     } else {
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
+        params.verb = VERB_FAILED;
     }
 
-    xasprintf(&params.msg, "%s probably moved to %s on %s\n", file->peer_file->localpath, file->localpath, get_rpm_header_arch(file->rpm_header));
+    xasprintf(&noun, _("%s moved to ${FILE} on ${ARCH}"), file->peer_file->localpath);
+    params.noun = noun;
+
+    xasprintf(&params.msg, _("%s probably moved to %s on %s\n"), file->peer_file->localpath, file->localpath, arch);
     add_result(ri, &params);
+
     free(params.msg);
+    free(noun);
     return false;
 }
 
 /*
  * Main driver for the 'movedfiles' inspection.
  */
-bool inspect_movedfiles(struct rpminspect *ri) {
+bool inspect_movedfiles(struct rpminspect *ri)
+{
     bool result = false;
     struct result_params params;
 
@@ -73,6 +89,7 @@ bool inspect_movedfiles(struct rpminspect *ri) {
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_MOVEDFILES;
+    params.verb = VERB_OK;
 
     if (result) {
         params.severity = RESULT_OK;

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -78,6 +78,8 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         xasprintf(&params.remedy, REMEDY_OWNERSHIP_DEFATTR, ri->fileinfo_filename);
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
+        params.verb = VERB_FAILED;
+        params.noun = _("forbidden owner for ${FILE} on ${ARCH}");
         add_result(ri, &params);
         free(params.msg);
         free(params.remedy);
@@ -90,6 +92,8 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         xasprintf(&params.remedy, REMEDY_OWNERSHIP_DEFATTR, ri->fileinfo_filename);
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
+        params.verb = VERB_FAILED;
+        params.noun = _("forbidden group for ${FILE} on ${ARCH}");
         add_result(ri, &params);
         free(params.msg);
         free(params.remedy);
@@ -107,6 +111,8 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 xasprintf(&params.remedy, REMEDY_OWNERSHIP_BIN_OWNER, ri->fileinfo_filename);
                 params.severity = RESULT_BAD;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
+                params.verb = VERB_FAILED;
+                params.noun = _("invalid owner for ${FILE} on ${ARCH}");
                 add_result(ri, &params);
                 free(params.msg);
                 free(params.remedy);
@@ -141,6 +147,8 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                             xasprintf(&params.msg, _("File %s on %s has CAP_SETUID capability but group `%s` and is world executable"), file->localpath, arch, group);
                             xasprintf(&params.remedy, REMEDY_OWNERSHIP_IXOTH, ri->fileinfo_filename);
                             params.waiverauth = WAIVABLE_BY_SECURITY;
+                            params.verb = VERB_FAILED;
+                            params.noun = _("CAP_SETUID and o+x for ${FILE} on ${ARCH}");
                             add_result(ri, &params);
                             free(params.msg);
                             free(params.remedy);
@@ -155,6 +163,8 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                             xasprintf(&params.msg, _("File %s on %s has CAP_SETUID capability but group `%s` and is group writable"), file->localpath, arch, group);
                             xasprintf(&params.remedy, REMEDY_OWNERSHIP_IWGRP, ri->fileinfo_filename);
                             params.waiverauth = WAIVABLE_BY_SECURITY;
+                            params.verb = VERB_FAILED;
+                            params.noun = _("CAP_SETUID and g+w for ${FILE} on ${ARCH}");
                             add_result(ri, &params);
                             free(params.msg);
                             free(params.remedy);
@@ -166,6 +176,8 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                     xasprintf(&params.remedy, REMEDY_OWNERSHIP_BIN_GROUP, ri->fileinfo_filename);
                     params.severity = RESULT_BAD;
                     params.waiverauth = WAIVABLE_BY_ANYONE;
+                    params.verb = VERB_FAILED;
+                    params.noun = _("invalid group for ${FILE} on ${ARCH}");
                     add_result(ri, &params);
                     free(params.msg);
                     free(params.remedy);
@@ -212,6 +224,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, "%s:%s", owner, group);
             params.severity = RESULT_VERIFY;
             params.waiverauth = WAIVABLE_BY_ANYONE;
+            params.verb = VERB_FAILED;
 
             if (bin &&
                 ((!strcmp(owner, ri->bin_owner) && !strcmp(what, "owner")) ||
@@ -223,11 +236,13 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                  */
                 params.severity = RESULT_INFO;
                 params.waiverauth = NOT_WAIVABLE;
+                params.verb = VERB_OK;
             }
 
             free(params.msg);
             xasprintf(&params.msg, _("File %s changed %s from `%s` to `%s` on %s"), file->localpath, what, before_val, after_val, arch);
             xasprintf(&params.remedy, REMEDY_OWNERSHIP_CHANGED, ri->fileinfo_filename);
+            params.noun = _("${FILE} changed owner on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
             free(params.remedy);
@@ -261,6 +276,7 @@ bool inspect_ownership(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_OWNERSHIP;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -33,6 +33,7 @@ static bool pathmigration_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     string_entry_t *entry = NULL;
     char *old = NULL;
     const char *arch = NULL;
+    char *noun = NULL;
     struct result_params params;
 
     /* Ignore files in the SRPM */
@@ -74,6 +75,8 @@ static bool pathmigration_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_PATHMIGRATION;
     params.remedy = REMEDY_PATHMIGRATION;
+    params.verb = VERB_FAILED;
+    params.file = file->localpath;
     params.arch = arch;
 
     /* Check for each path migration, break early if we find a match */
@@ -91,10 +94,12 @@ static bool pathmigration_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         /* Check to see if we found a path that should be migrated */
         if (strprefix(file->localpath, old)) {
-            xasprintf(&params.msg, "File %s found should be in %s on %s", file->localpath, hentry->value, arch);
-            params.file = file->localpath;
+            xasprintf(&params.msg, _("File %s found should be in %s on %s"), file->localpath, hentry->value, arch);
+            xasprintf(&noun, _("${FILE} should be in %s on ${ARCH}"), hentry->value);
+            params.noun = noun;
             add_result(ri, &params);
             free(params.msg);
+            free(noun);
             result = false;
         }
 
@@ -127,6 +132,7 @@ bool inspect_pathmigration(struct rpminspect *ri) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_PATHMIGRATION;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -92,6 +92,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.header = NAME_REMOVEDFILES;
     params.arch = arch;
     params.file = file->localpath;
+    params.noun = _("library ${FILE} removed on ${ARCH}");
 
     /* Set the waiver type if this is a file of security concern */
     if (ri->security_path_prefix) {
@@ -102,6 +103,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             if (strprefix(entry->data, file->localpath)) {
                 params.waiverauth = WAIVABLE_BY_SECURITY;
+                params.verb = VERB_FAILED;
                 break;
             }
         }
@@ -114,10 +116,12 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (rebase) {
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
+            params.verb = VERB_OK;
         } else {
             params.severity = get_secrule_result_severity(ri, file, SECRULE_SECURITYPATH);
             params.waiverauth = WAIVABLE_BY_ANYONE;
             params.remedy = REMEDY_REMOVEDFILES;
+            params.verb = VERB_FAILED;
         }
 
         if (is_elf(file->fullpath) && !strcmp(type, "application/x-pie-executable")) {
@@ -125,6 +129,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             if (soname) {
                 xasprintf(&params.msg, _("ABI break: Library %s with SONAME '%s' removed from %s"), file->localpath, soname, arch);
+                params.noun = _("missing SONAME in ${FILE} on ${ARCH}");
                 free(soname);
             } else {
                 xasprintf(&params.msg, _("ABI break: Library %s removed from %s"), file->localpath, arch);
@@ -194,6 +199,7 @@ bool inspect_removedfiles(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_REMOVEDFILES;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -213,7 +213,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
             if (!valid) {
                 xasprintf(&params.msg, _("%s has an invalid-looking %s on %s: %s"), file->localpath, symbol, arch, entry->data);
                 params.verb = VERB_FAILED;
-                params.noun = _("runtime search path in ${FILE}");
+                params.noun = _("runtime search path in ${FILE} on ${ARCH}");
                 add_result(ri, &params);
                 free(params.msg);
                 r = false;
@@ -288,8 +288,9 @@ static bool runpath_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.waiverauth = NOT_WAIVABLE;
         params.remedy = REMEDY_RUNPATH_BOTH;
         params.file = file->localpath;
+        params.arch = arch;
         params.verb = VERB_FAILED;
-        params.noun = _("both DT_RPATH and DT_RUNPATH in ${FILE}");
+        params.noun = _("both DT_RPATH and DT_RUNPATH in ${FILE} on ${ARCH}");
 
         xasprintf(&params.msg, _("%s has both DT_RPATH and DT_RUNPATH on %s; this is not allowed"), file->localpath, arch);
         add_result(ri, &params);
@@ -323,7 +324,8 @@ cleanup:
 /*
  * Main driver for the runpath inspection.
  */
-bool inspect_runpath(struct rpminspect *ri) {
+bool inspect_runpath(struct rpminspect *ri)
+{
     bool result;
     struct result_params params;
 
@@ -338,6 +340,7 @@ bool inspect_runpath(struct rpminspect *ri) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_RUNPATH;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -135,6 +135,8 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.header = NAME_SHELLSYNTAX;
     params.arch = arch;
     params.file = file->localpath;
+    params.verb = VERB_FAILED;
+    params.noun = _("invalid shell script ${FILE} on ${ARCH}");
 
     if (file->peer_file) {
         before_shell = get_shell(ri, file->peer_file->fullpath);
@@ -150,6 +152,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
             params.remedy = REMEDY_SHELLSYNTAX_GAINED_SHELL;
+            params.verb = VERB_OK;
             add_result(ri, &params);
             free(params.msg);
         }
@@ -198,6 +201,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.waiverauth = NOT_WAIVABLE;
             params.details = before_errors;
             params.remedy = NULL;
+            params.verb = VERB_OK;
             add_result(ri, &params);
             free(params.msg);
         } else if ((before_exitcode || before_errors) && (exitcode || errors)) {
@@ -217,6 +221,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.waiverauth = NOT_WAIVABLE;
             params.details = NULL;
             params.remedy = NULL;
+            params.verb = VERB_OK;
             add_result(ri, &params);
             free(params.msg);
         } else if (exitcode || errors) {
@@ -239,7 +244,8 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 /*
  * Main driver for the 'shellsyntax' inspection.
  */
-bool inspect_shellsyntax(struct rpminspect *ri) {
+bool inspect_shellsyntax(struct rpminspect *ri)
+{
     bool result;
     struct result_params params;
 
@@ -252,6 +258,7 @@ bool inspect_shellsyntax(struct rpminspect *ri) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_SHELLSYNTAX;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_specname.c
+++ b/lib/inspect_specname.c
@@ -29,7 +29,8 @@
 static bool specgood = false;
 static bool seen = false;
 
-static bool specname_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
+static bool specname_driver(struct rpminspect *ri, rpmfile_entry_t *file)
+{
     char *specfile = NULL;
     char *dot = NULL;
     char *desc = NULL;
@@ -79,6 +80,8 @@ static bool specname_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
         params.header = NAME_SPECNAME;
         params.remedy = REMEDY_SPECNAME;
         params.file = file->localpath;
+        params.verb = VERB_FAILED;
+        params.noun = _("unexpected spec filename");
 
         if (ri->specmatch == MATCH_FULL) {
             desc = _("exactly match");
@@ -102,7 +105,8 @@ static bool specname_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
 /*
  * Main driver for the 'specname' inspection.
  */
-bool inspect_specname(struct rpminspect *ri) {
+bool inspect_specname(struct rpminspect *ri)
+{
     struct result_params params;
 
     assert(ri != NULL);
@@ -111,6 +115,7 @@ bool inspect_specname(struct rpminspect *ri) {
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_SPECNAME;
+    params.verb = VERB_OK;
 
     if (specgood) {
         params.severity = RESULT_OK;

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -75,7 +75,7 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.arch = arch;
         params.file = file->localpath;
         params.verb = VERB_CHANGED;
-        params.noun = _("${FILE} MIME type");
+        params.noun = _("${FILE} MIME type on ${ARCH}");
         xasprintf(&params.msg, _("MIME type on %s was %s and became %s on %s"), file->localpath, bt, at, arch);
         add_result(ri, &params);
         free(params.msg);
@@ -89,7 +89,8 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 /*
  * Main driver for the 'types' inspection.
  */
-bool inspect_types(struct rpminspect *ri) {
+bool inspect_types(struct rpminspect *ri)
+{
     struct result_params params;
 
     assert(ri != NULL);
@@ -103,6 +104,7 @@ bool inspect_types(struct rpminspect *ri) {
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_TYPES;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -71,11 +71,12 @@ static bool upstream_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Compare digests of source archive */
     params.file = file->localpath;
+    params.arch = NULL;
 
     if (file->peer_file == NULL) {
         xasprintf(&params.msg, _("New upstream source file `%s` appeared"), params.file)
         params.verb = VERB_ADDED;
-        params.noun = _("source file ${FILE}");
+        params.noun = _("new source file ${FILE}");
         add_result(ri, &params);
         result = !(params.severity >= RESULT_VERIFY);
         reported = true;
@@ -149,6 +150,7 @@ bool inspect_upstream(struct rpminspect *ri)
     if (!have_source) {
         params.severity = RESULT_INFO;
         params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_OK;
         xasprintf(&params.msg, _("No source packages available, skipping inspection."));
         add_result(ri, &params);
         free(params.msg);
@@ -194,6 +196,8 @@ bool inspect_upstream(struct rpminspect *ri)
         if (removed != NULL && !TAILQ_EMPTY(removed)) {
             TAILQ_FOREACH(entry, removed, items) {
                 xasprintf(&params.msg, _("Source file `%s` removed"), entry->data);
+                params.verb = VERB_REMOVED;
+                params.noun = _("source file ${FILE} removed");
                 add_result(ri, &params);
                 free(params.msg);
                 result = !(params.severity >= RESULT_VERIFY);
@@ -211,6 +215,7 @@ bool inspect_upstream(struct rpminspect *ri)
         params.severity = RESULT_OK;
         params.waiverauth = NOT_WAIVABLE;
         params.msg = NULL;
+        params.verb = VERB_OK;
         free(params.remedy);
         params.remedy = NULL;
         add_result(ri, &params);

--- a/lib/output_summary.c
+++ b/lib/output_summary.c
@@ -55,7 +55,7 @@ void output_summary(const results_t *results, const char *dest, __attribute__((u
     /* output the results */
     TAILQ_FOREACH(result, results, items) {
         /* skip conditions */
-        if (!strcmp(result->header, NAME_DIAGNOSTICS)) {
+        if (!strcmp(result->header, NAME_DIAGNOSTICS) || (result->verb == VERB_OK && result->noun == NULL)) {
             continue;
         }
 


### PR DESCRIPTION
This is a final set of updates to librpminspect to support the
'summary' output mode.  There may need to be updates to the messages
it displays and such, but those can be addressed case-by-case.

Fixes: #26

Signed-off-by: David Cantrell <dcantrell@redhat.com>