### PR TITLE
[fix] Do not incorrectly report added files for single builds

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -283,7 +283,7 @@ char **build_argv(const char *cmd);
 void free_argv(char **argv);
 
 /* fileinfo.c */
-bool match_fileinfo_mode(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *);
+bool match_fileinfo_mode(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *);
 bool match_fileinfo_owner(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *);
 bool match_fileinfo_group(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *);
 caps_filelist_entry_t *get_caps_entry(struct rpminspect *, const char *, const char *);

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -38,11 +38,10 @@
  * @param header The header string to use for results reporting if the
  *               file is found.
  * @param remedy The remedy string to use for results reporting if the
- *               file is found.  Must contain a %s for fname.
- * @param fname The filename of the data package file to update.
+ *               file is found.
  * @return True if the file is on the fileinfo list, false otherwise.
  */
-bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, const char *header, const char *remedy, const char *fname)
+bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, const char *header, const char *remedy)
 {
     fileinfo_entry_t *fientry = NULL;
     mode_t interesting = S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO;
@@ -62,7 +61,7 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
     params.file = file->localpath;
 
     if (remedy) {
-        xasprintf(&params.remedy, remedy, fname);
+        params.remedy = strdup(remedy);
     }
 
     if (init_fileinfo(ri)) {
@@ -85,8 +84,6 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
                         add_result(ri, &params);
                         free(params.msg);
                         free(params.remedy);
-                        params.remedy = NULL;
-
                         return true;
                     }
                 }
@@ -106,7 +103,6 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
             add_result(ri, &params);
             free(params.msg);
             free(params.remedy);
-            params.remedy = NULL;
         }
     }
 

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -67,7 +67,7 @@ static bool permissions_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     mode_diff = before_mode ^ after_mode;
-    allowed = match_fileinfo_mode(ri, file, NAME_PERMISSIONS, NULL, NULL);
+    allowed = match_fileinfo_mode(ri, file, NAME_PERMISSIONS, NULL);
 
     /* if setuid/setgid or new mode is more open */
     if (mode_diff && file->peer_file && !allowed && (ri->tests & INSPECT_PERMISSIONS)) {

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -29,7 +29,8 @@
 /*
  * Initialize a new rpmpeer_t list.
  */
-rpmpeer_t *init_rpmpeer(void) {
+rpmpeer_t *init_rpmpeer(void)
+{
     rpmpeer_t *peers = NULL;
 
     peers = calloc(1, sizeof(*(peers)));
@@ -41,7 +42,8 @@ rpmpeer_t *init_rpmpeer(void) {
 /*
  * Free memory associated with an rpmpeer_t list.
  */
-void free_rpmpeer(rpmpeer_t *peers) {
+void free_rpmpeer(rpmpeer_t *peers)
+{
     rpmpeer_entry_t *entry = NULL;
 
     if (peers == NULL) {


### PR DESCRIPTION
The addedfiles inspection runs for single builds or build comparisons.
The actual added files check only makes sense when comparing builds,
but the inspection runs in both conditions to check for security
related things.  This patch makes sure the addedfiles inspection does
not incorrectly report that every file in every package was added when
just running rpminspect on a single build.

Signed-off-by: David Cantrell <dcantrell@redhat.com>