### PR TITLE
[cmd] Exit with code 3 if the named profile (-p) is not found

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -99,7 +99,8 @@ extern volatile sig_atomic_t terminal_resized;
 enum {
     RI_INSPECTION_SUCCESS = 0,   /* inspections passed */
     RI_INSPECTION_FAILURE = 1,   /* inspections failed */
-    RI_PROGRAM_ERROR = 2         /* program errored in some way */
+    RI_PROGRAM_ERROR = 2,        /* program errored in some way */
+    RI_MISSING_PROFILE = 3       /* specified profile not found */
 };
 
 /*

--- a/lib/init.c
+++ b/lib/init.c
@@ -2069,7 +2069,7 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         i = read_cfgfile(ri, cfg->data);
 
         if (i) {
-            warn(_("*** error reading '%s'\n"), cfg->data);
+            warn(_("*** error reading '%s'"), cfg->data);
             free(cfg->data);
             free(cfg);
             return NULL;
@@ -2085,12 +2085,12 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         filename = realpath(tmp, NULL);
 
         if ((filename == NULL) || (access(filename, F_OK|R_OK) == -1)) {
-            warn(_("*** unable to read profile '%s' from %s\n"), profile, filename);
+            errx(RI_MISSING_PROFILE, _("*** unable to find profile '%s'"), profile);
         } else {
             i = read_cfgfile(ri, filename);
 
             if (i) {
-                warn(_("*** error reading '%s'\n"), filename);
+                warn(_("*** error reading '%s'"), filename);
                 return NULL;
             }
         }

--- a/src/rpminspect.1
+++ b/src/rpminspect.1
@@ -273,7 +273,8 @@ what was found.  Descriptions of actions developers can take are provided in
 the findings.
 .SH EXIT STATUS
 rpminspect exits 0 if all inspections pass, 1 if at least one
-inspection did not pass, or 2 if a program error occurred.
+inspection did not pass.  rpminspect exits 3 if the specified profile
+is not found, and 2 if any other program error occurred.
 .SH BUGS
 Please report bugs at https://github.com/rpminspect/rpminspect using
 the Issues tab.


### PR DESCRIPTION
If the user passes "-p PROFILE" to the rpminspect and that profile is
not found, display an error message and exit with code 3.  This is a
new exit code specifically to indicate a missing profile.

Fixes: #590

Signed-off-by: David Cantrell <dcantrell@redhat.com>