### PR TITLE
[lib] Drop use_ignore parameter from foreach_peer_file()

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -478,6 +478,13 @@ specname:
     primary: name
     #primary: filename
 
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/lib*/libexample.so*
+
 annocheck:
     # annocheck(1) tests to run.  The left side of the colon is the
     # test name you want to use and the right side are the arguments
@@ -539,6 +546,14 @@ pathmigration:
     excluded_paths:
         - /lib/modules
 
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/lib*/libexample.so*
+
+politics:
     # Optional list of glob(7) specifications to match files to ignore
     # for this inspection.  The format of this list is the same as the
     # global 'ignore' list.  The difference is the items specified
@@ -824,3 +839,11 @@ rpmdeps:
     # Only one regexp can be expressed for each dependency type.
     # Additional listings will overwrite previous definitions in the
     # runtime configuration.
+
+virus:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/lib*/libexample.so*

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -68,11 +68,9 @@
  * @param ri Pointer to the struct rpminspect used for the program.
  * @param inspection Name of the currently running inspection.
  * @param callback Callback function to iterate over each file.
- * @param use_ignore True to skip files that match entries in the
- *        ignore section of the configuration file, false otherwise.
  * @return True if the check_fn passed for each file, false otherwise.
  */
-bool foreach_peer_file(struct rpminspect *ri, const char *inspection, foreach_peer_file_func check_fn, bool use_ignore);
+bool foreach_peer_file(struct rpminspect *ri, const char *inspection, foreach_peer_file_func check_fn);
 
 /**
  * @brief Return inspection ID given its name string.

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -107,11 +107,9 @@ struct inspect inspections[] = {
  * @param ri Pointer to the struct rpminspect used for the program.
  * @param inspection Name of currently running inspection.
  * @param callback Callback function to iterate over each file.
- * @param use_ignore True to skip files that match entries in the
- *        ignore section of the configuration file, false otherwise.
  * @return True if the check_fn passed for each file, false otherwise.
  */
-bool foreach_peer_file(struct rpminspect *ri, const char *inspection, foreach_peer_file_func check_fn, bool use_ignore)
+bool foreach_peer_file(struct rpminspect *ri, const char *inspection, foreach_peer_file_func check_fn)
 {
     rpmpeer_entry_t *peer;
     rpmfile_entry_t *file;
@@ -128,7 +126,7 @@ bool foreach_peer_file(struct rpminspect *ri, const char *inspection, foreach_pe
 
         TAILQ_FOREACH(file, peer->after_files, items) {
             /* Ignore files we should be ignoring */
-            if (use_ignore && ignore_path(ri, inspection, file->localpath, peer->after_root)) {
+            if (ignore_path(ri, inspection, file->localpath, peer->after_root)) {
                 continue;
             }
 

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -297,7 +297,7 @@ bool inspect_abidiff(struct rpminspect *ri)
     }
 
     /* run the main inspection */
-    result = foreach_peer_file(ri, NAME_ABIDIFF, abidiff_driver, true);
+    result = foreach_peer_file(ri, NAME_ABIDIFF, abidiff_driver);
 
     /* clean up */
     free_abi(abi);

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -216,7 +216,7 @@ bool inspect_addedfiles(struct rpminspect *ri)
 
     xasprintf(&remedy_addedfiles, REMEDY_ADDEDFILES, ri->fileinfo_filename ? _("the fileinfo list") : ri->fileinfo_filename);
     assert(remedy_addedfiles != NULL);
-    result = foreach_peer_file(ri, NAME_ADDEDFILES, addedfiles_driver, false);
+    result = foreach_peer_file(ri, NAME_ADDEDFILES, addedfiles_driver);
     free(remedy_addedfiles);
 
     if (result) {

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -230,7 +230,7 @@ bool inspect_annocheck(struct rpminspect *ri)
     }
 
     /* run the annocheck tests across all ELF files */
-    result = foreach_peer_file(ri, NAME_ANNOCHECK, annocheck_driver, true);
+    result = foreach_peer_file(ri, NAME_ANNOCHECK, annocheck_driver);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -169,7 +169,7 @@ bool inspect_badfuncs(struct rpminspect *ri)
 
     if (ri->bad_functions != NULL) {
         init_elf_data(ri);
-        result = foreach_peer_file(ri, NAME_BADFUNCS, badfuncs_driver, true);
+        result = foreach_peer_file(ri, NAME_BADFUNCS, badfuncs_driver);
     }
 
     if (result) {

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -195,7 +195,7 @@ bool inspect_capabilities(struct rpminspect *ri)
     assert(ri != NULL);
 
     /* run the capabilities inspection across all RPM files */
-    result = foreach_peer_file(ri, NAME_CAPABILITIES, capabilities_driver, true);
+    result = foreach_peer_file(ri, NAME_CAPABILITIES, capabilities_driver);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -481,7 +481,7 @@ bool inspect_changedfiles(struct rpminspect *ri)
     bool result;
     struct result_params params;
 
-    result = foreach_peer_file(ri, NAME_CHANGEDFILES, changedfiles_driver, true);
+    result = foreach_peer_file(ri, NAME_CHANGEDFILES, changedfiles_driver);
 
     if (result && !reported) {
         init_result_params(&params);

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -207,7 +207,7 @@ bool inspect_config(struct rpminspect *ri)
 
     assert(ri != NULL);
 
-    result = foreach_peer_file(ri, NAME_CONFIG, config_driver, true);
+    result = foreach_peer_file(ri, NAME_CONFIG, config_driver);
 
     if (result && !reported) {
         init_result_params(&params);

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -500,7 +500,7 @@ bool inspect_desktop(struct rpminspect *ri)
      * them.  The before and after peers are compared for these files.
      * For the after files, the Exec and Icon references are checked.
      */
-    result = foreach_peer_file(ri, NAME_DESKTOP, desktop_driver, true);
+    result = foreach_peer_file(ri, NAME_DESKTOP, desktop_driver);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -145,7 +145,7 @@ bool inspect_doc(struct rpminspect *ri)
 
     assert(ri != NULL);
 
-    result = foreach_peer_file(ri, NAME_DOC, doc_driver, true);
+    result = foreach_peer_file(ri, NAME_DOC, doc_driver);
 
     if (result && !reported) {
         init_result_params(&params);

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -226,7 +226,7 @@ bool inspect_dsodeps(struct rpminspect *ri)
     assert(ri != NULL);
 
     /* run the dsodeps test across all ELF files */
-    result = foreach_peer_file(ri, NAME_DSODEPS, dsodeps_driver, true);
+    result = foreach_peer_file(ri, NAME_DSODEPS, dsodeps_driver);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -1110,7 +1110,7 @@ bool inspect_elf(struct rpminspect *ri)
 
     init_elf_data(ri);
     rip = ri;
-    result = foreach_peer_file(ri, NAME_ELF, elf_driver, true);
+    result = foreach_peer_file(ri, NAME_ELF, elf_driver);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -142,7 +142,7 @@ bool inspect_filesize(struct rpminspect *ri)
     assert(ri != NULL);
 
     /* run the size inspection across all RPM files */
-    result = foreach_peer_file(ri, NAME_FILESIZE, filesize_driver, true);
+    result = foreach_peer_file(ri, NAME_FILESIZE, filesize_driver);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -309,7 +309,7 @@ bool inspect_kmod(struct rpminspect *ri)
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_KMOD;
     params.verb = VERB_OK;
-    result = foreach_peer_file(ri, NAME_KMOD, kmod_driver, true);
+    result = foreach_peer_file(ri, NAME_KMOD, kmod_driver);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -214,7 +214,7 @@ bool inspect_lto(struct rpminspect *ri) {
 
     if (ri->lto_symbol_name_prefixes != NULL) {
         lto_symbol_name_prefixes = ri->lto_symbol_name_prefixes;
-        result = foreach_peer_file(ri, NAME_LTO, lto_driver, true);
+        result = foreach_peer_file(ri, NAME_LTO, lto_driver);
     }
 
     if (result) {

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -358,7 +358,7 @@ bool inspect_manpage(struct rpminspect *ri)
     struct result_params params;
 
     inspect_manpage_alloc();
-    result = foreach_peer_file(ri, NAME_MANPAGE, manpage_driver, true);
+    result = foreach_peer_file(ri, NAME_MANPAGE, manpage_driver);
     inspect_manpage_free();
 
     if (result) {

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -87,7 +87,7 @@ bool inspect_modularity(struct rpminspect *ri) {
         return true;
     }
 
-    result = foreach_peer_file(ri, NAME_MODULARITY, modularity_driver, true);
+    result = foreach_peer_file(ri, NAME_MODULARITY, modularity_driver);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -84,7 +84,7 @@ bool inspect_movedfiles(struct rpminspect *ri)
 
     assert(ri != NULL);
 
-    result = foreach_peer_file(ri, NAME_MOVEDFILES, movedfiles_driver, true);
+    result = foreach_peer_file(ri, NAME_MOVEDFILES, movedfiles_driver);
 
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -272,7 +272,7 @@ bool inspect_ownership(struct rpminspect *ri)
     struct result_params params;
 
     assert(ri != NULL);
-    result = foreach_peer_file(ri, NAME_OWNERSHIP, ownership_driver, true);
+    result = foreach_peer_file(ri, NAME_OWNERSHIP, ownership_driver);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -124,7 +124,7 @@ bool inspect_pathmigration(struct rpminspect *ri) {
 
     /* Only run the inspection if path migrations are specified */
     if (ri->pathmigration) {
-        result = foreach_peer_file(ri, NAME_PATHMIGRATION, pathmigration_driver, true);
+        result = foreach_peer_file(ri, NAME_PATHMIGRATION, pathmigration_driver);
     }
 
     if (result) {

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -122,7 +122,7 @@ bool inspect_permissions(struct rpminspect *ri)
     assert(ri != NULL);
 
     /* run the permissions inspection across all RPM files */
-    result = foreach_peer_file(ri, NAME_PERMISSIONS, permissions_driver, true);
+    result = foreach_peer_file(ri, NAME_PERMISSIONS, permissions_driver);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -173,7 +173,7 @@ bool inspect_politics(struct rpminspect *ri)
 
     /* run the politics check on each file */
     if (init_politics(ri)) {
-        result = foreach_peer_file(ri, NAME_POLITICS, politics_driver, false);
+        result = foreach_peer_file(ri, NAME_POLITICS, politics_driver);
     }
 
     /* hope the result is always this */

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -332,7 +332,7 @@ bool inspect_runpath(struct rpminspect *ri)
     assert(ri != NULL);
 
     /* run the runpath test across all ELF files */
-    result = foreach_peer_file(ri, NAME_RUNPATH, runpath_driver, true);
+    result = foreach_peer_file(ri, NAME_RUNPATH, runpath_driver);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -262,7 +262,7 @@ bool inspect_shellsyntax(struct rpminspect *ri)
 
     assert(ri != NULL);
 
-    result = foreach_peer_file(ri, NAME_SHELLSYNTAX, shellsyntax_driver, true);
+    result = foreach_peer_file(ri, NAME_SHELLSYNTAX, shellsyntax_driver);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_specname.c
+++ b/lib/inspect_specname.c
@@ -110,7 +110,7 @@ bool inspect_specname(struct rpminspect *ri)
     struct result_params params;
 
     assert(ri != NULL);
-    foreach_peer_file(ri, NAME_SPECNAME, specname_driver, false);
+    foreach_peer_file(ri, NAME_SPECNAME, specname_driver);
 
     init_result_params(&params);
     params.waiverauth = NOT_WAIVABLE;

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -330,7 +330,7 @@ bool inspect_symlinks(struct rpminspect *ri)
     struct result_params params;
 
     assert(ri != NULL);
-    result = foreach_peer_file(ri, NAME_SYMLINKS, symlinks_driver, true);
+    result = foreach_peer_file(ri, NAME_SYMLINKS, symlinks_driver);
 
     if (result) {
         init_result_params(&params);

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -96,7 +96,7 @@ bool inspect_types(struct rpminspect *ri)
     assert(ri != NULL);
 
     /* run the types inspection across all RPM files */
-    foreach_peer_file(ri, NAME_TYPES, types_driver, true);
+    foreach_peer_file(ri, NAME_TYPES, types_driver);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -637,7 +637,7 @@ bool inspect_unicode(struct rpminspect *ri)
         globalri = ri;
 
         /* run the inspection */
-        result = foreach_peer_file(ri, NAME_UNICODE, unicode_driver, false);
+        result = foreach_peer_file(ri, NAME_UNICODE, unicode_driver);
 
         /* free the forbidden list memory */
         while (!TAILQ_EMPTY(forbidden)) {

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -195,7 +195,7 @@ bool inspect_virus(struct rpminspect *ri)
     params.header = NAME_VIRUS;
     params.verb = VERB_FAILED;
     params.noun = _("virus or malware in ${FILE} on ${ARCH}");
-    result = foreach_peer_file(ri, NAME_VIRUS, virus_driver, false);
+    result = foreach_peer_file(ri, NAME_VIRUS, virus_driver);
 
     /* hope the result is always this */
     if (result) {

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -228,7 +228,7 @@ bool inspect_xml(struct rpminspect *ri)
     struct result_params params;
 
     assert(ri != NULL);
-    result = foreach_peer_file(ri, NAME_XML, xml_driver, true);
+    result = foreach_peer_file(ri, NAME_XML, xml_driver);
 
     if (result) {
         init_result_params(&params);


### PR DESCRIPTION
This was an idea I had when I first implemented the per-inspection
ignore lists.  I thought we should have the ability to make some
inspection impenetrable to a per-inspection ignore list.  An
inspection so important that it can never be ignored.  Five
inspections carried this classification.  Over time I've come to the
conclusion that this functionality is not really needed and only adds
confusion.  This patch removes that functionality and every inspection
can now have a per-inspection ignore list.

Fixes: #604

Signed-off-by: David Cantrell <dcantrell@redhat.com>