### PR TITLE
[fix] Remove unnecessary free() calls in librpminspect and rpminspect

### DIFF
--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -489,7 +489,6 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
 
                 if (errno == ENOMEM) {
                     warn("realloc");
-                    free(line);
                 }
 
                 line = line_new;

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -93,7 +93,6 @@ static char *match_product(string_map_t *products, const char *candidate)
 {
     char *ret = NULL;
     bool matched = false;
-    char *needle = NULL;
     string_map_t *hentry = NULL;
     string_map_t *tmp_hentry = NULL;
     regex_t product_regex;
@@ -115,14 +114,12 @@ static char *match_product(string_map_t *products, const char *candidate)
         if (result != 0) {
             regerror(result, &product_regex, reg_error, sizeof(reg_error));
             warnx(_("*** unable to compile product release regular expression: %s"), reg_error);
-            free(needle);
             return NULL;
         }
 
         /* now try to match the candidate */
         if (regexec(&product_regex, candidate, 1, matches, 0) != 0) {
             regfree(&product_regex);
-            free(needle);
             continue;
         }
 
@@ -134,11 +131,8 @@ static char *match_product(string_map_t *products, const char *candidate)
         regfree(&product_regex);
 
         if (matched) {
-            free(needle);
             break;
         }
-
-        free(needle);
     }
 
     return ret;
@@ -173,7 +167,6 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
      * Get the character after the last occurrence of a period. This should
      * tell us what release flag the product is.
      */
-    //pos += 1;
     after_candidate = strdup(pos);
 
     if (after_candidate == NULL) {
@@ -196,7 +189,6 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
             return NULL;
         }
 
-        //pos += 1;
         before_candidate = strdup(pos);
 
         if (before_candidate == NULL) {


### PR DESCRIPTION
The one in validate_file() in inspect_unicode.c is incorrect.  The
ones in rpminspect.c are part of a prior code path where I was using
strstr(), but I removed all that but still kept all the free() calls
for needle.  Removed.

Signed-off-by: David Cantrell <dcantrell@redhat.com>