### PR TITLE
[fix] Match shared lib Requires correctly & handle multiple Provides

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -483,5 +483,6 @@
  * Filename prefix for shared libraries and library packages.
  */
 #define SHARED_LIB_PREFIX "lib"
+#define SHARED_LIB_SUFFIX ".so"
 
 #endif

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -145,7 +145,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
     /* iterate over the deps of the after build peer */
     TAILQ_FOREACH(req, after_deps, items) {
         /* only looking at lib* Requires right now */
-        if ((req->type != TYPE_REQUIRES) || !strprefix(req->requirement, SHARED_LIB_PREFIX)) {
+        if ((req->type != TYPE_REQUIRES) || !(strprefix(req->requirement, SHARED_LIB_PREFIX) && strstr(req->requirement, SHARED_LIB_SUFFIX))) {
             continue;
         }
 
@@ -167,7 +167,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                 }
 
                 /* only looking at Provides right now */
-                if ((prov->type != TYPE_PROVIDES) || !strprefix(prov->requirement, SHARED_LIB_PREFIX)) {
+                if ((prov->type != TYPE_PROVIDES) || !(strprefix(req->requirement, SHARED_LIB_PREFIX) && strstr(req->requirement, SHARED_LIB_SUFFIX))) {
                     continue;
                 }
 
@@ -178,7 +178,11 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                     /* a package is allowed to to Provide and Require the same thing */
                     /* otherwise we found the subpackage that Provides this explicit Requires */
                     potential_prov = peer;
-                    req->providers = list_add(req->providers, pn);
+
+                    if (!list_contains(req->providers, pn)) {
+                        req->providers = list_add(req->providers, pn);
+                    }
+
                     found = true;
                 } else if (strstr(req->requirement, "(") || strstr(prov->requirement, "(")) {
                     /*
@@ -194,7 +198,11 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
 
                     if (!strcmp(isareq, isaprov)) {
                         potential_prov = peer;
-                        req->providers = list_add(req->providers, pn);
+
+                        if (!list_contains(req->providers, pn)) {
+                            req->providers = list_add(req->providers, pn);
+                        }
+
                         found = true;
                     }
 


### PR DESCRIPTION
Fix two errors in the rpmdeps inspection:

1) Match the automatic shared library Requires correctly by checking
for both the "lib" prefix on the name and the ".so" suffix.

2) Avoid adding a Provide name to the list of providers if we already
have it.  The big problem here was getting duplicates because of the
different architectures.

Signed-off-by: David Cantrell <dcantrell@redhat.com>