### PR TITLE
[cmd] Implement the -s/--suppress option in rpminspect

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -202,7 +202,7 @@ bool strsuffix(const char *, const char *);
 int printwrap(const char *, const size_t, const unsigned int, FILE *);
 bool versioned_match(const char *, Header, const char *, Header);
 char *strseverity(const severity_t);
-severity_t getseverity(const char *);
+severity_t getseverity(const char *, const severity_t);
 char *strwaiverauth(const waiverauth_t);
 char *strreplace(const char *, const char *, const char *);
 char *strxmlescape(const char *);
@@ -248,21 +248,22 @@ results_t *init_results(void);
 void free_results(results_t *);
 void add_result_entry(results_t **, struct result_params *);
 void add_result(struct rpminspect *, struct result_params *);
+bool suppressed_results(const results_t *results, const char *header, const severity_t suppress);
 
 /* output.c */
 const char *format_desc(unsigned int);
 
 /* output_text.c */
-void output_text(const results_t *, const char *, const severity_t);
+void output_text(const results_t *, const char *, const severity_t, const severity_t);
 
 /* output_json.c */
-void output_json(const results_t *, const char *, const severity_t);
+void output_json(const results_t *, const char *, const severity_t, const severity_t);
 
 /* output_xunit.c */
-void output_xunit(const results_t *, const char *, const severity_t);
+void output_xunit(const results_t *, const char *, const severity_t, const severity_t);
 
 /* output_summary.c */
-void output_summary(const results_t *results, const char *dest, const severity_t threshold);
+void output_summary(const results_t *results, const char *dest, const severity_t threshold, const severity_t suppress);
 
 /* unpack.c */
 int unpack_archive(const char *, const char *, const bool);

--- a/include/types.h
+++ b/include/types.h
@@ -643,9 +643,10 @@ struct rpminspect {
     bool rebase_detection;     /* Is rebase detection enabled for
                                   builds? (default true) */
 
-    /* Failure threshold */
+    /* Failure threshold and results suppression threshold */
     severity_t threshold;
     severity_t worst_result;
+    severity_t suppress;
 
     /* The product release we are inspecting against */
     char *product_release;
@@ -684,7 +685,7 @@ struct format {
     char *name;
 
     /* output driver function */
-    void (*driver)(const results_t *, const char *, const severity_t);
+    void (*driver)(const results_t *, const char *, const severity_t, const severity_t);
 };
 
 /*

--- a/lib/init.c
+++ b/lib/init.c
@@ -2117,6 +2117,7 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
     ri->peers = init_rpmpeer();
     ri->threshold = RESULT_VERIFY;
     ri->worst_result = RESULT_OK;
+    ri->suppress = RESULT_NULL;
 
 #if 0
     /* debugging output only to make sure we captured ignores */

--- a/lib/output_json.c
+++ b/lib/output_json.c
@@ -31,7 +31,7 @@
 /*
  * Output a results_t in JSON format.
  */
-void output_json(const results_t *results, const char *dest, __attribute__((unused)) const severity_t threshold)
+void output_json(const results_t *results, const char *dest, __attribute__((unused)) const severity_t threshold, __attribute__((unused)) const severity_t suppress)
 {
     results_entry_t *result = NULL;
     int r = 0;

--- a/lib/output_summary.c
+++ b/lib/output_summary.c
@@ -30,7 +30,7 @@
 /*
  * Output a results_t in summary text format.
  */
-void output_summary(const results_t *results, const char *dest, __attribute__((unused)) const severity_t threshold)
+void output_summary(const results_t *results, const char *dest, __attribute__((unused)) const severity_t threshold, const severity_t suppress)
 {
     results_entry_t *result = NULL;
     int r = 0;
@@ -55,7 +55,9 @@ void output_summary(const results_t *results, const char *dest, __attribute__((u
     /* output the results */
     TAILQ_FOREACH(result, results, items) {
         /* skip conditions */
-        if (!strcmp(result->header, NAME_DIAGNOSTICS) || (result->verb == VERB_OK && result->noun == NULL)) {
+        if (!strcmp(result->header, NAME_DIAGNOSTICS)
+            || (result->verb == VERB_OK && result->noun == NULL)
+            || (result->severity >= suppress)) {
             continue;
         }
 

--- a/lib/output_xunit.c
+++ b/lib/output_xunit.c
@@ -29,7 +29,7 @@
  * Output a results_t in XUnit format.  This can be consumed by Jenkins or
  * other services that can read in XUnit data (e.g., GitHub).
  */
-void output_xunit(const results_t *results, const char *dest, const severity_t threshold)
+void output_xunit(const results_t *results, const char *dest, const severity_t threshold, __attribute__((unused)) const severity_t suppress)
 {
     results_entry_t *result = NULL;
     int r = 0;

--- a/lib/results.c
+++ b/lib/results.c
@@ -164,3 +164,23 @@ void add_result(struct rpminspect *ri, struct result_params *params)
     add_result_entry(&ri->results, params);
     return;
 }
+
+/*
+ * Returns true if all the results for the named inspection are
+ * suppressed.
+ */
+bool suppressed_results(const results_t *results, const char *header, const severity_t suppress)
+{
+    results_entry_t *result = NULL;
+
+    assert(results != NULL);
+    assert(header != NULL);
+
+    TAILQ_FOREACH(result, results, items) {
+        if (!strcmp(header, result->header) && result->severity >= suppress) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -278,8 +278,8 @@ char *strseverity(const severity_t severity) {
  * Given a severity string, return a severity_t matching it.
  * Or return the default.
  */
-severity_t getseverity(const char *name) {
-    severity_t s = RESULT_VERIFY;
+severity_t getseverity(const char *name, const severity_t default_s) {
+    severity_t s = default_s;
 
     if (name == NULL) {
         return s;

--- a/src/rpminspect.1
+++ b/src/rpminspect.1
@@ -170,6 +170,14 @@ to any of the valid result codes.  Available result codes are OK, INFO,
 WAIVED, VERIFY, or BAD.  The argument expects the result threshold specified
 as a string.  Case does not matter.
 .TP
+.B \-s TAG, \-\-suppress=TAG
+Results suppression threshold.  By default all results are reported,
+but you can use this option to suppress results below a reporting
+level.  The values are the same as for the \-t option above.  For
+example, to only show VERIFY and higher results, pass "\-s VERIFY" at
+run time.  This option is not valid on the "json" or "xunit" output
+formats.
+.TP
 .B \-l, \-\-list
 List available output formats and inspections
 .TP


### PR DESCRIPTION
This is a command line option you can use to filter the results
printed out by rpminspect in the 'text' and 'summary' output modes.
'json' and 'xunit' still output everything since those output modes
are intended for processing by other systems.

To only report results at the VERIFY severity or higher, pass "-s
VERIFY" on the command line.  By default you get all results.  If no
inspection has any results at or above the suppression level,
rpminspect will skip it in the output entirely.

This option is only for text output.  The exit code is still the same
and all of the results are still computed anyway.  The intent of this
option is to give users a way to just see what needs attention if they
are iterating over fixes and builds.  Eventually you will get to an
exit code of 0 and no output if using the -s option.

Signed-off-by: David Cantrell <dcantrell@redhat.com>