### PR TITLE
[fix] Handle explicit shared lib deps with %{_isa} notation

### DIFF
--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -145,7 +145,8 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
     /* iterate over the deps of the after build peer */
     TAILQ_FOREACH(req, after_deps, items) {
         /* only looking at lib* Requires right now */
-        if ((req->type != TYPE_REQUIRES) || !(strprefix(req->requirement, SHARED_LIB_PREFIX) && strstr(req->requirement, SHARED_LIB_SUFFIX))) {
+        if ((req->type != TYPE_REQUIRES)
+            || !(strprefix(req->requirement, SHARED_LIB_PREFIX) && strstr(req->requirement, SHARED_LIB_SUFFIX))) {
             continue;
         }
 
@@ -167,7 +168,8 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                 }
 
                 /* only looking at Provides right now */
-                if ((prov->type != TYPE_PROVIDES) || !(strprefix(req->requirement, SHARED_LIB_PREFIX) && strstr(req->requirement, SHARED_LIB_SUFFIX))) {
+                if ((prov->type != TYPE_PROVIDES)
+                    || !(strprefix(req->requirement, SHARED_LIB_PREFIX) && strstr(req->requirement, SHARED_LIB_SUFFIX))) {
                     continue;
                 }
 
@@ -234,12 +236,23 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
 
             TAILQ_FOREACH(verify, after_deps, items) {
                 /* look only at explicit Requires right now */
-                if ((verify->type != TYPE_REQUIRES) || strprefix(verify->requirement, SHARED_LIB_PREFIX)) {
+                if ((verify->type != TYPE_REQUIRES)
+                    || (strprefix(verify->requirement, SHARED_LIB_PREFIX) && strstr(verify->requirement, SHARED_LIB_SUFFIX))) {
                     continue;
                 }
 
-                if (!strcmp(verify->requirement, pn) && verify->operator == OP_EQUAL && !strcmp(verify->version, r)) {
+                /* trim potential %{_isa} suffix */
+                isareq = strdup(verify->requirement);
+                assert(isareq != NULL);
+                isareq[strcspn(isareq, "(")] = '\0';
+
+                if (!strcmp(isareq, pn) && verify->operator == OP_EQUAL && !strcmp(verify->version, r)) {
                     found = true;
+                }
+
+                free(isareq);
+
+                if (found) {
                     break;
                 }
             }


### PR DESCRIPTION
Seen while checking the a52dec package.  If a package carries the
correct explicit subpackage Requires dependency when rpmbuild picked
up an automatic shared library dependency, rpminspect should be ok
with that.  It is, except it was not handling the explicit subpackage
Requires syntax that uses %{_isa}, such as:

    Requires: liba52%{_isa} = %{version}-%{release}

This patch fixes rpmdeps so it handles the above.

Signed-off-by: David Cantrell <dcantrell@redhat.com>