### PR TITLE
[fix] Handle packages that provide automatic shared lib deps

### DIFF
--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -257,6 +257,11 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                 }
             }
 
+            /* could be circular */
+            if (!found && !strcmp(name, pn)) {
+                found = true;
+            }
+
             free(r);
         }
 


### PR DESCRIPTION
If a package generates automatic shared library dependencies but also
provides those dependencies, it does not need an explicit dependency
in the form of "Requires: NAME = VERSION-RELEASE" since it's the same
package.  The explicit dependency requirement is meant for SRPMs that
split the built files across multiple subpackages and ensuring the
entire set remains tied as users upgrade and remove packages.

Signed-off-by: David Cantrell <dcantrell@redhat.com>