### PR TITLE
[lib] Add is_rich_dep() to mark rich dependency strings in deprules

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -166,6 +166,7 @@ typedef struct _deprule_entry_t {
     char *requirement;                     /* dependency requirement name (e.g., glibc or /bin/sh) */
     dep_op_t operator;                     /* dependency operator (e.g., >, >=) */
     char *version;                         /* dependency version */
+    bool rich;                             /* true if this dep is a rich dependency */
     bool need_explicit_deps;               /* true if a subpkg needs to explicit require an NVR */
     string_list_t *providers;              /* for TYPE_REQUIRES, list of subpackages providing it */
     struct _deprule_entry_t *peer_deprule; /* corresponding before/after deprule */

--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -27,6 +27,21 @@
 #include "rpminspect.h"
 
 /*
+ * Given a deprule requirement string, return true if it is a rich
+ * dependency string.  This does what rpmdsIsRich() does in
+ * lib/rpmds.c from rpm, but without first creating a rpmds which we
+ * don't need here.
+ */
+static bool is_rich_dep(const char *requirement)
+{
+    if (requirement && *requirement == '(') {
+        return true;
+    }
+
+    return false;
+}
+
+/*
  * Gather the specific type of deprules and add them to rules.  Return
  * the list.
  */
@@ -141,6 +156,8 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
                 deprule_entry->version = strdup(v);
                 assert(deprule_entry->version != NULL);
             }
+
+            deprule_entry->rich = is_rich_dep(deprule_entry->requirement);
 
             TAILQ_INSERT_TAIL(deprules, deprule_entry, items);
         }

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -714,7 +714,7 @@ bool inspect_rpmdeps(struct rpminspect *ri)
                         params.remedy = REMEDY_RPMDEPS_CHANGED;
                         params.verb = VERB_CHANGED;
 
-                        if (expected_deprule_change(rebase, deprule, peer->after_hdr, ri->peers)) {
+                        if (deprule->rich || expected_deprule_change(rebase, deprule, peer->after_hdr, ri->peers)) {
                             params.severity = RESULT_INFO;
                             params.waiverauth = NOT_WAIVABLE;
                             params.msg = strappend(params.msg, _("; this is expected"), NULL);


### PR DESCRIPTION
Note whether or not a dependency requirement is a rich dependency
string or not.  rpminspect does not parse these, but just reports the
changes for informational purposes.

Signed-off-by: David Cantrell <dcantrell@redhat.com>