### PR TITLE
[lib] Use libxdiff instead of relying on /usr/bin/diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ meson and ninja, plus the following libraries:
 | [curl](https://curl.se/) | :heavy_check_mark: | | [MIT](https://spdx.org/licenses/MIT.html) |
 | [ClamAV](https://www.clamav.net/) | :heavy_check_mark: | | [GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html) |
 | [gettext](https://www.gnu.org/software/gettext/) | | .po to .mo | [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later.html) |
+| [libxdiff](https://github.com/spotrh/libxdiff) | :heavy_check_mark: | | [LGPL-2.1-or-later](https://spdx.org/licenses/LGPL-2.1-or-later.html) |
 
 Additionally, the unit test suite requires the following packages:
 
@@ -146,10 +147,10 @@ there are a number of userspace programs used:
 
     /usr/bin/desktop-file-validate [optional]
     /usr/bin/msgunfmt
-    /usr/bin/diff
     /usr/bin/abidiff [optional]
     /usr/bin/kmidiff [optional]
     /usr/bin/annocheck [optional]
+    /usr/bin/diffstat
 
 The provided spec file template uses the Fedora locations for these
 files, but in the program, they must be on the runtime system.
@@ -160,7 +161,7 @@ packages.
 In Fedora, for example, you can run the following to install these
 programs:
 
-    yum install desktop-file-utils gettext diffutils libabigail /usr/bin/annocheck
+    yum install desktop-file-utils gettext diffstat libabigail /usr/bin/annocheck
 
 The 'shellsyntax' inspection uses the actual shell programs listed in
 the shells setting in the rpminspect configuration file.  Since this

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -64,13 +64,13 @@ there are a number of userspace programs used:
 +--------------------------------+-----------+---------------------------------------------------------------+
 | /usr/bin/msgunfmt              | **Yes**   | https://www.gnu.org/software/gettext/                         |
 +--------------------------------+-----------+---------------------------------------------------------------+
-| /usr/bin/diff                  | **Yes**   | https://www.gnu.org/software/diffutils/                       |
-+--------------------------------+-----------+---------------------------------------------------------------+
 | /usr/bin/abidiff               | No        | https://sourceware.org/libabigail/                            |
 +--------------------------------+-----------+---------------------------------------------------------------+
 | /usr/bin/kmidiff               | No        | https://sourceware.org/libabigail/                            |
 +--------------------------------+-----------+---------------------------------------------------------------+
 | /usr/bin/annocheck             | No        | https://sourceware.org/git/annobin.git                        |
++--------------------------------+-----------+---------------------------------------------------------------+
+| /usr/bin/diffstat              | No        | https://invisible-island.net/diffstat/                        |
 +--------------------------------+-----------+---------------------------------------------------------------+
 
 The provided RPM_ spec file template uses the `Fedora Linux
@@ -82,7 +82,7 @@ tools. If they are available, you should use those packages.
 In `Fedora Linux <https://getfedora.org>`_, for example, you can run
 the following to install these programs::
 
-    dnf install desktop-file-utils gettext diffutils libabigail /usr/bin/annocheck
+    dnf install desktop-file-utils gettext diffstat libabigail /usr/bin/annocheck
 
 The *shellsyntax* inspection uses the actual shell programs listed in
 the shells setting in the rpminspect_ configuration file.  Since this

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -444,10 +444,9 @@ run when in comparison mode.
     suspected security impact). Any gzip, bzip2, or xz compressed
     files will have their uncompressed content compared only, which
     will allow changes through in the compression level used. Message
-    catalog files (.mo) are unpacked and compared using
-    diff(1). Public C and C++ header files are preprocessed and
-    compared using diff(1). Any changes with diff output are included
-    in the results.
+    catalog files (.mo) are unpacked and compared.  Public C and C++
+    header files are preprocessed and compared. Any changes with
+    unified diff output are included in the results.
 
 - **movedfiles**
 

--- a/include/constants.h
+++ b/include/constants.h
@@ -178,13 +178,6 @@
 #define MSGUNFMT_CMD "msgunfmt"
 
 /**
- * @def DIFF_CMD
- * Executable providing diff(1).  NOTE: This should be GNU diff or
- * 100% compatible.
- */
-#define DIFF_CMD "diff"
-
-/**
  * @def DIFFSTAT_CMD
  * Executable providing diffstat(1).
  */

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -436,4 +436,7 @@ const char *get_deprule_operator_desc(const dep_op_t operator);
 bool deprules_match(const deprule_entry_t *a, const deprule_entry_t *b);
 char *strdeprule(const deprule_entry_t *deprule);
 
+/* delta.c */
+char *get_file_delta(const char *a, const char *b);
+
 #endif

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -129,10 +129,6 @@ void dump_cfg(const struct rpminspect *ri)
 
     printf("commands:\n");
 
-    if (ri->commands.diff) {
-        printf("    diff: %s\n", ri->commands.diff);
-    }
-
     if (ri->commands.diffstat) {
         printf("    diffstat: %s\n", ri->commands.diffstat);
     }

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2022 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <xdiff.h>
+#include "rpminspect.h"
+
+static string_list_t *list = NULL;
+
+static int fill_mmfile(mmfile_t *mf, const char *file)
+{
+    int fd;
+    struct stat sb;
+    char *buf = NULL;
+    unsigned long size;
+    int retval;
+
+    mf->ptr = NULL;
+    mf->size = 0;
+    fd = open(file, O_RDONLY);
+
+    if (fd < 0) {
+        return 0;
+    }
+
+    if (stat(file, &sb)) {
+        warn("stat");
+        return 1;
+    }
+
+    size = sb.st_size;
+    buf = (char *) malloc(size);
+
+    if (buf == NULL) {
+        warn("malloc");
+        return 1;
+    }
+
+    mf->ptr = buf;
+    mf->ptr[size - 1] = '\0';
+    mf->size = size;
+
+    while (size) {
+        retval = read(fd, buf, size);
+
+        if (retval < 0) {
+            if (errno = EINTR || errno == EAGAIN) {
+                continue;
+            }
+
+            break;
+        }
+
+        if (!retval) {
+            break;
+        }
+
+        buf += retval;
+        size -= retval;
+    }
+
+    mf->size -= size;
+
+    if (close(fd) < 0) {
+        warn("close");
+    }
+
+    return 0;
+}
+
+static int delta_out(__attribute__((unused)) void *priv, mmbuffer_t *mb, int nbuf)
+{
+    int i;
+    string_entry_t *entry = NULL;
+
+    for (i = 0; i < nbuf; i++) {
+        entry = calloc(1, sizeof(*entry));
+        assert(entry != NULL);
+
+        entry->data = calloc(1, mb[i].size + 1);
+        assert(entry->data != NULL);
+
+        if (snprintf(entry->data, mb[i].size, "%s", mb[i].ptr) < 0) {
+            free(entry->data);
+            free(entry);
+            return -1;
+        }
+
+        entry->data[strcspn(entry->data, "\n")] = '\0';
+        entry->data = realloc(entry->data, strlen(entry->data) + 1);
+
+        TAILQ_INSERT_TAIL(list, entry, items);
+    }
+
+    return 0;
+}
+
+/*
+ * Given two paths to files (a and b), load them and generate a
+ * unified diff.  The function returns the formatted delta or NULL if
+ * there are no differences.
+ */
+char *get_file_delta(const char *a, const char *b)
+{
+    mmfile_t old;
+    mmfile_t new;
+    xpparam_t xpp;
+    xdemitconf_t xecfg;
+    xdemitcb_t ecb;
+    char *r = NULL;
+
+    if (fill_mmfile(&old, a) < 0 || fill_mmfile(&new, b) < 0) {
+        warn("fill_mmfile");
+        return NULL;
+    }
+
+    memset(&xpp, 0, sizeof(xpp));
+    memset(&xecfg, 0, sizeof(xecfg));
+    memset(&ecb, 0, sizeof(ecb));
+
+    xpp.flags = 0;
+    xpp.flags |= XDF_IGNORE_WHITESPACE;
+
+    xecfg.ctxlen = 3;
+    ecb.priv = 0;
+    ecb.outf = delta_out;
+
+    list = calloc(1, sizeof(*list));
+    assert(list != NULL);
+    TAILQ_INIT(list);
+
+    if (xdl_diff(&old, &new, &xpp, &xecfg, &ecb) < 0) {
+        warn("xdl_diff");
+    }
+
+    if (TAILQ_EMPTY(list)) {
+        free(list);
+        return NULL;
+    }
+
+    r = list_to_string(list, "\n");
+    list_free(list, free);
+
+    return r;
+}

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -207,22 +207,6 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     free(ver);
 
-    /* diff */
-    tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "--version", NULL);
-    details = strsplit(tmp, "\n");
-    free(tmp);
-
-    entry = TAILQ_FIRST(details);
-    ver = strdup(entry->data);
-    list_free(details, free);
-
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
-    xasprintf(&entry->data, "%s", ver);
-    TAILQ_INSERT_TAIL(list, entry, items);
-
-    free(ver);
-
     /* diffstat */
     ver = run_cmd(&exitcode, ri->worksubdir, ri->commands.diffstat, "--version", NULL);
     entry = calloc(1, sizeof(*entry));

--- a/lib/free.c
+++ b/lib/free.c
@@ -230,7 +230,6 @@ void free_rpminspect(struct rpminspect *ri) {
     free(ri->desktop_entry_files_dir);
     free(ri->vendor);
 
-    free(ri->commands.diff);
     free(ri->commands.diffstat);
     free(ri->commands.msgunfmt);
     free(ri->commands.desktop_file_validate);

--- a/lib/init.c
+++ b/lib/init.c
@@ -957,10 +957,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             ri->kojimbs = strdup(t);
                         }
                     } else if (block == BLOCK_COMMON) {
-                        if (!strcmp(key, "diff")) {
-                            free(ri->commands.diff);
-                            ri->commands.diff = strdup(t);
-                        } else if (!strcmp(key, "diffstat")) {
+                        if (!strcmp(key, "diffstat")) {
                             free(ri->commands.diffstat);
                             ri->commands.diffstat = strdup(t);
                         } else if (!strcmp(key, "msgunfmt")) {
@@ -2038,7 +2035,6 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         ri->patch_line_threshold = DEFAULT_PATCH_LINE_THRESHOLD;
 
         /* Initialize commands */
-        ri->commands.diff = strdup(DIFF_CMD);
         ri->commands.diffstat = strdup(DIFFSTAT_CMD);
         ri->commands.msgunfmt = strdup(MSGUNFMT_CMD);
         ri->commands.desktop_file_validate = strdup(DESKTOP_FILE_VALIDATE_CMD);

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -213,7 +213,6 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
     char *before_output = NULL;
     char *after_output = NULL;
     char *diff_output = NULL;
-    int exitcode = 0;
 
     assert(ri != NULL);
     assert(peer != NULL);
@@ -239,7 +238,7 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     /* Compare the changelogs */
     if (before_output && after_output) {
-        diff_output = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", before_output, after_output, NULL);
+        diff_output = get_file_delta(before_output, after_output);
     }
 
     /* Set up result parameters */
@@ -249,7 +248,7 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
     params.waiverauth = NOT_WAIVABLE;
     params.noun = _("%%changelog");
 
-    if (exitcode) {
+    if (diff_output) {
         /* Skip past the diff(1) header lines */
         params.details = skip_diff_headers(diff_output);
 
@@ -341,7 +340,6 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
     char *before_output = NULL;
     char *after_output = NULL;
     char *diff_output = NULL;
-    int exitcode = 0;
     string_entry_t *entry = NULL;
 
     assert(ri != NULL);
@@ -361,7 +359,7 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     /* Compare the changelogs */
     if (before_output && after_output) {
-        diff_output = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", before_output, after_output, NULL);
+        diff_output = get_file_delta(before_output, after_output);
     }
 
     /* Set up result parameters */
@@ -372,7 +370,7 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
     params.verb = VERB_CHANGED;
     params.noun = _("%%changelog");
 
-    if (exitcode) {
+    if (diff_output) {
         /* Skip past the diff(1) header lines */
         params.details = skip_diff_headers(diff_output);
         params.severity = RESULT_INFO;

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -163,26 +163,21 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             if (exitcode) {
                 /* the files differ and not a rebase, see if it's only whitespace changes */
                 free(diff_output);
-                params.details = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
+                params.details = get_file_delta(file->peer_file->fullpath, file->fullpath);
 
-                if (exitcode == 0) {
-                    xasprintf(&params.msg, _("%%config file content change for %s in %s on %s (comments/whitespace only)"), file->localpath, name, arch);
-                    params.severity = RESULT_INFO;
-                    params.waiverauth = NOT_WAIVABLE;
-                    params.verb = VERB_OK;
-                    result = true;
-                } else {
+                if (params.details) {
                     xasprintf(&params.msg, _("%%config file content change for %s in %s on %s"), file->localpath, name, arch);
 
                     if (params.severity == RESULT_VERIFY) {
                         result = false;
                     }
+
+                    add_result(ri, &params);
+                    reported = true;
                 }
 
-                add_result(ri, &params);
                 free(params.msg);
                 free(params.details);
-                reported = true;
             }
         }
     } else if (before_config || after_config) {

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -104,13 +104,15 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (exitcode) {
             /* the files differ, see if it's only whitespace changes */
-            diff_output = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", "-w", "-I^#.*", file->peer_file->fullpath, file->fullpath, NULL);
+            diff_output = get_file_delta(file->peer_file->fullpath, file->fullpath);
 
             /* always report content changes on %doc files as INFO */
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
 
-            xasprintf(&params.msg, _("%%doc file content change for %s in %s on %s%s\n"), file->localpath, name, arch, (exitcode == 0) ? _(" (comments/whitespace only)") : "");
+            if (diff_output) {
+                xasprintf(&params.msg, _("%%doc file content change for %s in %s on %s\n"), file->localpath, name, arch);
+            }
 
             /* only add the diff output for text content */
             if (strprefix(get_mime_type(file->peer_file), "text/") && strprefix(get_mime_type(file), "text/")) {

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -499,32 +499,36 @@ static bool expected_deprule_change(const bool rebase, const deprule_entry_t *de
     }
 
     /* deprule version strings are a combo of the version-release or epoch:version-release */
-    if (!found) {
-        /* use the main package vr and evr */
-        if ((pkg_epoch > 0) && pkg_evr && !strcmp(deprule->version, pkg_evr)) {
-            r = true;
-        } else if (pkg_vr && !strcmp(deprule->version, pkg_vr)) {
-            r = true;
-        }
-    } else {
-        /* check against the subpackage match we found */
-        version = headerGetString(peer->after_hdr, RPMTAG_VERSION);
-        release = headerGetString(peer->after_hdr, RPMTAG_RELEASE);
-        epoch = headerGetNumber(peer->after_hdr, RPMTAG_EPOCH);
-        xasprintf(&vr, "%s-%s", version, release);
-        xasprintf(&evr, "%ju:%s-%s", epoch, version, release);
-
-        /* determine if this is expected */
-        if (deprule->version) {
-            if ((epoch > 0) && evr && !strcmp(deprule->version, evr)) {
+    if (deprule->version) {
+        if (!found) {
+            /* use the main package vr and evr */
+            if ((pkg_epoch > 0) && pkg_evr && !strcmp(deprule->version, pkg_evr)) {
                 r = true;
-            } else if (vr && !strcmp(deprule->version, vr)) {
+            } else if (pkg_vr && !strcmp(deprule->version, pkg_vr)) {
                 r = true;
             }
-        }
+        } else {
+            /* check against the subpackage match we found */
+            version = headerGetString(peer->after_hdr, RPMTAG_VERSION);
+            release = headerGetString(peer->after_hdr, RPMTAG_RELEASE);
+            epoch = headerGetNumber(peer->after_hdr, RPMTAG_EPOCH);
+            xasprintf(&vr, "%s-%s", version, release);
+            xasprintf(&evr, "%ju:%s-%s", epoch, version, release);
 
-        free(vr);
-        free(evr);
+            /* determine if this is expected */
+            if (deprule->version) {
+                if ((epoch > 0) && evr && !strcmp(deprule->version, evr)) {
+                    r = true;
+                } else if (vr && !strcmp(deprule->version, vr)) {
+                    r = true;
+                }
+            }
+
+            free(vr);
+            free(evr);
+        }
+    } else if (deprule->version == NULL && found) {
+        r = true;
     }
 
     free(req);

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -62,7 +62,6 @@ static bool upstream_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     char *after_sum = NULL;
     char *diff_output = NULL;
     char *diff_head = NULL;
-    int exitcode;
 
     /* If we are not looking at a Source file, bail. */
     if (!is_source(file)) {
@@ -88,7 +87,7 @@ static bool upstream_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (strcmp(before_sum, after_sum)) {
             /* capture 'diff -u' output for text files */
             if (is_text_file(file->peer_file) && is_text_file(file)) {
-                diff_head = diff_output = run_cmd(&exitcode, ri->worksubdir, ri->commands.diff, "-u", file->peer_file->fullpath, file->fullpath, NULL);
+                diff_head = diff_output = get_file_delta(file->peer_file->fullpath, file->fullpath);
 
                 /* skip the two leading lines */
                 if (strprefix(diff_head, "--- ")) {

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -22,6 +22,7 @@ librpminspect_sources = [
     'checksums.c',
     'copyfile.c',
     'debug.c',
+    'delta.c',
     'deprules.c',
     'diags.c',
     'filecmp.c',
@@ -122,6 +123,7 @@ deps = [
     dl,
     icu_uc,
     icu_io,
+    libxdiff,
 ]
 
 if get_option('with_libkmod')

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ yaml = dependency('yaml-0.1', required : true)
 clamav = dependency('libclamav', required : true)
 icu_uc = dependency('icu-uc', required : true)
 icu_io = dependency('icu-io', required : true)
+libxdiff = dependency('libxdiff', required : true)
 
 # libkmod
 if get_option('with_libkmod')

--- a/osdeps/almalinux8/reqs.txt
+++ b/osdeps/almalinux8/reqs.txt
@@ -28,6 +28,7 @@ libcurl-devel
 libffi-devel
 libicu-devel
 libmandoc-devel
+libxdiff-devel
 libxml2-devel
 libyaml-devel
 make

--- a/osdeps/centos7/reqs.txt
+++ b/osdeps/centos7/reqs.txt
@@ -30,6 +30,7 @@ libcurl-devel
 libffi-devel
 libicu-devel
 libtool
+libxdiff-devel
 libxml2-devel
 libyaml-devel
 make

--- a/osdeps/centos8/reqs.txt
+++ b/osdeps/centos8/reqs.txt
@@ -28,6 +28,7 @@ libcurl-devel
 libffi-devel
 libicu-devel
 libmandoc-devel
+libxdiff-devel
 libxml2-devel
 libyaml-devel
 make

--- a/osdeps/centos9/reqs.txt
+++ b/osdeps/centos9/reqs.txt
@@ -28,6 +28,7 @@ libcurl-devel
 libffi-devel
 libicu-devel
 libmandoc-devel
+libxdiff-devel
 libxml2-devel
 libyaml-devel
 make

--- a/osdeps/fedora-rawhide.i686/reqs.txt
+++ b/osdeps/fedora-rawhide.i686/reqs.txt
@@ -33,6 +33,7 @@ libcurl-devel.i686
 libffi-devel.i686
 libicu-devel.i686
 libmandoc-devel.i686
+libxdiff-devel.i686
 libxml2-devel.i686
 libyaml-devel.i686
 make

--- a/osdeps/fedora-rawhide/reqs.txt
+++ b/osdeps/fedora-rawhide/reqs.txt
@@ -32,6 +32,7 @@ libcurl-devel
 libffi-devel
 libicu-devel
 libmandoc-devel
+libxdiff-devel
 libxml2-devel
 libyaml-devel
 make

--- a/osdeps/fedora.i686/reqs.txt
+++ b/osdeps/fedora.i686/reqs.txt
@@ -33,6 +33,7 @@ libffi-devel.i686
 libicu-devel.i686
 libmandoc-devel.i686
 libxml2-devel.i686
+libxdiff-devel.i686
 libyaml-devel.i686
 make
 meson

--- a/osdeps/fedora/reqs.txt
+++ b/osdeps/fedora/reqs.txt
@@ -31,6 +31,7 @@ libcurl-devel
 libffi-devel
 libicu-devel
 libmandoc-devel
+libxdiff-devel
 libxml2-devel
 libyaml-devel
 make

--- a/osdeps/oraclelinux8/reqs.txt
+++ b/osdeps/oraclelinux8/reqs.txt
@@ -28,6 +28,7 @@ libcurl-devel
 libffi-devel
 libicu-devel
 libmandoc-devel
+libxdiff-devel
 libxml2-devel
 libyaml-devel
 make

--- a/osdeps/rocky8/reqs.txt
+++ b/osdeps/rocky8/reqs.txt
@@ -28,6 +28,7 @@ libcurl-devel
 libffi-devel
 libicu-devel
 libmandoc-devel
+libxdiff-devel
 libxml2-devel
 libyaml-devel
 make

--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -37,6 +37,7 @@ BuildRequires:  clamav-devel
 BuildRequires:  libmandoc-devel >= 1.14.5
 BuildRequires:  gnupg2
 BuildRequires:  libicu-devel
+BuildRequires:  libxdiff-devel
 
 
 %description
@@ -51,7 +52,6 @@ Summary:        Library providing RPM test API and functionality
 Group:          Development/Tools
 Requires:       desktop-file-utils
 Requires:       gettext
-Requires:       diffutils
 Requires:       diffstat
 Requires:       clamav-data
 

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -802,6 +802,7 @@ class TestCompareKoji(TestCompareRPMs):
                 args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             (self.out, self.err) = self.p.communicate()
+            self.results = []
 
             try:
                 with open(self.outputfile) as f:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -262,7 +262,7 @@ class ConfigChangesWhitespaceCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.result = "INFO"
+        self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
 
@@ -283,7 +283,7 @@ class ConfigChangesWhitespaceCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.result = "INFO"
+        self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
 
@@ -304,7 +304,7 @@ class ConfigChangesWhitespaceRebaseCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "config"
-        self.result = "INFO"
+        self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
 
@@ -325,7 +325,7 @@ class ConfigChangesWhitespaceRebaseCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "config"
-        self.result = "INFO"
+        self.result = "OK"
         self.waiver_auth = "Not Waivable"
 
 


### PR DESCRIPTION
This has been queued up for a while, but drop the dependency on the
external /usr/bin/diff program for determining text differences and
collecting unified diff output.  Use the libxdiff library, which can
be found in tools like git.

Signed-off-by: David Cantrell <dcantrell@redhat.com>