### PR TITLE
[ci] Drop diffutils from all CI job reqs.txt files

### DIFF
--- a/osdeps/almalinux8/reqs.txt
+++ b/osdeps/almalinux8/reqs.txt
@@ -8,7 +8,6 @@ CUnit-devel
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/alpine/reqs.txt
+++ b/osdeps/alpine/reqs.txt
@@ -11,7 +11,6 @@ cunit-dev
 curl
 curl-dev
 desktop-file-utils
-diffutils
 elfutils-dev
 freshclam
 fts-dev

--- a/osdeps/altlinux/reqs.txt
+++ b/osdeps/altlinux/reqs.txt
@@ -6,7 +6,6 @@ curl
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 gcc
 gettext-devel

--- a/osdeps/amzn2/reqs.txt
+++ b/osdeps/amzn2/reqs.txt
@@ -8,7 +8,6 @@ CUnit-devel
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/centos7/reqs.txt
+++ b/osdeps/centos7/reqs.txt
@@ -8,7 +8,6 @@ CUnit-devel
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 fedora-packager
 file-devel

--- a/osdeps/centos8/reqs.txt
+++ b/osdeps/centos8/reqs.txt
@@ -8,7 +8,6 @@ CUnit-devel
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/centos9/reqs.txt
+++ b/osdeps/centos9/reqs.txt
@@ -8,7 +8,6 @@ CUnit-devel
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/fedora-rawhide.i686/reqs.txt
+++ b/osdeps/fedora-rawhide.i686/reqs.txt
@@ -8,7 +8,6 @@ CUnit-devel.i686
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel.i686
 file-devel.i686
 gcc

--- a/osdeps/fedora-rawhide/reqs.txt
+++ b/osdeps/fedora-rawhide/reqs.txt
@@ -8,7 +8,6 @@ CUnit-devel
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/fedora.i686/reqs.txt
+++ b/osdeps/fedora.i686/reqs.txt
@@ -9,7 +9,6 @@ CUnit-devel.i686
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel.i686
 file-devel.i686
 gcc

--- a/osdeps/fedora/reqs.txt
+++ b/osdeps/fedora/reqs.txt
@@ -9,7 +9,6 @@ CUnit-devel
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/freebsd/reqs.txt
+++ b/osdeps/freebsd/reqs.txt
@@ -32,7 +32,6 @@ cargo
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/mageia/reqs.txt
+++ b/osdeps/mageia/reqs.txt
@@ -5,7 +5,6 @@ clamav-db
 dash
 desktop-file-utils
 diffstat
-diffutils
 gettext-devel
 git
 glibc-devel

--- a/osdeps/opensuse-leap/reqs.txt
+++ b/osdeps/opensuse-leap/reqs.txt
@@ -6,7 +6,6 @@ cunit-devel
 curl
 desktop-file-utils
 diffstat
-diffutils
 file-devel
 gcc
 gcc-32bit

--- a/osdeps/opensuse-tumbleweed/reqs.txt
+++ b/osdeps/opensuse-tumbleweed/reqs.txt
@@ -9,7 +9,6 @@ cunit-devel
 curl
 desktop-file-utils
 diffstat
-diffutils
 file-devel
 gcc
 gcc-32bit

--- a/osdeps/oraclelinux8/reqs.txt
+++ b/osdeps/oraclelinux8/reqs.txt
@@ -8,7 +8,6 @@ CUnit-devel
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/rocky8/reqs.txt
+++ b/osdeps/rocky8/reqs.txt
@@ -8,7 +8,6 @@ CUnit-devel
 dash
 desktop-file-utils
 diffstat
-diffutils
 elfutils-devel
 file-devel
 gcc


### PR DESCRIPTION
diffutils is no longer required, so do not install it in the images
used to run the CI jobs.

Signed-off-by: David Cantrell <dcantrell@redhat.com>