### PR TITLE
[lib] Report annocheck failures as RESULT_VERIFY

### DIFF
--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -31,7 +31,7 @@
  * this inspection.  By default we will report at the RESULT_INFO
  * level but still capture annocheck output.
  */
-static severity_t annocheck_failure_severity = RESULT_INFO;
+static severity_t annocheck_failure_severity = RESULT_VERIFY;
 
 /* Trim workdir substrings from a generated string. */
 static char *trim_workdir(const rpmfile_entry_t *file, char *s)


### PR DESCRIPTION
Per the discussion in BZ#2054115, flip this back over to reporting
annocheck failures as RESULT_VERIFY rather than RESULT_INFO.

Signed-off-by: David Cantrell <dcantrell@redhat.com>