### PR TITLE
[lib] Make annocheck failure reporting severity a config file setting

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -486,6 +486,26 @@ specname:
     #    - /usr/lib*/libexample.so*
 
 annocheck:
+    # Reporting severity for annocheck(1) failures.  By default,
+    # rpminspect will report annocheck(1) failures as a VERIFY result
+    # but you can change this to any valid rpminspect result type.
+    # The valid choices are:
+    #     OK
+    #     INFO
+    #     VERIFY
+    #     BAD
+    #     SKIP
+    # The result codes are primarily for use by systems integrating
+    # rpminspect and process the results output, but the result
+    # reporting level also determines what causes rpminspect to exit
+    # non-zero or not.  By default, any result of VERIFY or higher
+    # will cause a non-zero exit of rpminspect which indicates it
+    # found an failure in one of the inspections.  The OK and INFO
+    # levels will still report the findings but not trigger a non-zero
+    # exit.  The SKIP result code will skip displaying the results in
+    # the output.
+    failure_severity: VERIFY
+
     # annocheck(1) tests to run.  The left side of the colon is the
     # test name you want to use and the right side are the arguments
     # to the annocheck executable before giving it the full path to
@@ -493,7 +513,11 @@ annocheck:
     #
     # This section is optional.  If no annocheck tests are defined
     # here, rpminspect will skip the annocheck inspection.
-    - hardened: --ignore-unknown --verbose
+    #
+    # These job entries may be listed here or under a block named
+    # 'jobs:' if you prefer.
+    jobs:
+        - hardened: --ignore-unknown --verbose
 
     # Optional list of glob(7) specifications to match files to ignore
     # for this inspection.  The format of this list is the same as the

--- a/include/types.h
+++ b/include/types.h
@@ -551,6 +551,7 @@ struct rpminspect {
 
     /* hash table of annocheck tests */
     string_map_t *annocheck;
+    severity_t annocheck_failure_severity;
 
     /* hash table of path migrations */
     string_map_t *pathmigration;

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -473,6 +473,8 @@ void dump_cfg(const struct rpminspect *ri)
 
     if (ri->annocheck || mapentry != NULL) {
         printf("annocheck:\n");
+        printf("    failure_severity: %s\n", strseverity(ri->annocheck_failure_severity));
+        printf("    jobs:\n");
 
         HASH_ITER(hh, ri->annocheck, hentry, tmp_hentry) {
             printf("    - %s: %s\n", hentry->key, hentry->value);

--- a/lib/init.c
+++ b/lib/init.c
@@ -1110,7 +1110,16 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             }
                         }
                     } else if (group == BLOCK_ANNOCHECK) {
-                        process_table(key, t, &ri->annocheck);
+                        if (!strcmp(key, "failure_severity")) {
+                            ri->annocheck_failure_severity = getseverity(t, RESULT_NULL);
+
+                            if (ri->annocheck_failure_severity == RESULT_NULL) {
+                                warnx(_("Invalid annocheck failure_reporting_level: %s, defaulting to %s."), t, strseverity(RESULT_VERIFY));
+                                ri->annocheck_failure_severity = RESULT_VERIFY;
+                            }
+                        } else {
+                            process_table(key, t, &ri->annocheck);
+                        }
                     } else if (group == BLOCK_JAVABYTECODE) {
                         process_table(key, t, &ri->jvm);
                     } else if (group == BLOCK_MIGRATED_PATHS) {
@@ -2033,6 +2042,7 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         ri->kmidiff_debuginfo_path = strdup(DEBUG_PATH);
         ri->patch_file_threshold = DEFAULT_PATCH_FILE_THRESHOLD;
         ri->patch_line_threshold = DEFAULT_PATCH_LINE_THRESHOLD;
+        ri->annocheck_failure_severity = RESULT_VERIFY;
 
         /* Initialize commands */
         ri->commands.diffstat = strdup(DIFFSTAT_CMD);

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -26,13 +26,6 @@
 
 #include "rpminspect.h"
 
-/*
- * Set this to RESULT_VERIFY to pass through annocheck failures up to
- * this inspection.  By default we will report at the RESULT_INFO
- * level but still capture annocheck output.
- */
-static severity_t annocheck_failure_severity = RESULT_VERIFY;
-
 /* Trim workdir substrings from a generated string. */
 static char *trim_workdir(const rpmfile_entry_t *file, char *s)
 {
@@ -163,12 +156,12 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 xasprintf(&params.msg, _("annocheck '%s' test now passes for %s on %s"), hentry->key, file->localpath, arch);
             } else if (before_exit == 0 && after_exit) {
                 xasprintf(&params.msg, _("annocheck '%s' test now fails for %s on %s"), hentry->key, file->localpath, arch);
-                params.severity = annocheck_failure_severity;
+                params.severity = ri->annocheck_failure_severity;
                 params.verb = VERB_CHANGED;
                 result = false;
             } else if (after_exit) {
                 xasprintf(&params.msg, _("annocheck '%s' test fails for %s on %s"), hentry->key, file->localpath, arch);
-                params.severity = annocheck_failure_severity;
+                params.severity = ri->annocheck_failure_severity;
                 params.verb = VERB_CHANGED;
                 result = false;
             }
@@ -177,7 +170,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 xasprintf(&params.msg, _("annocheck '%s' test passes for %s on %s"), hentry->key, file->localpath, arch);
             } else if (after_exit) {
                 xasprintf(&params.msg, _("annocheck '%s' test fails for %s on %s"), hentry->key, file->localpath, arch);
-                params.severity = annocheck_failure_severity;
+                params.severity = ri->annocheck_failure_severity;
                 params.verb = VERB_CHANGED;
                 result = false;
             }


### PR DESCRIPTION
Add a new config file setting under the 'annocheck' block called
'failure_severity'.  The default is VERIFY which means when annocheck
exits non-zero, rpminspect will report that result as VERIFY and
depending on the reporting threshold of rpminspect that may trigger a
non-zero exit code from rpminspect.  The user may modify the config
file for rpminspect and adjust the failure_severity to any valid
result severity.  The most common use case is to set it to INFO to
both report annocheck failures but not fail rpminspect.

Signed-off-by: David Cantrell <dcantrell@redhat.com>