### PR TITLE
[cfg] Drop diff(1) command setting from generic.yaml

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -31,10 +31,6 @@ koji:
 commands:
     # External helper commands used by rpminspect.  Defaults are noted.
 
-    # diff(1) command, must support -u, -w, and -I options as defined
-    # in GNU diff.
-    #diff: /usr/bin/diff
-
     # diffstat(1) command.
     # https://invisible-island.net/diffstat/
     #diffstat: /usr/bin/diffstat


### PR DESCRIPTION
rpminspect does not use diff anymore, so the config files do not need
to carry this setting.

Signed-off-by: David Cantrell <dcantrell@redhat.com>