### PR TITLE
[cmd] Do not remove default or user-specified --workdir paths

### DIFF
--- a/lib/mkdirp.c
+++ b/lib/mkdirp.c
@@ -29,7 +29,8 @@
 #include <unistd.h>
 #include "rpminspect.h"
 
-int mkdirp(const char *path, mode_t mode) {
+int mkdirp(const char *path, mode_t mode)
+{
     int r = 0;
     char *p = NULL;
     char *start = NULL;
@@ -37,6 +38,13 @@ int mkdirp(const char *path, mode_t mode) {
     struct stat sb;
 
     assert(path != NULL);
+
+    /* exit if path exists */
+    r = stat(path, &sb);
+
+    if (r == 0 && S_ISDIR(sb.st_mode)) {
+        return 0;
+    }
 
     /* handle relative vs. explicit paths, we want explicit */
     if (*path == '/') {


### PR DESCRIPTION
Longstanding bug.  On exit, rpminspect tries to clean up after itself
and part of that is wiping what it dumped in the workdir.  However the
cleanup was also removing the workdir.  If you were using the default
location this meant that /var/tmp/rpminspect would be removed and
recreated on each run.  But if you were using -w to specify your own
workdir that maybe you already created and other fun files in, then
rpminspect would also try to remove that directory too.  If it was
empty by the time it finished its FTW_DEPTH, then it would rmdir() it
and it was gone.

This patch fixes the cleanup behavior to not remove workdir itself but
otherwise do the contents cleanup.

I also moved the handling of the -w argument to use wordexp(3) instead
of glob(3) since it is entirely valid to pass a non-existent directory
to -w and let rpminspect create it.  You can pass that value using
shell notation too (e.g., ~) and rpminspect will expand that.
wordexp(3) does this without requiring the target to exist on the
filesystem whereas glob(3) and fnmatch(3).

Fixes: #624

Signed-off-by: David Cantrell <dcantrell@redhat.com>