### PR TITLE
[lib] Pretend that TTY has 80 columns, if the real width is unknown

### DIFF
--- a/lib/tty.c
+++ b/lib/tty.c
@@ -27,15 +27,18 @@
 
 /*
  * Return the terminal width.  Used by output routines sending text to
- * stdout.  This function returns 0 if it cannot figure out the width,
- * which means callers should just not worry about the terminal.
+ * stdout.  This function returns 80 if it cannot figure out the width.
  */
 size_t tty_width(void) {
     struct winsize w;
 
     /* get the terminal size */
     if (ioctl(0, TIOCGWINSZ, &w) == -1) {
-        return 0;
+        /*
+         * We couldn't determine the real size,
+         * so let's go with the standard width.
+         */
+        return 80;
     }
 
     return w.ws_col;


### PR DESCRIPTION
80 columns ought to be enough for anybody.

Returning zero from tty_width() could cause problems down the road
as we could easily end up with negative bar_width in setup_progress_bar().

Signed-off-by: Michal Srb <michal@redhat.com>