### PR TITLE
[fix] Do not assume peer is not NULL in set_peer()

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -435,7 +435,10 @@ static void set_peer(rpmfile_entry_t *file, struct file_data *fentry)
     fentry->rpmfile = NULL;
 
     file->peer_file = peer;
-    peer->peer_file = file;
+
+    if (peer) {
+        peer->peer_file = file;
+    }
 
     return;
 }


### PR DESCRIPTION
It is entirely possible for peer to be NULL, so don't assume it always
has a value.

Signed-off-by: David Cantrell <dcantrell@redhat.com>