### PR TITLE
[fix] YAML parsing error for the failure_severity setting

### DIFF
--- a/lib/debug.c
+++ b/lib/debug.c
@@ -86,6 +86,7 @@ void dump_cfg(const struct rpminspect *ri)
     string_map_t *hentry = NULL;
     string_map_t *tmp_hentry = NULL;
     string_list_map_t *mapentry = NULL;
+    string_list_map_t *tmp_mapentry = NULL;
     deprule_ignore_map_t *drentry = NULL;
     deprule_ignore_map_t *tmp_drentry = NULL;
 
@@ -724,6 +725,30 @@ void dump_cfg(const struct rpminspect *ri)
 
         HASH_ITER(hh, ri->deprules_ignore, drentry, tmp_drentry) {
             printf("    %s: %s\n", get_deprule_desc(drentry->type), (drentry->pattern == NULL) ? "" : drentry->pattern);
+        }
+    }
+
+    /* global and per-inspection ignores */
+
+    if (ri->ignores && !TAILQ_EMPTY(ri->ignores)) {
+        printf("global ignores:\n");
+
+        TAILQ_FOREACH(entry, ri->ignores, items) {
+            printf("    - %s\n", entry->data);
+        }
+    }
+
+    if (ri->inspection_ignores) {
+        printf("per-inspection ignores:\n");
+
+        HASH_ITER(hh, ri->inspection_ignores, mapentry, tmp_mapentry) {
+            if (mapentry->value && !TAILQ_EMPTY(mapentry->value)) {
+                printf("    %s:\n", mapentry->key);
+
+                TAILQ_FOREACH(entry, mapentry->value, items) {
+                    printf("        - %s\n", entry->data);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Under the 'annocheck' block in the rpminspect config file, you can
define a failure_severity to control what result code annocheck
failures report through rpminspect.  The format of the annocheck block
in the rpminspect config file has changed a bit to accomodate this
setting, but I wanted to retain backwards compatibility with existing
blocks.  So the 'jobs:' section is optional for grouping the annocheck
job definitions.  I need to be careful how I handle parsing this block
to avoid picking up the string 'failure_severity' as a job name.

Signed-off-by: David Cantrell <dcantrell@redhat.com>