### PR TITLE
[cmd] Pretend that TTY has 80 columns, if the real width is unknown

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -478,4 +478,9 @@
 #define SHARED_LIB_PREFIX "lib"
 #define SHARED_LIB_SUFFIX ".so"
 
+/*
+ * Fallback tty width if TIOCGWINSZ fails.
+ */
+#define DEFAULT_TTY_WIDTH 80
+
 #endif

--- a/lib/tty.c
+++ b/lib/tty.c
@@ -27,15 +27,19 @@
 
 /*
  * Return the terminal width.  Used by output routines sending text to
- * stdout.  This function returns 0 if it cannot figure out the width,
- * which means callers should just not worry about the terminal.
+ * stdout.  This function returns DEFAULT_TTY_WIDTH if it cannot
+ * figure out the width.
  */
 size_t tty_width(void) {
     struct winsize w;
 
     /* get the terminal size */
     if (ioctl(0, TIOCGWINSZ, &w) == -1) {
-        return 0;
+        /*
+         * We couldn't determine the real size,
+         * so let's go with the default width.
+         */
+        return DEFAULT_TTY_WIDTH;
     }
 
     return w.ws_col;


### PR DESCRIPTION
80 columns ought to be enough for anybody.

Returning zero from tty_width() could cause problems down the road
as we could easily end up with negative bar_width in setup_progress_bar().

Signed-off-by: Michal Srb <michal@redhat.com>