### PR TITLE
[fix] Do not call rpmFreeMacros() in load_macros()

### DIFF
--- a/lib/macros.c
+++ b/lib/macros.c
@@ -49,7 +49,6 @@ void load_macros(struct rpminspect *ri)
     if (ri->macrofiles) {
         macropath = list_to_string(ri->macrofiles, ":");
         mf = rpmGetPath(macropath, NULL);
-        rpmFreeMacros(NULL);
         rpmInitMacros(NULL, mf);
         free(macropath);
         free(mf);


### PR DESCRIPTION
Doing this drops any already loaded macros, which can cause problems
depending on how rpm is installed on the system.  With load_macros(),
rpminspect should just be piling up macros until it's time to exit and
then cleanup.

Signed-off-by: David Cantrell <dcantrell@redhat.com>