### PR TITLE
Drop the Unicode copyright symbol from license boilerplates

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Red Hat, Inc.
+ * Copyright 2018 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/include/output.h
+++ b/include/output.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019  Red Hat, Inc.
+ * Copyright 2019  Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/include/queue.h
+++ b/include/queue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/include/readelf.h
+++ b/include/readelf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/include/results.h
+++ b/include/results.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/include/secrules.h
+++ b/include/secrules.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/include/types.h
+++ b/include/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/abi.c
+++ b/lib/abi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/abspath.c
+++ b/lib/abspath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/arches.c
+++ b/lib/arches.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/badwords.c
+++ b/lib/badwords.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/bytes.c
+++ b/lib/bytes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Red Hat, Inc.
+ * Copyright 2022 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/lib/filecmp.c
+++ b/lib/filecmp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/files.c
+++ b/lib/files.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/lib/flags.c
+++ b/lib/flags.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/free.c
+++ b/lib/free.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/init.c
+++ b/lib/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_files.c
+++ b/lib/inspect_files.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Red Hat, Inc.
+ * Copyright 2018 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/lib/inspect_metadata.c
+++ b/lib/inspect_metadata.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_specname.c
+++ b/lib/inspect_specname.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/lib/local.c
+++ b/lib/local.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Red Hat, Inc.
+ * Copyright 2018 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/magic.c
+++ b/lib/magic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/output.c
+++ b/lib/output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/output_json.c
+++ b/lib/output_json.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/output_summary.c
+++ b/lib/output_summary.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/output_text.c
+++ b/lib/output_text.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/output_xunit.c
+++ b/lib/output_xunit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/pairfuncs.c
+++ b/lib/pairfuncs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *            David Shea <dshea@redhat.com>
  *

--- a/lib/readfile.c
+++ b/lib/readfile.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/rebase.c
+++ b/lib/rebase.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/release.c
+++ b/lib/release.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/results.c
+++ b/lib/results.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/secrule.c
+++ b/lib/secrule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Red Hat, Inc.
+ * Copyright 2018 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/tty.c
+++ b/lib/tty.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/lib/uncompress.c
+++ b/lib/uncompress.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Red Hat, Inc.
+ * Copyright 2020 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/test/data/derp-kmod/derp.c
+++ b/test/data/derp-kmod/derp.c
@@ -1,6 +1,6 @@
 /*
  * derp kernel module
- * Copyright © 2020 David Cantrell <dcantrell@redhat.com>
+ * Copyright 2020 David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/test/lib/elftest.c
+++ b/test/lib/elftest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/test/lib/test-abspath.c
+++ b/test/lib/test-abspath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/test/lib/test-badwords.c
+++ b/test/lib/test-badwords.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/test/lib/test-init.c
+++ b/test/lib/test-init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/test/lib/test-inspect_elf.c
+++ b/test/lib/test-inspect_elf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/test/lib/test-koji.c
+++ b/test/lib/test-koji.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/test/lib/test-main.c
+++ b/test/lib/test-main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/test/lib/test-main.h
+++ b/test/lib/test-main.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Shea <dshea@redhat.com>
  *            David Cantrell <dcantrell@redhat.com>
  *

--- a/test/lib/test-strfuncs.c
+++ b/test/lib/test-strfuncs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify

--- a/test/lib/test-tty.c
+++ b/test/lib/test-tty.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Red Hat, Inc.
+ * Copyright 2019 Red Hat, Inc.
  * Author(s): David Cantrell <dcantrell@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
These were present in the source files but sometimes when editing code
in a Docker container or other system, they would show up as '?' and I
got tired of seeing that.  They add nothing to the statement, so just
reduce it to "Copyright".

Signed-off-by: David Cantrell <dcantrell@redhat.com>