### PR TITLE
[lib] Drop dependency on the external 'diffstat' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ there are a number of userspace programs used:
     /usr/bin/abidiff [optional]
     /usr/bin/kmidiff [optional]
     /usr/bin/annocheck [optional]
-    /usr/bin/diffstat
 
 The provided spec file template uses the Fedora locations for these
 files, but in the program, they must be on the runtime system.
@@ -160,7 +159,7 @@ packages.
 In Fedora, for example, you can run the following to install these
 programs:
 
-    yum install desktop-file-utils gettext diffstat libabigail /usr/bin/annocheck
+    yum install desktop-file-utils gettext libabigail /usr/bin/annocheck
 
 The 'shellsyntax' inspection uses the actual shell programs listed in
 the shells setting in the rpminspect configuration file.  Since this

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -31,10 +31,6 @@ koji:
 commands:
     # External helper commands used by rpminspect.  Defaults are noted.
 
-    # diffstat(1) command.
-    # https://invisible-island.net/diffstat/
-    #diffstat: /usr/bin/diffstat
-
     # msgunfmt(1) as found in GNU gettext
     #msgunfmt: /usr/bin/msgunfmt
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -70,8 +70,6 @@ there are a number of userspace programs used:
 +--------------------------------+-----------+---------------------------------------------------------------+
 | /usr/bin/annocheck             | No        | https://sourceware.org/git/annobin.git                        |
 +--------------------------------+-----------+---------------------------------------------------------------+
-| /usr/bin/diffstat              | No        | https://invisible-island.net/diffstat/                        |
-+--------------------------------+-----------+---------------------------------------------------------------+
 
 The provided RPM_ spec file template uses the `Fedora Linux
 <https://getfedora.org>`_ locations for these files, but in the
@@ -82,7 +80,7 @@ tools. If they are available, you should use those packages.
 In `Fedora Linux <https://getfedora.org>`_, for example, you can run
 the following to install these programs::
 
-    dnf install desktop-file-utils gettext diffstat libabigail /usr/bin/annocheck
+    dnf install desktop-file-utils gettext libabigail /usr/bin/annocheck
 
 The *shellsyntax* inspection uses the actual shell programs listed in
 the shells setting in the rpminspect_ configuration file.  Since this

--- a/include/constants.h
+++ b/include/constants.h
@@ -231,12 +231,6 @@
 #define MSGUNFMT_CMD "msgunfmt"
 
 /**
- * @def DIFFSTAT_CMD
- * Executable providing diffstat(1).
- */
-#define DIFFSTAT_CMD "diffstat"
-
-/**
  * @def DESKTOP_FILE_VALIDATE_CMD
  * Executable providing desktop-file-validate(1)
  */

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -621,12 +621,13 @@ bool inspect_doc(struct rpminspect *ri);
  * @brief Main driver for the 'patches' inspection.
  *
  * Inspects all patches defined in the spec file and reports changes
- * between builds.  At the INFO level, rpminspect reports diffstat(1)
- * and patch size changes.  If thresholds are reached regarding a
- * change in the patch size or the number of files the patch touches,
- * rpminspect reports the change at the VERIFY level unless the
- * comparison is for a rebase.  The configuration file can also list
- * patch names that rpminspect should ignore during the inspection.
+ * between builds.  At the INFO level, rpminspect reports patch file
+ * count, line count, and patch size changes.  If thresholds are
+ * reached regarding a change in the patch size or the number of files
+ * the patch touches, rpminspect reports the change at the VERIFY
+ * level unless the comparison is for a rebase.  The configuration
+ * file can also list patch names that rpminspect should ignore during
+ * the inspection.
  *
  * @param ri Pointer to the struct rpminspect for the program.
  * @return True if the inspection passed, false otherwise.
@@ -1526,7 +1527,7 @@ bool inspect_rpmdeps(struct rpminspect *ri);
  * @def DESC_PATCHES
  * The description for the 'patches' inspection.
  */
-#define DESC_PATCHES _("Inspects all patches defined in the spec file and reports changes between builds.  At the INFO level, rpminspect reports diffstat(1) and patch size changes.  If thresholds are reached regarding a change in the patch size or the number of files the patch touches, rpminspect reports the change at the VERIFY level unless the comparison is for a rebase.  The configuration file can also list patch names that rpminspect should ignore during the inspection.")
+#define DESC_PATCHES _("Inspects all patches defined in the spec file and reports changes between builds.  At the INFO level, rpminspect reports file count, line count, and patch size changes.  If thresholds are reached regarding a change in the patch size or the number of files the patch touches, rpminspect reports the change at the VERIFY level unless the comparison is for a rebase.  The configuration file can also list patch names that rpminspect should ignore during the inspection.")
 
 /**
  * @def DESC_VIRUS

--- a/include/types.h
+++ b/include/types.h
@@ -373,7 +373,6 @@ typedef enum _politics_field_t {
 /* Commands used by rpminspect at runtime. */
 struct command_paths {
     char *diff;
-    char *diffstat;
     char *msgunfmt;
     char *desktop_file_validate;
     char *annocheck;
@@ -986,11 +985,11 @@ typedef struct _abi_t {
 } abi_t;
 
 /*
- * diffstat(1) findings for reporting in the patches inspection
+ * Patch stats for reporting in the patches inspection
  */
-typedef struct _diffstat_t {
+typedef struct _patchstat_t {
     long int files;
     long int lines;
-} diffstat_t;
+} patchstat_t;
 
 #endif

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -130,10 +130,6 @@ void dump_cfg(const struct rpminspect *ri)
 
     printf("commands:\n");
 
-    if (ri->commands.diffstat) {
-        printf("    diffstat: %s\n", ri->commands.diffstat);
-    }
-
     if (ri->commands.msgunfmt) {
         printf("    msgunfmt: %s\n", ri->commands.msgunfmt);
     }

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -207,14 +207,6 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     free(ver);
 
-    /* diffstat */
-    ver = run_cmd(&exitcode, ri->worksubdir, ri->commands.diffstat, "--version", NULL);
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
-    xasprintf(&entry->data, "%s", ver);
-    TAILQ_INSERT_TAIL(list, entry, items);
-    free(ver);
-
     /* annocheck */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.annocheck, "--version", NULL);
     details = strsplit(tmp, "\n");

--- a/lib/free.c
+++ b/lib/free.c
@@ -230,7 +230,6 @@ void free_rpminspect(struct rpminspect *ri) {
     free(ri->desktop_entry_files_dir);
     free(ri->vendor);
 
-    free(ri->commands.diffstat);
     free(ri->commands.msgunfmt);
     free(ri->commands.desktop_file_validate);
     free(ri->commands.annocheck);

--- a/lib/init.c
+++ b/lib/init.c
@@ -966,10 +966,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             ri->kojimbs = strdup(t);
                         }
                     } else if (block == BLOCK_COMMON) {
-                        if (!strcmp(key, "diffstat")) {
-                            free(ri->commands.diffstat);
-                            ri->commands.diffstat = strdup(t);
-                        } else if (!strcmp(key, "msgunfmt")) {
+                        if (!strcmp(key, "msgunfmt")) {
                             free(ri->commands.msgunfmt);
                             ri->commands.msgunfmt = strdup(t);
                         } else if (!strcmp(key, "desktop-file-validate")) {
@@ -2063,7 +2060,6 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         ri->annocheck_failure_severity = RESULT_VERIFY;
 
         /* Initialize commands */
-        ri->commands.diffstat = strdup(DIFFSTAT_CMD);
         ri->commands.msgunfmt = strdup(MSGUNFMT_CMD);
         ri->commands.desktop_file_validate = strdup(DESKTOP_FILE_VALIDATE_CMD);
         ri->commands.annocheck = strdup(ANNOCHECK_CMD);

--- a/osdeps/almalinux8/reqs.txt
+++ b/osdeps/almalinux8/reqs.txt
@@ -7,7 +7,6 @@ CUnit
 CUnit-devel
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -31,17 +31,6 @@ sed -i -e 's|^int dummy;$|extern int dummy;|g' "${SUBDIR}"/compat_err.c
 ( cd "${SUBDIR}" && ./configure && make && make lib-install )
 rm -rf mandoc.tar.gz "${SUBDIR}"
 
-# diffstat is not available as a package, so build it
-curl -O ftp://ftp.invisible-island.net/diffstat/diffstat.tar.gz
-SUBDIR="$(tar -tvf diffstat.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
-tar -xvf diffstat.tar.gz
-cd "${SUBDIR}" || exit 1
-./configure --prefix=/usr/local
-make
-make install
-cd "${CWD}" || exit 1
-rm -rf diffstat.tar.gz "${SUBDIR}"
-
 # The 'rc' shell is not available in Arch Linux, build manually
 git clone https://github.com/rakitzis/rc.git
 cd rc || exit 1

--- a/osdeps/altlinux/reqs.txt
+++ b/osdeps/altlinux/reqs.txt
@@ -5,7 +5,6 @@ CUnit-devel
 curl
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 gcc
 gettext-devel

--- a/osdeps/amzn2/reqs.txt
+++ b/osdeps/amzn2/reqs.txt
@@ -7,7 +7,6 @@ CUnit
 CUnit-devel
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/arch/reqs.txt
+++ b/osdeps/arch/reqs.txt
@@ -4,7 +4,6 @@ bison
 clamav
 cunit
 desktop-file-utils
-diffstat
 gcc
 gettext
 git

--- a/osdeps/centos7/reqs.txt
+++ b/osdeps/centos7/reqs.txt
@@ -7,7 +7,6 @@ CUnit
 CUnit-devel
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 fedora-packager
 file-devel

--- a/osdeps/centos8/reqs.txt
+++ b/osdeps/centos8/reqs.txt
@@ -7,7 +7,6 @@ CUnit
 CUnit-devel
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/centos9/reqs.txt
+++ b/osdeps/centos9/reqs.txt
@@ -7,7 +7,6 @@ CUnit
 CUnit-devel
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/debian/reqs.txt
+++ b/osdeps/debian/reqs.txt
@@ -1,7 +1,6 @@
 abigail-tools
 clamav
 desktop-file-utils
-diffstat
 gcc
 gcovr
 gettext

--- a/osdeps/fedora-rawhide.i686/reqs.txt
+++ b/osdeps/fedora-rawhide.i686/reqs.txt
@@ -7,7 +7,6 @@ CUnit.i686
 CUnit-devel.i686
 dash
 desktop-file-utils
-diffstat
 elfutils-devel.i686
 file-devel.i686
 gcc

--- a/osdeps/fedora-rawhide/reqs.txt
+++ b/osdeps/fedora-rawhide/reqs.txt
@@ -7,7 +7,6 @@ CUnit
 CUnit-devel
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/fedora.i686/reqs.txt
+++ b/osdeps/fedora.i686/reqs.txt
@@ -8,7 +8,6 @@ CUnit.i686
 CUnit-devel.i686
 dash
 desktop-file-utils
-diffstat
 elfutils-devel.i686
 file-devel.i686
 gcc

--- a/osdeps/fedora/reqs.txt
+++ b/osdeps/fedora/reqs.txt
@@ -8,7 +8,6 @@ CUnit
 CUnit-devel
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/freebsd/reqs.txt
+++ b/osdeps/freebsd/reqs.txt
@@ -31,7 +31,6 @@ bash
 cargo
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/gentoo/reqs.txt
+++ b/osdeps/gentoo/reqs.txt
@@ -11,7 +11,6 @@ dev-libs/xmlrpc-c
 dev-python/pip
 dev-util/cunit
 dev-util/desktop-file-utils
-dev-util/diffstat
 dev-util/gcovr
 dev-util/libabigail
 dev-util/patchelf

--- a/osdeps/mageia/reqs.txt
+++ b/osdeps/mageia/reqs.txt
@@ -4,7 +4,6 @@ clamav
 clamav-db
 dash
 desktop-file-utils
-diffstat
 gettext-devel
 git
 glibc-devel

--- a/osdeps/opensuse-leap/reqs.txt
+++ b/osdeps/opensuse-leap/reqs.txt
@@ -5,7 +5,6 @@ clamav-devel
 cunit-devel
 curl
 desktop-file-utils
-diffstat
 file-devel
 gcc
 gcc-32bit

--- a/osdeps/opensuse-tumbleweed/reqs.txt
+++ b/osdeps/opensuse-tumbleweed/reqs.txt
@@ -8,7 +8,6 @@ clamav-devel
 cunit-devel
 curl
 desktop-file-utils
-diffstat
 file-devel
 gcc
 gcc-32bit

--- a/osdeps/oraclelinux8/reqs.txt
+++ b/osdeps/oraclelinux8/reqs.txt
@@ -7,7 +7,6 @@ CUnit
 CUnit-devel
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/rocky8/reqs.txt
+++ b/osdeps/rocky8/reqs.txt
@@ -7,7 +7,6 @@ CUnit
 CUnit-devel
 dash
 desktop-file-utils
-diffstat
 elfutils-devel
 file-devel
 gcc

--- a/osdeps/slackware/reqs.txt
+++ b/osdeps/slackware/reqs.txt
@@ -8,7 +8,6 @@ check
 cmake
 curl
 desktop-file-utils
-diffstat
 elfutils
 flex
 gcc

--- a/osdeps/ubuntu/reqs.txt
+++ b/osdeps/ubuntu/reqs.txt
@@ -1,7 +1,6 @@
 abigail-tools
 cargo
 clamav
-diffstat
 desktop-file-utils
 gcc
 gcc-multilib

--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -51,7 +51,6 @@ Summary:        Library providing RPM test API and functionality
 Group:          Development/Tools
 Requires:       desktop-file-utils
 Requires:       gettext
-Requires:       diffstat
 Requires:       clamav-data
 
 # If these are present, the xml inspection can try DTD validation.


### PR DESCRIPTION
The only place the diffstat(1) command was used was in the patches
inspection.  Replace that with a function that counts files and lines
modified in individual patches.  This drops another runtime
requirement that rpminspect carries.  I really want to eliminate as
many fork & exec programs that rpminspect uses.

Signed-off-by: David Cantrell <dcantrell@redhat.com>