### PR TITLE
Fix errors noted in issue #651

### DIFF
--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -100,31 +100,36 @@ static void get_kabi_dir(struct rpminspect *ri)
  */
 static char *get_kabi_file(const struct rpminspect *ri, const char *arch)
 {
+    char *tmp = NULL;
     char *template = NULL;
     char *kabi = NULL;
 
     assert(ri != NULL);
+    assert(arch != NULL);
 
     if (kabi_dir == NULL || ri->kabi_filename == NULL) {
         return NULL;
     }
 
     /* build the template */
-    assert(arch != NULL);
     xasprintf(&template, "%s/%s", kabi_dir, ri->kabi_filename);
     assert(template != NULL);
 
     /* replace variables */
-    kabi = strreplace(template, "${ARCH}", arch);
+    tmp = strreplace(template, "${ARCH}", arch);
 
-    if (strstr(kabi, "$ARCH")) {
-        free(kabi);
-        kabi = strreplace(template, "$ARCH", arch);
+    if (strstr(tmp, "$ARCH")) {
+        free(tmp);
+        tmp = strreplace(template, "$ARCH", arch);
     }
+
+    /* normalize the path */
+    kabi = abspath(tmp);
+    assert(kabi != NULL);
+    free(tmp);
 
     /* let's see if this is actually a file */
     if (access(kabi, R_OK)) {
-        warn("%s", kabi);
         free(kabi);
         kabi = NULL;
     }

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -91,7 +91,6 @@ static patchstat_t get_patch_stats(const char *patch)
     lines = read_file(patch);
 
     if (lines == NULL || TAILQ_EMPTY(lines)) {
-        warn("read_file");
         return r;
     }
 

--- a/lib/readfile.c
+++ b/lib/readfile.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <err.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 
 #include "rpminspect.h"
 
@@ -36,8 +37,20 @@ void *read_file_bytes(const char *path, off_t *len)
     int fd = 0;
     void *data = NULL;
     void *buf = NULL;
+    struct stat sb;
 
     assert(path != NULL);
+
+    /* zero length files can be ignored */
+    if (stat(path, &sb) == -1) {
+        warn("stat");
+        return NULL;
+    }
+
+    if (sb.st_size == 0) {
+        /* zero length file, ignore */
+        return NULL;
+    }
 
     /* open the file for reading */
     fd = open(path, O_RDONLY);


### PR DESCRIPTION
A couple of things.  Handle missing KABI files in the kmidiff test and in general avoid spurious warnings when file reads fail and we just return NULL.