### PR TITLE
[fix] On stat() failure in read_file_bytes(), just return NULL

### DIFF
--- a/lib/readfile.c
+++ b/lib/readfile.c
@@ -41,14 +41,13 @@ void *read_file_bytes(const char *path, off_t *len)
 
     assert(path != NULL);
 
-    /* zero length files can be ignored */
+    /* unreadable files can be ignored */
     if (stat(path, &sb) == -1) {
-        warn("stat");
         return NULL;
     }
 
+    /* zero length file, ignore */
     if (sb.st_size == 0) {
-        /* zero length file, ignore */
         return NULL;
     }
 


### PR DESCRIPTION
No need to display a warning on stderr.  If we can't read the file by
the name specified, just return NULL.

Fixes: #661

Signed-off-by: David Cantrell <dcantrell@redhat.com>