### PR TITLE
[fix] Use CURLINFO_CONTENT_LENGTH_DOWNLOAD on older libcurl releases

### DIFF
--- a/lib/curl.c
+++ b/lib/curl.c
@@ -240,6 +240,9 @@ curl_off_t curl_get_size(const char *src)
     curl_off_t r = 0;
     CURL *c = NULL;
     CURLcode cc;
+#ifndef CURLINFO_CONTENT_LENGTH_DOWNLOAD_T
+    double len = 0;
+#endif
 
     assert(src != NULL);
 
@@ -262,7 +265,12 @@ curl_off_t curl_get_size(const char *src)
         warn("curl_easy_perform");
     }
 
+#ifdef CURLINFO_CONTENT_LENGTH_DOWNLOAD_T
     curl_easy_getinfo(c, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &r);
+#else
+    curl_easy_getinfo(c, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &len);
+    r = (curl_off_t) len;
+#endif
     curl_easy_cleanup(c);
 
     return r;


### PR DESCRIPTION
CURLINFO_CONTENT_LENGTH_DOWNLOAD_T does not exist in older versions of
the library, so use CURLINFO_CONTENT_LENGTH_DOWNLOAD instead.

Signed-off-by: David Cantrell <dcantrell@redhat.com>