### PR TITLE
[lib] Check for enough disk space before unpacking RPMs

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -233,6 +233,22 @@ rpmpeer_t *init_rpmpeer(void);
 void free_rpmpeer(rpmpeer_t *);
 void add_peer(rpmpeer_t **, int, bool, const char *, Header);
 
+/**
+ * @brief Iterate over all packages and extract them.
+ *
+ * Called internally when the program has verified enough disk space
+ * exists to extract the RPM packages and begin inspections.  The
+ * extraction step previously happened in add_peer() but has been
+ * moved to this function to allow for a disk space check before
+ * extraction begins.  If fetchonly is true, this function is a no-op
+ * and returns 0 immediately.
+ *
+ * @param ri The main rpminspect object
+ * @param fetchonly True if rpminspect is running in fetch-only mode
+ * @return 0 on success, -1 on failure
+ */
+int extract_peers(struct rpminspect *ri, bool fetchonly);
+
 /* files.c */
 void free_files(rpmfile_t *files);
 rpmfile_t * extract_rpm(const char *, Header, char **output_dir);

--- a/include/types.h
+++ b/include/types.h
@@ -189,16 +189,18 @@ typedef struct _deprule_ignore_map_t {
  * reference.
  */
 typedef struct _rpmpeer_entry_t {
-    Header before_hdr;                /* RPM header of the before package */
-    Header after_hdr;                 /* RPM header of the after package */
-    char *before_rpm;                 /* full path to the before RPM */
-    char *after_rpm;                  /* full path to the after RPM */
-    char *before_root;                /* full path to the before RPM extracted root dir */
-    char *after_root;                 /* full path to the after RPM extracted root dir */
-    rpmfile_t *before_files;          /* list of files in the payload of the before RPM */
-    rpmfile_t *after_files;           /* list of files in the payload of the after RPM */
-    deprule_list_t *before_deprules;  /* dependency rules for the before RPM */
-    deprule_list_t *after_deprules;   /* dependency rules for the after RPM */
+    Header before_hdr;                       /* RPM header of the before package */
+    Header after_hdr;                        /* RPM header of the after package */
+    char *before_rpm;                        /* full path to the before RPM */
+    char *after_rpm;                         /* full path to the after RPM */
+    char *before_root;                       /* full path to the before RPM extracted root dir */
+    char *after_root;                        /* full path to the after RPM extracted root dir */
+    rpmfile_t *before_files;                 /* list of files in the payload of the before RPM */
+    rpmfile_t *after_files;                  /* list of files in the payload of the after RPM */
+    deprule_list_t *before_deprules;         /* dependency rules for the before RPM */
+    deprule_list_t *after_deprules;          /* dependency rules for the after RPM */
+    unsigned long int before_unpacked_size;  /* size of unpacked RPM payload */
+    unsigned long int after_unpacked_size;   /* size of unpacked RPM payload */
     TAILQ_ENTRY(_rpmpeer_entry_t) items;
 } rpmpeer_entry_t;
 

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -794,7 +794,7 @@ int gather_builds(struct rpminspect *ri, bool fo)
 
     /* did we get a before build specified? */
     if (ri->before == NULL) {
-        return 0;
+        return extract_peers(ri, fo);
     }
 
     whichbuild = BEFORE_BUILD;
@@ -847,5 +847,8 @@ int gather_builds(struct rpminspect *ri, bool fo)
      */
     init_arches(ri);
 
-    return 0;
+    /*
+     * extract the RPMs
+     */
+    return extract_peers(ri, fo);
 }


### PR DESCRIPTION
Split RPM extraction out to a new extract_peers() function and add a
disk space check that verifies the working directory has enough space
to hold all unpacked RPMs.

Fixes: #669

Signed-off-by: David Cantrell <dcantrell@redhat.com>