### PR TITLE
[lib] Add strexitcode() and RI_INSUFFICIENT_SPACE exit code

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -98,10 +98,11 @@ extern volatile sig_atomic_t terminal_resized;
  * Types of exit codes from the program.
  */
 enum {
-    RI_INSPECTION_SUCCESS = 0,   /* inspections passed */
+    RI_SUCCESS = 0,              /* everything ok */
     RI_INSPECTION_FAILURE = 1,   /* inspections failed */
     RI_PROGRAM_ERROR = 2,        /* program errored in some way */
-    RI_MISSING_PROFILE = 3       /* specified profile not found */
+    RI_MISSING_PROFILE = 3,      /* specified profile not found */
+    RI_INSUFFICIENT_SPACE = 4    /* insufficient disk space */
 };
 
 /*
@@ -211,6 +212,19 @@ char *strappend(char *, ...);
 string_list_t *strsplit(const char *, const char *);
 const char *strtype(const mode_t mode);
 char *strshorten(const char *s, size_t width);
+
+/**
+ * @brief Return descriptive string for the given exit code.
+ *
+ * Return the descriptive string for the specified program exit code.
+ * Unknown exit codes return "".  The caller must not free this
+ * string.
+ *
+ * @param exitcode The program exit code.
+ * @return Descriptive string for the specified exit code (do not
+ *         free!)
+ */
+const char *strexitcode(int exitcode);
 
 /* badwords.c */
 bool has_bad_word(const char *, const string_list_t *);

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -174,7 +174,7 @@ int extract_peers(struct rpminspect *ri, bool fetchonly)
     rpmpeer_entry_t *peer = NULL;
 
     if (fetchonly) {
-        return 0;
+        return RI_SUCCESS;
     }
 
     assert(ri != NULL);
@@ -194,7 +194,7 @@ int extract_peers(struct rpminspect *ri, bool fetchonly)
         fprintf(stderr, _("    Need %lu in %s, have %lu.\n"), need, ri->workdir, avail);
         fprintf(stderr, _("See the `-w' option for specifying an alternate working directory.\n"));
         fflush(stderr);
-        return -1;
+        return RI_INSUFFICIENT_SPACE;
     }
 
     /* unpack all RPMs */
@@ -215,5 +215,5 @@ int extract_peers(struct rpminspect *ri, bool fetchonly)
         }
     }
 
-    return 0;
+    return RI_SUCCESS;
 }

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -58,7 +58,8 @@ static int printword(const char *word, const size_t width, const unsigned int in
 /*
  * Returns true if s starts with prefix.
  */
-bool strprefix(const char *s, const char *prefix) {
+bool strprefix(const char *s, const char *prefix)
+{
     size_t plen;
 
     assert(s);
@@ -81,7 +82,8 @@ bool strprefix(const char *s, const char *prefix) {
  * Test if the string STR ends up with the string SUFFIX.
  * Both strings have to be NULL terminated.
  */
-bool strsuffix(const char *s, const char *suffix) {
+bool strsuffix(const char *s, const char *suffix)
+{
     int sl, xl;
 
     assert(s);
@@ -105,7 +107,8 @@ bool strsuffix(const char *s, const char *suffix) {
  * don't preformat your strings with two spaces after sentences and stuff
  * like that unless you weird looking word wrapped output.
  */
-int printwrap(const char *s, const size_t width, const unsigned int indent, FILE *dest) {
+int printwrap(const char *s, const size_t width, const unsigned int indent, FILE *dest)
+{
     int lines = 0;
     bool first = false;
     bool begin = false;
@@ -254,7 +257,8 @@ cleanup:
 /*
  * Given a severity_t, return a string representing the value.
  */
-char *strseverity(const severity_t severity) {
+char *strseverity(const severity_t severity)
+{
     switch (severity) {
         case RESULT_NULL:
             return _("NULL");
@@ -279,7 +283,8 @@ char *strseverity(const severity_t severity) {
  * Given a severity string, return a severity_t matching it.
  * Or return the default.
  */
-severity_t getseverity(const char *name, const severity_t default_s) {
+severity_t getseverity(const char *name, const severity_t default_s)
+{
     severity_t s = default_s;
 
     if (name == NULL) {
@@ -306,7 +311,8 @@ severity_t getseverity(const char *name, const severity_t default_s) {
 /*
  * Given a type of waiver authorization, return a string representing it.
  */
-char *strwaiverauth(const waiverauth_t waiverauth) {
+char *strwaiverauth(const waiverauth_t waiverauth)
+{
     switch (waiverauth) {
         case NOT_WAIVABLE:
             return _("Not Waivable");
@@ -617,4 +623,21 @@ char *strshorten(const char *s, size_t width)
     tail = stpcpy(tail, s);
 
     return r;
+}
+
+const char *strexitcode(int exitcode)
+{
+    if (exitcode == RI_SUCCESS) {
+        return _("Success.");
+    } else if (exitcode == RI_INSPECTION_FAILURE) {
+        return _("One or more inspections failed.");
+    } else if (exitcode == RI_PROGRAM_ERROR) {
+        return _("Program error.");
+    } else if (exitcode == RI_MISSING_PROFILE) {
+        return _("The specified profile is not found.");
+    } else if (exitcode == RI_INSUFFICIENT_SPACE) {
+        return _("Insufficient disk space in the working directory.");
+    }
+
+    return "";
 }

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -289,7 +289,7 @@ int main(int argc, char **argv)
     int i = 0;
     int j = 0;
     int idx = 0;
-    int ret = RI_INSPECTION_SUCCESS;
+    int ret = RI_SUCCESS;
     wordexp_t expand;
     struct stat sb;
     char *short_options = "c:p:T:E:a:r:no:F:lw:t:s:fkdDv\?V";
@@ -523,7 +523,7 @@ int main(int argc, char **argv)
             }
         }
 
-        exit(RI_INSPECTION_SUCCESS);
+        exit(RI_SUCCESS);
     }
 
     /*
@@ -644,7 +644,7 @@ int main(int argc, char **argv)
             free_rpminspect(ri);
 
             if (dump_config) {
-                return RI_INSPECTION_SUCCESS;
+                return RI_SUCCESS;
             } else {
                 warnx(_("*** Invalid before and after build specification."));
                 errx(RI_PROGRAM_ERROR, _("*** See `%s --help` for more information."), COMMAND_NAME);
@@ -722,12 +722,18 @@ int main(int argc, char **argv)
         for (i = optind; i < argc; i++) {
             ri->after = strdup(argv[i]);
             assert(ri->after != NULL);
+            i = gather_builds(ri, true);
 
-            if (gather_builds(ri, true)) {
+            if (i) {
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
-                errx(RI_PROGRAM_ERROR, _("*** failed to gather specified builds."));
+
+                if (i > 0) {
+                    errx(i, strexitcode(i));
+                } else {
+                    exit(i);
+                }
             }
 
             free(ri->after);
@@ -739,13 +745,20 @@ int main(int argc, char **argv)
         free_rpminspect(ri);
         rpmFreeMacros(NULL);
         rpmFreeRpmrc();
-        return RI_INSPECTION_SUCCESS;
+        return RI_SUCCESS;
     } else {
-        if (gather_builds(ri, false)) {
+        i = gather_builds(ri, false);
+
+        if (i) {
             free_rpminspect(ri);
             rpmFreeMacros(NULL);
             rpmFreeRpmrc();
-            errx(RI_PROGRAM_ERROR, _("*** failed to gather specified builds."));
+
+            if (i > 0) {
+                errx(i, strexitcode(i));
+            } else {
+                exit(i);
+            }
         }
     }
 


### PR DESCRIPTION
Fix up the exit codes for rpminspect and add a function that can
return the descriptive string of an error code.  Add
RI_INSUFFICIENT_SPACE for situations where insufficient disk space is
available for the operation.  This is 4, so at the shell you can check
$? for 4 to see if rpminspect is telling you it needs more disk space.

Signed-off-by: David Cantrell <dcantrell@redhat.com>