### PR TITLE
[cmd] Add missing format string to errx() calls

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -730,7 +730,7 @@ int main(int argc, char **argv)
                 rpmFreeRpmrc();
 
                 if (i > 0) {
-                    errx(i, strexitcode(i));
+                    errx(i, "%s", strexitcode(i));
                 } else {
                     exit(i);
                 }
@@ -755,7 +755,7 @@ int main(int argc, char **argv)
             rpmFreeRpmrc();
 
             if (i > 0) {
-                errx(i, strexitcode(i));
+                errx(i, "%s", strexitcode(i));
             } else {
                 exit(i);
             }


### PR DESCRIPTION
Two errx() calls were missing the format string.  Add those in to
suppress various versions of gcc and their worriedness.

Signed-off-by: David Cantrell <dcantrell@redhat.com>