### PR TITLE
[cmd] Match products with dist tags containing periods

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -149,7 +149,6 @@ static char *match_product(string_map_t *products, const char *candidate)
 static char *get_product_release(string_map_t *products, const favor_release_t favor_release, const char *before, const char *after)
 {
     int c;
-    char *pos = NULL;
     char *before_candidate = NULL;
     char *after_candidate = NULL;
     char *before_product = NULL;
@@ -158,9 +157,11 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
 
     assert(after != NULL);
 
-    pos = rindex(after, '.');
+    while (*after != '.' && *after != '\0') {
+        after++;
+    }
 
-    if (!pos) {
+    if (!after) {
         warnx(_("*** Product release for after build (%s) is empty"), after);
         return NULL;
     }
@@ -169,7 +170,7 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
      * Get the character after the last occurrence of a period. This should
      * tell us what release flag the product is.
      */
-    after_candidate = strdup(pos);
+    after_candidate = strdup(after);
 
     if (after_candidate == NULL) {
         warnx(_("*** Product release for after build (%s) is empty"), after);
@@ -183,15 +184,17 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
     after_candidate[strcspn(after_candidate, "/")] = 0;
 
     if (before) {
-        pos = rindex(before, '.');
+        while (*before != '.' && *before != '\0') {
+            before++;
+        }
 
-        if (!pos) {
+        if (!before) {
             warnx(_("*** Product release for before build (%s) is empty"), before);
             free(after_candidate);
             return NULL;
         }
 
-        before_candidate = strdup(pos);
+        before_candidate = strdup(before);
 
         if (before_candidate == NULL) {
             warnx(_("*** Product release for before build (%s) is empty"), before);


### PR DESCRIPTION
This bug affects a lot of packages.  Previously rpminspect lacked
support for dist tags with periods in them.  Let's say you had a dist
tag that looked like this:

    .el8_2.2

rpminspect would try to match the product name using the substring
".2".  The reason for this is the match_product() function was taking
the substring from the rindex() position of '.' in the dist tag, which
assumes there's only ever the leading period.

This patch changes the behavior to increment past any and all leading
periods and using the resulting string for the match test.

Signed-off-by: David Cantrell <dcantrell@redhat.com>