### PR TITLE
[lib] Display insufficient space messages in human readable sizes

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -522,4 +522,17 @@ curl_off_t curl_get_size(const char *src);
  */
 bool is_remote_rpm(const char *url);
 
+/* humansize.c */
+/**
+ * @brief Return human-readable size for the bytes given.
+ *
+ * Given a number of bytes, return a human-readable string
+ * representing that size.  The caller must free the returned string.
+ *
+ * @param bytes Number of bytes to convert.
+ * @return Allocated string containing human-readable size; caller
+ *         must free.
+ */
+char *human_size(const unsigned long bytes);
+
 #endif

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -236,6 +236,8 @@ static int copytree(const char *fpath, const struct stat *sb, int tflag, struct 
 static int download_build(const struct rpminspect *ri, const struct koji_build *build)
 {
     unsigned long avail = 0;
+    char *availh = NULL;
+    char *needh = NULL;
     size_t total_width = 0;
     koji_buildlist_entry_t *buildentry = NULL;
     koji_rpmlist_entry_t *rpm = NULL;
@@ -262,11 +264,16 @@ static int download_build(const struct rpminspect *ri, const struct koji_build *
     avail = get_available_space(workri->workdir);
 
     if (avail < build->total_size) {
+        availh = human_size(avail);
+        needh = human_size(build->total_size);
+
         fprintf(stderr, _("There is not enough available space to download the requested build.\n"));
-        fprintf(stderr, _("    Need %lu in %s, have %lu.\n"), build->total_size, workri->workdir, avail);
+        fprintf(stderr, _("    Need %s in %s, have %s.\n"), needh, workri->workdir, availh);
         fprintf(stderr, _("See the `-w' option for specifying an alternate working directory.\n"));
         fflush(stderr);
         rmtree(workri->worksubdir, true, false);
+        free(needh);
+        free(availh);
         return RI_INSUFFICIENT_SPACE;
     }
 
@@ -505,6 +512,8 @@ static int download_build(const struct rpminspect *ri, const struct koji_build *
 static int download_task(const struct rpminspect *ri, struct koji_task *task)
 {
     unsigned long avail = 0;
+    char *availh = NULL;
+    char *needh = NULL;
     size_t len;
     char *pkg = NULL;
     char *src = NULL;
@@ -550,11 +559,16 @@ static int download_task(const struct rpminspect *ri, struct koji_task *task)
     avail = get_available_space(workri->workdir);
 
     if (avail < task->total_size) {
+        availh = human_size(avail);
+        needh = human_size(task->total_size);
+
         fprintf(stderr, _("There is not enough available space to download the requested task.\n"));
-        fprintf(stderr, _("    Need %lu in %s, have %lu.\n"), task->total_size, workri->workdir, avail);
+        fprintf(stderr, _("    Need %s in %s, have %s.\n"), needh, workri->workdir, availh);
         fprintf(stderr, _("See the `-w' option for specifying an alternate working directory.\n"));
         fflush(stderr);
         rmtree(workri->worksubdir, true, false);
+        free(availh);
+        free(needh);
         return RI_INSUFFICIENT_SPACE;
     }
 
@@ -648,6 +662,8 @@ static int download_rpm(const char *rpm)
 {
     unsigned long avail = 0;
     unsigned long rpmsize = 0;
+    char *availh = NULL;
+    char *needh = NULL;
     char *pkg = NULL;
     char *dstdir = NULL;
     char *dst = NULL;
@@ -659,10 +675,15 @@ static int download_rpm(const char *rpm)
     avail = get_available_space(workri->workdir);
 
     if (avail < rpmsize) {
+        availh = human_size(avail);
+        needh = human_size(rpmsize);
+
         fprintf(stderr, _("There is not enough available space to download the requested RPM.\n"));
-        fprintf(stderr, _("    Need %lu in %s, have %lu.\n"), rpmsize, workri->workdir, avail);
+        fprintf(stderr, _("    Need %s in %s, have %s.\n"), needh, workri->workdir, availh);
         fprintf(stderr, _("See the `-w' option for specifying an alternate working directory.\n"));
         fflush(stderr);
+        free(availh);
+        free(needh);
         return RI_INSUFFICIENT_SPACE;
     }
 

--- a/lib/humansize.c
+++ b/lib/humansize.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <assert.h>
+#include <math.h>
+
+#include "rpminspect.h"
+
+char *human_size(const unsigned long bytes)
+{
+    char *r = NULL;
+    double s = 0;
+    char *units = "BKMGTPEZY";
+    char *begin = units;
+
+    s = (double) bytes;
+    units = begin;
+
+    while ((s > 1024) && (*(units + 1) != '\0')) {
+        s = round(s / 1024);
+        units++;
+    }
+
+    xasprintf(&r, "%lu %c%s", lround(s), *units, (*units == 'B') ? "" : "iB");
+    return r;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -32,6 +32,7 @@ librpminspect_sources = [
     'flags.c',
     'free.c',
     'fs.c',
+    'humansize.c',
     'init.c',
     'inspect.c',
     'inspect_addedfiles.c',
@@ -125,6 +126,7 @@ deps = [
     dl,
     icu_uc,
     icu_io,
+    m,
 ]
 
 if get_option('with_libkmod')

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -171,6 +171,8 @@ int extract_peers(struct rpminspect *ri, bool fetchonly)
 {
     unsigned long avail = 0;
     unsigned long need = 0;
+    char *availh = NULL;
+    char *needh = NULL;
     rpmpeer_entry_t *peer = NULL;
 
     if (fetchonly) {
@@ -190,10 +192,15 @@ int extract_peers(struct rpminspect *ri, bool fetchonly)
     avail = get_available_space(ri->workdir);
 
     if (avail < need) {
+        availh = human_size(avail);
+        needh = human_size(need);
+
         fprintf(stderr, _("There is not enough available space to unpack all of the RPMs.\n"));
-        fprintf(stderr, _("    Need %lu in %s, have %lu.\n"), need, ri->workdir, avail);
+        fprintf(stderr, _("    Need %s in %s, have %s.\n"), needh, ri->workdir, availh);
         fprintf(stderr, _("See the `-w' option for specifying an alternate working directory.\n"));
         fflush(stderr);
+        free(needh);
+        free(availh);
         return RI_INSUFFICIENT_SPACE;
     }
 

--- a/meson.build
+++ b/meson.build
@@ -204,6 +204,17 @@ endif
 
 dl = declare_dependency(link_args : ['-ldl'])
 
+# libm
+if not cc.has_function('round', args : ['-lm'])
+    error('*** unable to find round() in libm')
+endif
+
+if not cc.has_function('lround', args : ['-lm'])
+    error('*** unable to find lround() in libm')
+endif
+
+m = declare_dependency(link_args : ['-lm'])
+
 # Check for sys/queue.h
 if not cc.has_header('sys/queue.h')
     message('<sys/queue.h> not found, using bundled copy')


### PR DESCRIPTION
Add human_size() to convert number of bytes in to a human-readable
size for the purposes of the error message before rpminspect exists
with RI_INSUFFICIENT_SPACE.

Signed-off-by: David Cantrell <dcantrell@redhat.com>