### PR TITLE
[cmd] Careful cleanup with rmtree() on exit

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -898,7 +898,7 @@ int main(int argc, char **argv)
             printf(_("\nKeeping working directory: %s\n"), ri->worksubdir);
         } else {
             /* remove the working directories we can */
-            (void) rmtree(ri->workdir, true, true);
+            (void) rmtree(ri->worksubdir, true, false);
         }
     }
 


### PR DESCRIPTION
Only wipe the working subdirectory rather than everything in the
working directory.  This allows multiple rpminspect jobs to run
concurrently.

Signed-off-by: David Cantrell <dcantrell@redhat.com>