### PR TITLE
[lib] Doxygen comment work but also add and use missing remedy strings

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -22,7 +22,7 @@
 /**
  * @file constants.h
  * @author David Cantrell &lt;dcantrell@redhat.com&gt;
- * @date 2018-2020
+ * @date 2018
  * @brief Constants and other defaults for librpminspect.
  * @copyright LGPL-3.0-or-later
  */
@@ -31,13 +31,17 @@
 #define _LIBRPMINSPECT_CONSTANTS_H
 
 /**
- * @defgroup CONSTANTS Constants and Other Defaults
+ * @defgroup Constants and Other Defaults
+ *
+ * These macros define program defaults or other more or less standard
+ * things so that when we need to change the value in the code, we
+ * only need to change it in one place.
  *
  * @{
  */
 
 /**
- * @defgroup INTERNAL Internal defaults used throughout librpminspect
+ * @defgroup Internal defaults used throughout librpminspect
  *
  * @{
  */
@@ -52,6 +56,7 @@
 
 /**
  * @def SHARED_LIB_PREFIX
+ *
  * Filename prefix for shared libraries.
  */
 #define SHARED_LIB_PREFIX "lib"
@@ -75,37 +80,42 @@
 /** @} */
 
 /**
- * @defgroup CONFIG Configuration defaults
+ * @defgroup Configuration defaults
  *
  * @{
  */
 
 /**
  * @def COMMAND_NAME
+ *
  * The standard name for the rpminspect command.
  */
 #define COMMAND_NAME "rpminspect"
 
 /**
  * @def SOFTWARE_NAME
+ *
  * Software name.  Used in Koji XMLRPC calls and logging.
  */
 #define SOFTWARE_NAME "librpminspect"
 
 /**
  * @def CFGFILE_DIR
+ *
  * Configuration file directory.
  */
 #define CFGFILE_DIR "/usr/share/rpminspect"
 
 /**
  * @def CFGFILE
+ *
  * Default configuration file.
  */
 #define CFGFILE "rpminspect.yaml"
 
 /**
  * @def DEFAULT_WORKDIR
+ *
  * Default working directory location.  rpminspect will create
  * subdirectories within this directory so multiple concurrent jobs
  * can run.
@@ -114,6 +124,7 @@
 
 /**
  * @def VENDOR_DATA_DIR
+ *
  * Default location for the vendor-specific data.  These files should
  * be provided by the vendor-specific rpminspect-data package.
  */
@@ -121,6 +132,7 @@
 
 /**
  * @def INSPECTIONS
+ *
  * Name of the [inspections] section in the config file.
  */
 #define INSPECTIONS "inspections"
@@ -128,7 +140,7 @@
 /** @} */
 
 /**
- * @defgroup VENDOR_DATA_SUBDIRS Vendor Data Subdirectories
+ * @defgroup Vendor Data Subdirectories
  *
  * With a few exceptions, the files within vendor data subdirectories
  * will correspond to the product release rpminspect is using rules
@@ -146,30 +158,35 @@
 
 /**
  * @def ABI_DIR
+ *
  * Name of the ABI checking subdirectory in VENDOR_DATA_DIR.
  */
 #define ABI_DIR "abi"
 
 /**
  * @def CAPABILITIES_DIR
+ *
  * Name of the capabilities(7) subdirectory in VENDOR_DATA_DIR.
  */
 #define CAPABILITIES_DIR "capabilities"
 
 /**
  * @def LICENSES_DIR
+ *
  * Name of the license database subdirectory in VENDOR_DATA_DIR.
  */
 #define LICENSES_DIR "licenses"
 
 /**
  * @def FILEINFO_DIR
+ *
  * Name of the fileinfo (stat(2)) list subdirectory in VENDOR_DATA_DIR.
  */
 #define FILEINFO_DIR "fileinfo"
 
 /**
  * @def REBASEABLE_DIR
+ *
  * Name of the VENDOR_DATA_DIR subdirectory listing rebaseable
  * packages.  A rebaseable package is one where the version number
  * changes between the before and after build but is expected.
@@ -180,6 +197,7 @@
 
 /**
  * @def POLITICS_DIR
+ *
  * Name of the VENDOR_DATA_DIR subdirectory with political related
  * file inclusion and exclusion rules.
  */
@@ -187,6 +205,7 @@
 
 /**
  * @def SECURITY_DIR
+ *
  * Name of the VENDOR_DATA_DIR subdirectory with security related
  * package rules.
  */
@@ -194,6 +213,7 @@
 
 /**
  * @def ICONS_DIR
+ *
  * Name of the VENDOR_DATA_DIR subdirectory with standard icon names
  * defined per product.
  */
@@ -202,7 +222,8 @@
 /** @} */
 
 /**
- * @defgroup DESKTOP Desktop Constants
+ * @defgroup Desktop Constants
+ *
  * Constants related to desktop files.  Paths and where to find icons,
  * for instance.
  * @{
@@ -210,6 +231,7 @@
 
 /**
  * @def DESKTOP_ENTRY_FILES_DIR
+ *
  * Standard location for desktop entry files.
  */
 #define DESKTOP_ENTRY_FILES_DIR "/usr/share/applications"
@@ -217,7 +239,8 @@
 /** @} */
 
 /**
- * @defgroup COMMANDS Commands used by different inspections
+ * @defgroup Commands used by different inspections
+ *
  * Avoid explicit paths, rpminspect assumes these commands are
  * available in the $PATH.
  *
@@ -226,30 +249,35 @@
 
 /**
  * @def MSGUNFMT_CMD
+ *
  * Executable providing msgunfmt(1)
  */
 #define MSGUNFMT_CMD "msgunfmt"
 
 /**
  * @def DESKTOP_FILE_VALIDATE_CMD
+ *
  * Executable providing desktop-file-validate(1)
  */
 #define DESKTOP_FILE_VALIDATE_CMD "desktop-file-validate"
 
 /**
  * @def ANNOCHECK_CMD
+ *
  * Executable providing annocheck(1)
  */
 #define ANNOCHECK_CMD "annocheck"
 
 /**
  * @def ABIDIFF_CMD
+ *
  * Executable providing abidiff(1)
  */
 #define ABIDIFF_CMD "abidiff"
 
 /**
  * @def ABI_SUPPRESSION
+ *
  * The command line option for abidiff(1) to use the suppression
  * specification file in the named file.  rpminspect will find the
  * suppression specification file in t he source package, but needs to
@@ -259,6 +287,7 @@
 
 /**
  * @def ABI_DEBUG_INFO_DIR1
+ *
  * The command line option for abidiff(1) to specify the location of
  * debugging symbols for files in the before build.  For RPM packages,
  * this is a path to the corresponding directory in a debuginfo
@@ -268,6 +297,7 @@
 
 /**
  * @def ABI_DEBUG_INFO_DIR2
+ *
  * The command line option for abidiff(1) to specify the location of
  * debugging symbols for files in the after build.  For RPM packages,
  * this is a path to the corresponding directory in a debuginfo
@@ -277,6 +307,7 @@
 
 /**
  * @def ABI_HEADERS_DIR1
+ *
  * The command line option for abidiff(1) to specify the location of
  * public headers for the files in the before build.
  */
@@ -284,6 +315,7 @@
 
 /**
  * @def ABI_HEADERS_DIR2
+ *
  * The command line option for abidiff(1) to specify the location of
  * public headers for the files in the after build.
  */
@@ -291,6 +323,7 @@
 
 /**
  * @def KMIDIFF_CMD
+ *
  * Executable providing kmidiff(1), the Kernel Module Interface
  * comparison tool.
  */
@@ -298,6 +331,7 @@
 
 /**
  * @def KMIDIFF_VMLINUX1
+ *
  * The command line option to kmidiff(1) specifying the location of
  * the Linux kernel file in the before build.
  */
@@ -305,6 +339,7 @@
 
 /**
  * @def KMIDIFF_VMLINUX2
+ *
  * The command line option to kmidiff(1) specifying the location of
  * the Linux kernel file in the after build.
  */
@@ -312,6 +347,7 @@
 
 /**
  * @def KMIDIFF_KMI_WHITELIST
+ *
  * The command line option to kmidiff(1) used to specify the kernel
  * module interface whitelist.  rpminspect will find this file in the
  * source package, but it needs to know the command line option to use
@@ -322,19 +358,21 @@
 /** @} */
 
 /**
- * @defgroup SYSTEM System defaults
+ * @defgroup System defaults
  *
  * @{
  */
 
 /**
  * @def SRPM_ARCH_NAME
+ *
  * The architecture name Koji uses for source RPMs.
  */
 #define SRPM_ARCH_NAME "src"
 
 /**
  * @def RPM_NOARCH_NAME
+ *
  * The architecture name Koji uses for binary RPMs built with
  * 'BuildArch: noarch'
  */
@@ -342,48 +380,56 @@
 
 /**
  * @def BIN_OWNER
+ *
  * Default executable file owner.
  */
 #define BIN_OWNER "root"
 
 /**
  * @def BIN_GROUP
+ *
  * Default executable file group.
  */
 #define BIN_GROUP "root"
 
 /**
  * @def BUILD_ID_DIR
+ *
  * Build ID subdirectory name.
  */
 #define BUILD_ID_DIR "/.build-id/"
 
 /**
  * @def DEBUGINFO_SUFFIX
+ *
  * The debuginfo package name suffix string.
  */
 #define DEBUGINFO_SUFFIX "-debuginfo"
 
 /**
  * @def DEBUGSOURCE_SUFFIX
+ *
  * The debugsource package name suffix string.
  */
 #define DEBUGSOURCE_SUFFIX "-debugsource"
 
 /**
  * @def DEBUG_PATH
+ *
  * Where debuginfo packages are installed.
  */
 #define DEBUG_PATH "/usr/lib/debug/"
 
 /**
  * @def DEBUG_SRC_PATH
+ *
  * Where debugsource packages are installed.
  */
 #define DEBUG_SRC_PATH "/usr/src/debug/"
 
 /**
  * @def DEBUG_SUBSTRING
+ *
  * The substring that can appear in filenames installed with debugging
  * information.
  */
@@ -391,12 +437,14 @@
 
 /**
  * @def KERNEL_MODULES_DIR
+ *
  * Linux loadable kernel modules subdirectory.
  */
 #define KERNEL_MODULES_DIR "/lib/modules/"
 
 /**
  * @def ABIDIFF_SUPPRESSION_FILE
+ *
  * Default ABI suppression file in source packages.  If this file is
  * found in a source package, it will be passed to abidiff(1) using
  * the ABI_SUPPRESSIONS option.
@@ -405,18 +453,21 @@
 
 /**
  * @def INCLUDE_PATH
+ *
  * Default header file path.
  */
 #define INCLUDE_PATH "/usr/include/"
 
 /**
  * @def KERNEL_FILENAMES
+ *
  * Default array of kernel executable filename possibilities.
  */
 #define KERNEL_FILENAMES { "vmlinux", "vmlinuz", NULL }
 
 /**
  * @def KMI_IGNORE_PATTERN
+ *
  * File pattern used to find the Kernel Module Interface ignore list
  * for kmidiff(1).  The substring '${ARCH}' will be replaced with the
  * package architecture.
@@ -426,79 +477,91 @@
 /** @} */
 
 /**
- * @defgroup EXTENSIONS Filename extensions
+ * @defgroup Filename extensions
  *
  * @{
  */
 
 /**
  * @def RPM_FILENAME_EXTENSION
+ *
  * RPM filename extension
  */
 #define RPM_FILENAME_EXTENSION ".rpm"
 
 /**
  * @def SPEC_FILENAME_EXTENSION
+ *
  * RPM spec filename extension
  */
 #define SPEC_FILENAME_EXTENSION ".spec"
 
 /**
  * @def JAR_FILENAME_EXTENSION
+ *
  * Java jar filename extension
  */
 #define JAR_FILENAME_EXTENSION ".jar"
 
 /**
  * @def CLASS_FILENAME_EXTENSION
+ *
  * Java class filename extension
  */
 #define CLASS_FILENAME_EXTENSION ".class"
 
 /**
  * @def EGGINFO_FILENAME_EXTENSION
+ *
  * Python egg-info filename extension
  */
 #define EGGINFO_FILENAME_EXTENSION ".egg-info"
 
 /**
  * @def GZIPPED_FILENAME_EXTENSION
+ *
  * Gzip filename extension
  */
 #define GZIPPED_FILENAME_EXTENSION ".gz"
 
 /**
  * @def DESKTOP_FILENAME_EXTENSION
+ *
  * Desktop filename extension
  */
 #define DESKTOP_FILENAME_EXTENSION ".desktop"
 
 /**
  * @def DIRECTORY_FILENAME_EXTENSION
+ *
  * Directory filename extension
  */
 #define DIRECTORY_FILENAME_EXTENSION ".directory"
 
 /**
  * @def MO_FILENAME_EXTENSION
+ *
  * Machine object filename extension (compiled translation data)
  */
 #define MO_FILENAME_EXTENSION ".mo"
 
 /**
  * @def PYTHON_PYC_FILE_EXTENSION
+ *
  * Python bytecode filename extension
  */
 #define PYTHON_PYC_FILE_EXTENSION ".pyc"
 
 /**
  * @def PYTHON_PYO_FILE_EXTENSION
+ *
  * Python optimized bytecode filename extension
  */
 #define PYTHON_PYO_FILE_EXTENSION ".pyo"
 
 /**
  * @def KERNEL_MODULE_FILENAME_EXTENSION
+ *
  * Linux loadable kernel module filename extension.  Note that kernel
  * modules can be compressed with a typical compression appened after
  * this string.  rpminspect can handle those cases.
@@ -507,18 +570,21 @@
 
 /**
  * @def SVG_FILENAME_EXTENSION
+ *
  * Scalable vector graphics filename extension
  */
 #define SVG_FILENAME_EXTENSION ".svg"
 
 /**
  * @def STATIC_LIB_FILENAME_EXTENSION
+ *
  * Static ELF library filename extension
  */
 #define STATIC_LIB_FILENAME_EXTENSION ".a"
 
 /**
  * @def ELF_LIB_EXTENSION
+ *
  * ELF shared library extension.  Note that this extension appears in
  * the middle of ELF library filenames because a version number comes
  * after it.  For files that end with just '.so', we do not care so
@@ -530,43 +596,49 @@
 /** @} */
 
 /**
- * @defgroup SPEC RPM spec file defaults
+ * @defgroup RPM spec file defaults
  *
  * @{
  */
 
 /**
  * @def SPEC_MACRO_DEFINE
+ *
  * How macros are defined in spec files.
  */
 #define SPEC_MACRO_DEFINE      "%define"
 
 /**
  * @def SPEC_MACRO_GLOBAL
+ *
  * How global macros are defined in spec files.
  */
 #define SPEC_MACRO_GLOBAL      "%global"
 
 /**
  * @def SPEC_SECTION_CHANGELOG
+ *
  * How the change log is specified in the spec file.
  */
 #define SPEC_SECTION_CHANGELOG "%changelog"
 
 /**
  * @def SPEC_SECTION_FILES
+ *
  * How file listings are specified in the spec file.
  */
 #define SPEC_SECTION_FILES     "%files"
 
 /**
  * @def SPEC_TAG_RELEASE
+ *
  * The name of RPMTAG_RELEASE in a spec file.
  */
 #define SPEC_TAG_RELEASE       "Release:"
 
 /**
  * @def SPEC_DISTTAG
+ *
  * The distribution "dist tag" typically used in SPEC_TAG_RELEASE
  * strings.  Common in Fedora Linux and related distributions, but may
  * not be consistently defined in other RPM-based distributions.
@@ -576,7 +648,7 @@
 /** @} */
 
 /**
- * @defgroup RPMBUILD_SUBDIRS Subdirectory names used by rpmbuild(1)
+ * @defgroup Subdirectory names used by rpmbuild(1)
  *
  * Names of rpmbuild(1) subdirectories.  rpminspect models an rpmbuild
  * layout similar to how rpmbuild is used for distributions like
@@ -591,6 +663,7 @@
 
 /**
  * @def RPMBUILD_TOPDIR
+ *
  * The rpmbuild(1) top directory.  The directory where all other
  * rpmbuild(1) subdirectories live.
  */
@@ -598,6 +671,7 @@
 
 /**
  * @def RPMBUILD_BUILDDIR
+ *
  * The BUILD subdirectory name under RPMBUILD_TOPDIR.
  */
 #define RPMBUILD_BUILDDIR      "BUILD"
@@ -605,30 +679,35 @@
 
 /**
  * @def RPMBUILD_BUILDROOTDIR
+ *
  * The BUILDROOT subdirectory name under RPMBUILD_TOPDIR.
  */
 #define RPMBUILD_BUILDROOTDIR  "BUILDROOT"
 
 /**
  * @def RPMBUILD_RPMDIR
+ *
  * The RPMS subdirectory name under RPMBUILD_TOPDIR.
  */
 #define RPMBUILD_RPMDIR        "RPMS"
 
 /**
  * @def RPMBUILD_SOURCEDIR
+ *
  * The SOURCES subdirectory name under RPMBUILD_TOPDIR.
  */
 #define RPMBUILD_SOURCEDIR     "SOURCES"
 
 /**
  * @def RPMBUILD_SPECDIR
+ *
  * The SPECS subdirectory name under RPMBUILD_TOPDIR.
  */
 #define RPMBUILD_SPECDIR       "SPECS"
 
 /**
  * @def RPMBUILD_SRPMSDIR
+ *
  * The SRPMS subdirectory name under RPMBUILD_TOPDIR.
  */
 #define RPMBUILD_SRPMDIR       "SRPMS"
@@ -636,13 +715,14 @@
 /** @} */
 
 /**
- * @defgroup ABI_DEFAULTS abi inspection defaults
+ * @defgroup 'abi' inspection defaults
  *
  * @{
  */
 
 /**
  * @def DEFAULT_ABI_SECURITY_THRESHOLD
+ *
  * Default ABI compat level security reporting threshold.
  */
 #define DEFAULT_ABI_SECURITY_THRESHOLD 2
@@ -650,19 +730,21 @@
 /** @} */
 
 /**
- * @defgroup PATCHES_DEFAULTS patches inspection defaults
+ * @defgroup 'patches' inspection defaults
  *
  * @{
  */
 
 /**
  * @def DEFAULT_PATCH_FILE_THRESHOLD
+ *
  * Default file count reporting threshold for 'patches'
  */
 #define DEFAULT_PATCH_FILE_THRESHOLD 20
 
 /**
  * @def DEFAULT_PATCH_LINE_THRESHOLD
+ *
  * Default line count reporting threshold for 'patches'
  */
 #define DEFAULT_PATCH_LINE_THRESHOLD 5000
@@ -670,13 +752,14 @@
 /** @} */
 
 /**
- * @defgroup RUNPATH_DEFAULTS runpath inspection defaults
+ * @defgroup 'runpath' inspection defaults
  *
  * @{
  */
 
 /**
  * @def RUNPATH_ORIGIN_STR
+ *
  * The value of the DT_RPATH or DT_RUNPATH $ORIGIN string.
  */
 #define RUNPATH_ORIGIN_STR "$ORIGIN"

--- a/include/results.h
+++ b/include/results.h
@@ -19,79 +19,206 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-/*
- * This header defines the results constants.
- */
-
 #ifndef _LIBRPMINSPECT_RESULTS_H
 #define _LIBRPMINSPECT_RESULTS_H
 
-/*
- * Inspection remedies
+/**
+ * @defgroup Inspection remedy strings.
+ *
+ * The purpose of the inspection remedy strings is to give the user an
+ * idea of what the finding means when reading the results from
+ * rpminspect.  Explain what was found and what steps can be taken to
+ * correct the error or where to look for additional information.
+ *
+ * @{
  */
-/* metadata */
+
+/**
+ * @defgroup metadata inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_VENDOR _("Change the string specified on the 'Vendor:' line in the spec file.")
 #define REMEDY_BUILDHOST _("Make sure the SRPM is built on a host within the expected subdomain.")
 #define REMEDY_BADWORDS _("Unprofessional language as defined in the configuration file was found in the text shown.  Remove or change the offending words and rebuild.")
 
-/* emptyrpm */
+/** @} */
+
+/**
+ * @defgroup emptyrpm inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_EMPTYRPM _("Check to see if you eliminated a subpackage but still have the %package and/or the %files section for it.")
 
-/* lostpayload */
+/** @} */
+
+/**
+ * @defgroup lostpayload inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_LOSTPAYLOAD _("Check to see if you eliminated a subpackage but still have the %package and/or the %files section for it.")
 
-/* license */
+/** @} */
+
+/**
+ * @defgroup license inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_LICENSE _("The License tag must contain an approved license string as defined by the distribution (e.g., GPLv2+).  If the license in question is approved, the license database needs updating in the rpminspect-data package.")
 #define REMEDY_LICENSEDB _("Make sure the licensedb setting in the rpminspect configuration is set to a valid licensedb file.  This is also commonly due to a missing vendor specific rpminspect-data package on the system.")
 #define REMEDY_UNAPPROVED_LICENSE _("The specified license abbreviation is not listed as approved in the license database.  The license database is specified in the rpminspect configuration file.  Check this file and send a pull request to the appropriate upstream project to update the database.  If the license is listed in the database but marked unapproved, you may need to work with the legal team regarding options for this software.")
 
-/* elf */
+/** @} */
+
+/**
+ * @defgroup elf inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_ELF_TEXTREL _("Ensure all object files are compiled with -fPIC")
 #define REMEDY_ELF_EXECSTACK_MISSING _("Ensure that the package is being built with the correct compiler and compiler flags")
 #define REMEDY_ELF_EXECSTACK_INVALID _("The data in an ELF file appears to be corrupt; ensure that packaged ELF files are not being truncated or incorrectly modified")
 #define REMEDY_ELF_EXECSTACK_EXECUTABLE _("An ELF stack is marked as executable. Ensure that no execstack options are being passed to the linker, and that no functions are defined on the stack.")
 #define REMEDY_ELF_GNU_RELRO _("Ensure executables are linked with with '-z relro -z now'")
 #define REMEDY_ELF_FPIC _("Ensure all object files are compiled with -fPIC")
-#define REMEDY_ELF_IPV6 _("Please review all usages of IPv4-only functions and ensure IPv6 compliance.")
 
-/* man */
+/** @} */
+
+/**
+ * @defgroup man inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_MAN_ERRORS _("Correct the errors in the man page as reported by the libmandoc parser.")
 #define REMEDY_MAN_PATH _("Correct the installation path for the man page. Man pages must be installed in the directory beneath /usr/share/man that matches the section number of the page.")
 
-/* xml */
+/** @} */
+
+/**
+ * @defgroup xml inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_XML _("Correct the reported errors in the XML document")
 
-/* desktop */
+/** @} */
+
+/**
+ * @defgroup desktop inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_DESKTOP _("Refer to the Desktop Entry Specification at https://standards.freedesktop.org/desktop-entry-spec/latest/ for help correcting the errors and warnings")
 
-/* disttag */
+/** @} */
+
+/**
+ * @defgroup disttag inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_DISTTAG _("The Release: tag in the spec file must include a '%{?dist}' string.  Please add this to the spec file per the distribution packaging guidelines.")
 
-/* specname */
+/** @} */
+
+/**
+ * @defgroup specname inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_SPECNAME _("The spec file name does not match the expected NAME.spec format.  Rename the spec file to conform to this policy.")
 
-/* modularity */
+/** @} */
+
+/**
+ * @defgroup modularity inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_MODULARITY _("This package is part of a module but is missing the %{modularitylabel} header tag.  Add this as a %define in the spec file and rebuild.")
 
-/* javabytecode */
+/** @} */
+
+/**
+ * @defgroup javabytecode inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_JAVABYTECODE _("The Java bytecode version for one or more class files in the build was not met for the product release.  Ensure you are using the correct JDK for the build.")
 
-/* changedfiles */
+/** @} */
+
+/**
+ * @defgroup changedfiles inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_CHANGEDFILES _("Unexpected file changes were found.  Verify these changes are correct.  If they are not, adjust the build to prevent file changes.")
 
-/* movedfiles */
+/** @} */
+
+/**
+ * @defgroup movedfiles inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_MOVEDFILES _("Unexpected file moves were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file moves between builds.")
 
-/* removedfiles */
+/** @} */
+
+/**
+ * @defgroup removedfiles inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_REMOVEDFILES _("Unexpected file removals were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file removals between builds.")
 
-/* addedfiles */
+/** @} */
+
+/**
+ * @defgroup addedfiles inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_ADDEDFILES _("Unexpected file additions were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file additions between builds.  If they are correct, update %s and send a patch to the rpminspect data project owning that file so rpminspect knows to expect this change.  You may also need to update the data package or local configuration file and change the forbidden_path_prefixes or forbidden_path_suffixes list.")
 
-/* upstream */
+/** @} */
+
+/**
+ * @defgroup upstream inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_UPSTREAM _("Unexpected changed source archive content. The version of the package did not change between builds, but the source archive content did. This may be deliberate, but needs inspection. If this change is expected, update %s and send a patch to the project that owns that file.")
 
-/* ownership */
+/** @} */
+
+/**
+ * @defgroup ownership inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_OWNERSHIP_DEFATTR _("Make sure the %%files section includes the %%defattr macro. If these permissions are expected, update %s and send a patch to the project that owns it.")
 #define REMEDY_OWNERSHIP_BIN_OWNER _("Bin path files must be owned by the bin_owner set in the rpminspect configuration, which is usually root. If this ownership is expected, update %s and send a patch to the project that owns it.")
 #define REMEDY_OWNERSHIP_BIN_GROUP _("Bin path files must be owned by the bin_group set in the rpminspect configuration, which is usually root. If this ownership is expect, update %s and send a patch to the project that owns it.")
@@ -99,92 +226,269 @@
 #define REMEDY_OWNERSHIP_IWGRP _("Either chgrp the file to the bin_group set in the rpminspect configuration or remove the group write bit on the file (chmod g-w). If this ownership is expected, update %s and send a patch to the project that owns it.")
 #define REMEDY_OWNERSHIP_CHANGED _("Verify the ownership changes are expected. If not, adjust the package build process to set correct owner and group information. If expected, update %s and send a patch to the project that owns it.")
 
-/* shellsyntax */
+/** @} */
+
+/**
+ * @defgroup shellsyntax inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_SHELLSYNTAX _("Consult the shell documentation for proper syntax.")
 #define REMEDY_SHELLSYNTAX_GAINED_SHELL _("The file referenced was not a known shell script in the before build but is now a shell script in the after build.")
 #define REMEDY_SHELLSYNTAX_BAD _("The referenced shell script is invalid. Consider debugging it with the '-n' option on the shell to find and fix the problem.")
 
-/* annocheck */
+/** @} */
+
+/**
+ * @defgroup annocheck inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_ANNOCHECK _("See annocheck(1) for more information.")
 #define REMEDY_ANNOCHECK_FORTIFY_SOURCE _("Ensure all object files are compiled with '-O2 -D_FORTIFY_SOURCE=2', and that all appropriate headers are included (no implicit function declarations). Symbols may also appear as unfortified if the compiler is unable to determine the size of a buffer, which is not necessarily an error.")
 
-/* dsodeps */
+/** @} */
+
+/**
+ * @defgroup dsodeps inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_DSODEPS _("DT_NEEDED symbols have been added or removed.  This happens when the build environment has different versions of the required libraries.  Sometimes this is deliberate but sometimes not.  Verify these changes are expected.  If they are not, modify the package spec file to ensure the build links with the correct shared libraries.")
 
-/* filesize */
+/** @} */
+
+/**
+ * @defgroup filesize inspection remedy strings
+ *
+ * @{
+ */
+
+#define REMEDY_FILESIZE_GREW _("A file grew by a noticeable amount.  Ensure this change is intended.  If it is, you can adjust the filesize inspection settings in the rpminspect.yaml file.")
+#define REMEDY_FILESIZE_SHRANK _("A file shrank by a noticeable amount.  Ensure this change is intended.  If it is, you can adjust the filesize inspection settings in the rpminspect.yaml file.")
 #define REMEDY_FILESIZE_BECAME_NOT_EMPTY _("A previously empty file is no longer empty.  Make sure this change is intended and fix the package spec file if necessary.")
 #define REMEDY_FILESIZE_BECAME_EMPTY _("A previously non-empty file is now empty.  Make sure this change is intended and fix the package space file if necessary.")
 
-/* capabilities */
+/** @} */
+
+/**
+ * @defgroup capabilities inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_CAPABILITIES _("Unexpected capabilities were found on the indicated file.  Consult capabilities(7) and either adjust the files in the package or modify the capabilities list in the rpminspect vendor data package.  The security team may also be of help for this situation.  If necessary, update %s with the changes found here and send a patch to the project that owns the data file.")
 
-/* kmod */
+/** @} */
+
+/**
+ * @defgroup kmod inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_KMOD_PARM _("Kernel module parameters were removed between builds.  This may present usability problems for users if module parameters were removed in a maintenance update.")
 #define REMEDY_KMOD_DEPS _("Kernel module dependencies changed between builds.  This may present usability problems for users if module dependencies changed in a maintenance update.")
 #define REMEDY_KMOD_ALIAS _("Kernel module device aliases changed between builds.  This may present usability problems for users if module device aliases changed in a maintenance update.")
 
-/* arch */
+/** @} */
+
+/**
+ * @defgroup arch inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_ARCH_LOST _("An architecture present in the before build is now missing in the after build.  This may be deliberate, but check to make sure you do not have any unexpected ExclusiveArch lines in the spec file.")
 #define REMEDY_ARCH_GAIN _("A new architecture has appeared in the after build.  This may indicate progress in the world of computing.")
 
-/* subpackages */
+/** @} */
+
+/**
+ * @defgroup subpackages inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_SUBPACKAGES_LOST _("A subpackage present in the before build is now missing in the after build.  This may be deliberate, but check to make sure you have correct syntax defining the subpackage in the spec file")
 #define REMEDY_SUBPACKAGES_GAIN _("A new subpackage has appeared in the after build.  This may indicate progress in the world of computing.")
 
-/* changelog */
+/** @} */
+
+/**
+ * @defgroup changelog inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_CHANGELOG _("Make sure the spec file in the after build contains a valid %changelog section.")
 
-/* pathmigration */
+/** @} */
+
+/**
+ * @defgroup pathmigration inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_PATHMIGRATION _("Files should not be installed in old directory names.  Modify the package to install the affected file to the preferred directory.")
 
-/* lto */
+/** @} */
+
+/**
+ * @defgroup lto inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_LTO _("ELF .o and .a files should not carry LTO (Link Time Optimization) bytecode.  Make sure you have stripped LTO bytecode from those files at install time.")
 
-/* symlinks */
+/** @} */
+
+/**
+ * @defgroup symlinks inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_SYMLINKS _("Make sure symlinks point to a valid destination in one of the subpackages of the build; dangling symlinks are not allowed.  If you are comparing builds and have a non-symlink turn in to a symlink, ensure this is deliberate.  NOTE:  You cannot turn a directory in to a symlink due to RPM limitations.");
 #define REMEDY_SYMLINKS_DIRECTORY _("Make sure symlinks point to a valid destination in one of the subpackages of the build; dangling symlinks are not allowed.  If you are comparing builds and have a non-symlink turn in to a symlink, ensure this is deliberate.  NOTE:  You cannot turn a directory in to a symlink due to RPM limitations.  If you absolutely must do that, make sure you include the %pretrans scriptlet for replacing a directory.  See the packaging guidelines for 'Scriptlet to replace a directory' for more information.");
 
-/* files */
+/** @} */
+
+/**
+ * @defgroup files inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_FILES _("Remove forbidden path references from the indicated line in the %files section.  In many cases you can use RPM macros to specify path locations.  See the RPM documentation or distribution package maintainer guide for more information.")
 
-/* types */
+/** @} */
+
+/**
+ * @defgroup types inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_TYPES _("In many cases the changing MIME type is deliberate.  Verify that the change is intended and if necessary fix the spec file so the correct file is included in the built package.")
 
-/* abidiff */
+/** @} */
+
+/**
+ * @defgroup abidiff inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_ABIDIFF _("ABI changes introduced during maintenance updates can lead to problems for users.  See the abidiff(1) documentation and the distribution ABI policies to determine if this detected change is allowed.")
 
-/* kmidiff */
+/** @} */
+
+/**
+ * @defgroup kmidiff inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_KMIDIFF _("Kernel Module Interface introduced during maintenance updates can lead to problems for users.  See the libabigail documentation and the distribution KMI policy to determine if this detected change is allowed.")
 
-/* config */
+/** @} */
+
+/**
+ * @defgroup config inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_CONFIG _("Changes to %config should be done carefully.  Make sure you have installed the correct file and in the correct location.  If a package is restructuring configuration files, make sure the package can handle upgrading an existing package -or- honor the old file locations.")
 
-/* doc */
+/** @} */
+
+/**
+ * @defgroup doc inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_DOC _("Changes found among the %doc files.  Verify these changes are intended if the package is not a rebase.  Sometimes upstream projects rename or move documentation files and the spec file needs to account for those changes.")
 
-/* patches */
+/** @} */
+
+/**
+ * @defgroup patches inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_PATCHES_CORRUPT _("An invalid patch file was found.  This is usually the result of generating a collection of patches by comparing two trees.  When files disappear that can lead to zero length patches in the resulting collection.  Check to see if the source package has any zero length or otherwise invalid patches and correct the problem.")
 
-/* virus */
+/** @} */
+
+/**
+ * @defgroup virus inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_VIRUS _("ClamAV has found a virus in the named file.  This may be a false positive, but you should manually inspect the file in question to ensure it is clean.  This may be a problem with the ClamAV database or detection.  If you are sure the file in question is clean, please file a bug with rpminspect for further help.")
 
-/* politics */
+/** @} */
+
+/**
+ * @defgroup politics inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_POLITICS _("A file with potential politically sensitive content was found in the package.  If this file is permitted, it should be added to the rpminspect vendor data package for the product.  Modify the %s file and send a patch to the project that owns it.")
 
-/* badfuncs */
+/** @} */
+
+/**
+ * @defgroup badfuncs inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_BADFUNCS _("Forbidden symbols were found in an ELF file in the package.  The configuration settings for rpminspect indicate the named symbols are forbidden in packages.  If this is deliberate, you may want to disable the badfuncs inspection.  If it is not deliberate, check the man pages for the named symbols to see what API functions have replaced the forbidden symbols.  Usually a function is marked as deprecated but still provided in order to allow for backwards compatibility.  Whenever possible the deprecated functions should not be used.")
 
-/* runpath */
+/** @} */
+
+/**
+ * @defgroup runpath inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_RUNPATH _("Either DT_RPATH or DT_RUNPATH properties were found on ELF shared objects in this package.  The use of DT_RPATH and DT_RUNPATH is discouraged except in certain situations.  Check to see that you a disabling rpath during the %build stage of the spec file.  If you are unable to do this easily, you can try using a program such as patchelf to remove these properties from the ELF files.")
 
 #define REMEDY_RUNPATH_BOTH _("Both DT_RPATH and DT_RUNPATH properties were found in an ELF shared object.  This indicates a linker error and should not happen.  ELF objects should only carry DT_RPATH or DT_RUNPATH, never both.")
 
-/* unicode */
+/** @} */
+
+/**
+ * @defgroup unicode inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_UNICODE _("The rpminspect configuration file contains a list of forbidden Unicode code points.  One was found in the extracted and patched source tree or in one of the text source files in the source RPM.  Either remove this code point or discuss the situation with the Product Security Team to determine the correct course of action.")
 
 #define REMEDY_UNICODE_PREP_FAILED _("The %prep section of the spec file could not be executed for some reason.  This usually results from a failure in librpmbuild, which is usually tied to archive extraction problems or the filesystem changing while rpminspect is running.  A common cause is removal of the working directory while the program is executing.")
 
-/* rpmdeps */
+/** @} */
+
+/**
+ * @defgroup rpmdeps inspection remedy strings
+ *
+ * @{
+ */
+
 #define REMEDY_RPMDEPS_MACROS _("Unexpanded RPM spec file macros were found in the noted dependency rule.  Check the spec file for this dependency and ensure you have not misspelled a macro or used a macro name that does not exist.")
 
 #define REMEDY_RPMDEPS_EXPLICIT _("Add the indicated explicit Requires to the spec file for the named subpackage.  Subpackages depending on shared libraries in another subpackage must carry an explicit 'Requires: SUBPACKAGE_NAME = %{version}-%{release}' in the spec file.")
@@ -200,5 +504,9 @@
 #define REMEDY_RPMDEPS_LOST _("A dependency seen in the before build is not seen in the after build meaning it was removed or lost.  If this is a VERIFY result, it means rpminspect noticed the change in what it considers a maintenance update in a package.  An INFO result means it noticed this change, but deems it ok because it is comparing a rebased build.")
 
 #define REMEDY_RPMDEPS_EPOCH _("The package has an Epoch value greater than zero, but the explicit subpackage dependencies are not consistently using it.  For the dependency reported, the '= %{version}-%{release}' needs to change to '= %{epoch}:%{version}-%{release}' to capture the package package Epoch in the dependency.")
+
+/** @} */
+
+/** @} */
 
 #endif

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -59,16 +59,16 @@ extern volatile sig_atomic_t terminal_resized;
 /* Macros */
 #ifdef NDEBUG
 /* Don't create unused variables if not using assert() */
-#define xasprintf(dest, ...) {                   \
-    *(dest) = NULL;                              \
-    asprintf((dest), __VA_ARGS__);               \
+#define xasprintf(dest, ...) {                         \
+    *(dest) = NULL;                                    \
+    asprintf((dest), __VA_ARGS__);                     \
 }
 #else
-#define xasprintf(dest, ...) {                   \
-    int _xasprintf_result;                       \
-    *(dest) = NULL;                              \
-    _xasprintf_result = asprintf((dest), __VA_ARGS__);\
-    assert(_xasprintf_result != -1);             \
+#define xasprintf(dest, ...) {                         \
+    int _xasprintf_result;                             \
+    *(dest) = NULL;                                    \
+    _xasprintf_result = asprintf((dest), __VA_ARGS__); \
+    assert(_xasprintf_result != -1);                   \
 }
 #endif
 

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -83,6 +83,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
         params.noun = _("non-empty ${FILE} on ${ARCH}");
+        params.remedy = REMEDY_FILESIZE_BECAME_NOT_EMPTY;
         result = false;
     } else if (file->st.st_size == 0 && file->peer_file->st.st_size > 0) {
         /* became empty */
@@ -91,6 +92,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
         params.noun = _("empty ${FILE} on ${ARCH}");
+        params.remedy = REMEDY_FILESIZE_BECAME_EMPTY;
         result = false;
     } else {
         change = ((file->st.st_size - file->peer_file->st.st_size) * 100 / file->peer_file->st.st_size);
@@ -109,10 +111,12 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             /* file grew */
             xasprintf(&params.msg, _("%s grew by %lld%% on %s"), file->localpath, llabs(change), arch);
             params.noun = _("${FILE} size grew on ${ARCH}");
+            params.remedy = REMEDY_FILESIZE_GREW;
         } else if (change < 0) {
             /* file shrank */
             xasprintf(&params.msg, _("%s shrank by %lld%% on %s"), file->localpath, llabs(change), arch);
             params.noun = _("${FILE} size shrank on ${ARCH}");
+            params.remedy = REMEDY_FILESIZE_SHRANK;
         }
     }
 
@@ -120,6 +124,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (ri->size_threshold == -1) {
         params.severity = RESULT_INFO;
         params.verb = VERB_OK;
+        params.remedy = NULL;
     }
 
     /* Reporting */

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -111,6 +111,7 @@ static bool check_class_file(struct rpminspect *ri, const char *fullpath, const 
     params.header = NAME_JAVABYTECODE;
     params.verb = VERB_FAILED;
     params.file = localpath;
+    params.remedy = REMEDY_JAVABYTECODE;
 
     /* try to see if this is just a .class file */
     major = get_jvm_major(fullpath, localpath, container);

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -57,10 +57,12 @@ static bool movedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.severity = RESULT_INFO;
         params.waiverauth = NOT_WAIVABLE;
         params.verb = VERB_OK;
+        params.remedy = NULL;
     } else {
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
+        params.remedy = REMEDY_MOVEDFILES;
     }
 
     xasprintf(&noun, _("%s moved to ${FILE} on ${ARCH}"), file->peer_file->localpath);


### PR DESCRIPTION
Working on documenting the remedy strings in results.h, remove unused
strings but also add in some missing ones.  In the library code, make
sure to set remedy strings in inspections where they were missing.  I
guess if no one has reported these by now, no one really pays
attention to them.

Signed-off-by: David Cantrell <dcantrell@redhat.com>