### PR TITLE
[fix] Correct the reporting of kmod parameter differences

### DIFF
--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -139,12 +139,12 @@ static void convert_module_dependencies(string_list_t *list, const struct kmod_l
  */
 bool compare_module_parameters(const struct kmod_list *before, const struct kmod_list *after, string_list_t **lost, string_list_t **gain)
 {
-    string_list_t *before_parm_list;
-    string_list_t *after_parm_list;
-    string_list_t *difference;
-    string_list_t *added;
-
-    bool result;
+    string_list_t *before_parm_list = NULL;
+    string_list_t *after_parm_list = NULL;
+    string_list_t *difference = NULL;
+    string_list_t *added = NULL;
+    string_list_t *combined = NULL;
+    bool result = true;
 
     assert(before);
     assert(after);
@@ -156,9 +156,14 @@ bool compare_module_parameters(const struct kmod_list *before, const struct kmod
     DEBUG_PRINT("after module\n");
     after_parm_list = modinfo_to_list(after, convert_module_parameters);
 
-    /* diff the parameter lists */
+    /* parameters present in both modules */
+    combined = list_intersection(before_parm_list, after_parm_list);
+
+    /* diff the parameter lists to get lost parameters */
     difference = list_difference(before_parm_list, after_parm_list);
-    added = list_difference(after_parm_list, before_parm_list);
+
+    /* gather any new parameters */
+    added = list_difference(after_parm_list, combined);
 
     /* If the lists are empty, everything is fine.
      * Otherwise, make a copy of difference so we can clean everything up
@@ -181,6 +186,7 @@ bool compare_module_parameters(const struct kmod_list *before, const struct kmod
     list_free(difference, NULL);
     list_free(before_parm_list, free);
     list_free(after_parm_list, free);
+    list_free(combined, free);
 
     return result;
 }

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -141,6 +141,10 @@ string_list_t *list_difference(const string_list_t *a, const string_list_t *b)
     /* Copy list b into a hash table */
     b_table = list_to_table(b);
 
+    if (b_table == NULL) {
+        return NULL;
+    }
+
     /* Iterate through list a looking for things not in list b */
     TAILQ_FOREACH(iter, a, items) {
         HASH_FIND_STR(b_table, iter->data, hentry);


### PR DESCRIPTION
This one was hiding in plain sight, but fortunately reported by a
kernel developer.  The code in librpminspect was correctly determining
the kernel module parameter lists differed between the before and
after build, but the reporting made no sense.  It said the module in
the after build both lost and gained the same parameter.

Digging in to it, I made the messages reported by the kmod inspection
a little more explicit.  Telling you what file the issue was found in
and what it was compared to.  The other problem was in
compare_module_parameters().  It was incorrectly computing a list of
added module parameters.  To get that list, the function should have
first intersected the list of before and after parameters, then
computed the difference between that list and the after parameter
list.  Doing that took away the erroneous 'added' reporting.

Fixes: #678

Signed-off-by: David Cantrell <dcantrell@redhat.com>