### PR TITLE
[lib] Drop the file count and line count checks in 'patches'

### DIFF
--- a/MISSING
+++ b/MISSING
@@ -60,3 +60,13 @@ TEST_METADATA (the 'fedora without red hat' string check)
     check itself was not foolproof and did not take in to account word
     boundaries of pathnames.  This kind of check is out of scope for
     rpminspect as it provides no technical or security benefit.
+
+TEST_PATCHES (the file and line count thresholds as failures)
+    The patches inspection will report changes between patches across
+    builds, both the number of lines and number of files touched.
+    However, all of these results are reported as INFO and there is no
+    support for a line count or file count threshold.  These are
+    subjective anyway and impossible to come up with what is allowable
+    or not.  The patches inspection does check for malformed patches
+    and compressed patches that cannot be uncompressed and will report
+    those as well.

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -681,18 +681,6 @@ patches:
     #ignore_list:
     #    - example.patch
 
-    # Reporting threshold for number of files that a patch modifies.
-    # If a patch modifies more than this number of files, the
-    # reporting message will mention it explicitly.  The default is
-    # 20 files.
-    file_count_threshold: 20
-
-    # Reporting theshold for number of lines that a patch modifies.
-    # If a patch modifies more than this number of lines, the
-    # reporting message will mention it explicitly.  The default is
-    # 5000 lines.
-    line_count_threshold: 5000
-
 badfuncs:
     # Shared function names prohibited from executables and libraries.
     # The function names listed here are generally ones provided by

--- a/include/constants.h
+++ b/include/constants.h
@@ -730,28 +730,6 @@
 /** @} */
 
 /**
- * @defgroup 'patches' inspection defaults
- *
- * @{
- */
-
-/**
- * @def DEFAULT_PATCH_FILE_THRESHOLD
- *
- * Default file count reporting threshold for 'patches'
- */
-#define DEFAULT_PATCH_FILE_THRESHOLD 20
-
-/**
- * @def DEFAULT_PATCH_LINE_THRESHOLD
- *
- * Default line count reporting threshold for 'patches'
- */
-#define DEFAULT_PATCH_LINE_THRESHOLD 5000
-
-/** @} */
-
-/**
  * @defgroup 'runpath' inspection defaults
  *
  * @{

--- a/include/types.h
+++ b/include/types.h
@@ -610,12 +610,6 @@ struct rpminspect {
     /* list of patches to ignore in the 'patches' inspection */
     string_list_t *patch_ignore_list;
 
-    /* file count reporting threshold in the 'patches' inspection */
-    long int patch_file_threshold;
-
-    /* line count reporting threshold in the 'patches' inspection */
-    long int patch_line_threshold;
-
     /* runpath inspection lists */
     string_list_t *runpath_allowed_paths;
     string_list_t *runpath_allowed_origin_paths;

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -614,9 +614,6 @@ void dump_cfg(const struct rpminspect *ri)
         }
     }
 
-    printf("    file_count_threshold: %ld\n", ri->patch_file_threshold);
-    printf("    line_count_threshold: %ld\n", ri->patch_line_threshold);
-
     /* badfuncs */
 
     HASH_FIND_STR(ri->inspection_ignores, NAME_BADFUNCS, mapentry);

--- a/lib/init.c
+++ b/lib/init.c
@@ -854,7 +854,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             block = BLOCK_IGNORE;
                         }
                     } else if (group == BLOCK_PATCHES) {
-                        if (!strcmp(key, "patch_ignore_list")) {
+                        if (!strcmp(key, "ignore_list")) {
                             block = BLOCK_PATCH_FILENAMES;
                             list_free(ri->patch_ignore_list, free);
                             ri->patch_ignore_list = NULL;
@@ -1182,22 +1182,6 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         } else if (!strcmp(key, "kabi_filename")) {
                             free(ri->kabi_filename);
                             ri->kabi_filename = strdup(t);
-                        }
-                    } else if (group == BLOCK_PATCHES) {
-                        if (!strcmp(key, "file_count_threshold")) {
-                            ri->patch_file_threshold = strtol(t, 0, 10);
-
-                            if ((ri->patch_file_threshold == LONG_MIN || ri->patch_file_threshold == LONG_MAX) && errno == ERANGE) {
-                                warn("strtol");
-                                ri->patch_file_threshold = DEFAULT_PATCH_FILE_THRESHOLD;
-                            }
-                        } else if (!strcmp(key, "line_count_threshold")) {
-                            ri->patch_line_threshold = strtol(t, 0, 10);
-
-                            if ((ri->patch_line_threshold == LONG_MIN || ri->patch_line_threshold == LONG_MAX) && errno == ERANGE) {
-                                warn("strtol");
-                                ri->patch_line_threshold = DEFAULT_PATCH_LINE_THRESHOLD;
-                            }
                         }
                     } else if (group == BLOCK_UNICODE && block == BLOCK_UNICODE_EXCLUDE) {
                         if (add_regex(t, &ri->unicode_exclude) != 0) {
@@ -2055,8 +2039,6 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         ri->abi_security_threshold = DEFAULT_ABI_SECURITY_THRESHOLD;
         ri->kmidiff_suppression_file = strdup(ABI_SUPPRESSION_FILE);
         ri->kmidiff_debuginfo_path = strdup(DEBUG_PATH);
-        ri->patch_file_threshold = DEFAULT_PATCH_FILE_THRESHOLD;
-        ri->patch_line_threshold = DEFAULT_PATCH_LINE_THRESHOLD;
         ri->annocheck_failure_severity = RESULT_VERIFY;
 
         /* Initialize commands */

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-import yaml
 import rpmfluff
 
 from baseclass import TestSRPM, TestCompareSRPM
@@ -240,7 +239,7 @@ class PatchAddedInRebaseCompare(TestCompareSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-# patch touches too many files (VERIFY)
+# patch touches too many files (INFO)
 class PatchTouchesTooManyFiles(TestSRPM):
     def setUp(self):
         super().setUp()
@@ -251,22 +250,8 @@ class PatchTouchesTooManyFiles(TestSRPM):
         )
 
         self.inspection = "patches"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
-
-    def configFile(self):
-        super().configFile()
-
-        # modify the threshold for the test run (set it to two files)
-        instream = open(self.conffile, "r")
-        cfg = yaml.full_load(instream)
-        instream.close()
-
-        cfg["patches"]["file_count_threshold"] = "2"
-
-        outstream = open(self.conffile, "w")
-        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
-        outstream.close()
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class PatchTouchesTooManyFilesCompare(TestCompareSRPM):
@@ -279,25 +264,11 @@ class PatchTouchesTooManyFilesCompare(TestCompareSRPM):
         )
 
         self.inspection = "patches"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
-
-    def configFile(self):
-        super().configFile()
-
-        # modify the threshold for the test run (set it to two files)
-        instream = open(self.conffile, "r")
-        cfg = yaml.full_load(instream)
-        instream.close()
-
-        cfg["patches"]["file_count_threshold"] = "2"
-
-        outstream = open(self.conffile, "w")
-        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
-        outstream.close()
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
-# patch touches too many lines (VERIFY)
+# patch touches too many lines (INFO)
 class PatchTouchesTooManyLines(TestSRPM):
     def setUp(self):
         super().setUp()
@@ -308,22 +279,8 @@ class PatchTouchesTooManyLines(TestSRPM):
         )
 
         self.inspection = "patches"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
-
-    def configFile(self):
-        super().configFile()
-
-        # modify the threshold for the test run (set it to two files)
-        instream = open(self.conffile, "r")
-        cfg = yaml.full_load(instream)
-        instream.close()
-
-        cfg["patches"]["line_count_threshold"] = "3"
-
-        outstream = open(self.conffile, "w")
-        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
-        outstream.close()
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class PatchTouchesTooManyLinesCompare(TestCompareSRPM):
@@ -336,19 +293,5 @@ class PatchTouchesTooManyLinesCompare(TestCompareSRPM):
         )
 
         self.inspection = "patches"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
-
-    def configFile(self):
-        super().configFile()
-
-        # modify the threshold for the test run (set it to two files)
-        instream = open(self.conffile, "r")
-        cfg = yaml.full_load(instream)
-        instream.close()
-
-        cfg["patches"]["line_count_threshold"] = "3"
-
-        outstream = open(self.conffile, "w")
-        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
-        outstream.close()
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
The patches inspection no longer produces VERIFY results based on the
file_count_threshold and line_count_threshold settings in the config
file.  These checks were a carryover from rpminspect's ancestor, but
the core problem is that it is trying to enforce an arbitrary rule
across all packages for no good reason.  Who cares if a patch is
subjectively large if it actually fixes a problem?

The patches inspection still reports malformed patches as a BAD
result, but patch statistics are only reported at the INFO level now.

The test suite and example config file has been updated.  The
file_count_threshold and line_count_threshold settings are no longer
honored in the config file.

Signed-off-by: David Cantrell <dcantrell@redhat.com>