### PR TITLE
[lib] Default the filesize inspection size_threshold to 'info'

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -408,12 +408,17 @@ shellsyntax:
 filesize:
     # File size reporting threshold percentage.  What percentage
     # change warrants reporting a VERIFY result?  This change can be
-    # file size increase or decrease.  The default is 20%
+    # file size increase or decrease.
     #
     # NOTE: you can set this to the keyword 'info' (without the single
     # quotes) to have rpminspect report all filesize changes but at
-    # the INFO reporting level
-    size_threshold: 20
+    # the INFO reporting level.
+    #
+    # The default is 'info' to only report changes as INFO.  To enable
+    # size threshold checks based on a percentage, enter the
+    # percentage without the '%'.  For example, to set the threshold
+    # to 20%, put '20' (but without the single quotes).
+    size_threshold: info
 
     # Optional list of glob(7) specifications to match files to ignore
     # for this inspection.  The format of this list is the same as the

--- a/lib/init.c
+++ b/lib/init.c
@@ -2040,6 +2040,7 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         ri->kmidiff_suppression_file = strdup(ABI_SUPPRESSION_FILE);
         ri->kmidiff_debuginfo_path = strdup(DEBUG_PATH);
         ri->annocheck_failure_severity = RESULT_VERIFY;
+        ri->size_threshold = -1;
 
         /* Initialize commands */
         ri->commands.msgunfmt = strdup(MSGUNFMT_CMD);

--- a/test/test_addedfiles.py
+++ b/test/test_addedfiles.py
@@ -17,7 +17,7 @@
 #
 
 import rpmfluff
-
+import yaml
 from baseclass import TestCompareRPMs
 
 
@@ -39,6 +39,20 @@ class FileSizeGrowsAtThreshold(TestCompareRPMs):
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()
+
 
 class FileSizeGrowsAboveThreshold(TestCompareRPMs):
     """Assert when a file grows by more than the configured threshold, VERIFY result occurs."""
@@ -58,6 +72,20 @@ class FileSizeGrowsAboveThreshold(TestCompareRPMs):
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
 
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()
+
 
 class FileSizeGrowsBelowThreshold(TestCompareRPMs):
     """Assert when a file grows by less than the configured threshold, an INFO result occurs."""
@@ -75,3 +103,17 @@ class FileSizeGrowsBelowThreshold(TestCompareRPMs):
         self.inspection = "filesize"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
+
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()

--- a/test/test_filesize.py
+++ b/test/test_filesize.py
@@ -15,8 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-import platform
 
+import platform
+import yaml
 import rpmfluff
 
 from baseclass import TestCompareRPMs
@@ -41,6 +42,20 @@ class FileSizeGrowsAtThreshold(TestCompareRPMs):
         self.waiver_auth = "Anyone"
         self.message = f"/some/file grew by 20% on {platform.machine()}"
 
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()
+
 
 class FileSizeGrowsAboveThreshold(TestCompareRPMs):
     """Assert when a file grows by more than the configured threshold, VERIFY result occurs."""
@@ -61,6 +76,20 @@ class FileSizeGrowsAboveThreshold(TestCompareRPMs):
         self.waiver_auth = "Anyone"
         self.message = f"/some/file grew by 100% on {platform.machine()}"
 
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()
+
 
 class FileSizeGrowsBelowThreshold(TestCompareRPMs):
     """Assert when a file grows by less than the configured threshold, an INFO result occurs."""
@@ -79,6 +108,20 @@ class FileSizeGrowsBelowThreshold(TestCompareRPMs):
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
         self.message = f"/some/file grew by 10% on {platform.machine()}"
+
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()
 
 
 class EmptyFileSizeGrows(TestCompareRPMs):
@@ -99,6 +142,20 @@ class EmptyFileSizeGrows(TestCompareRPMs):
         self.waiver_auth = "Anyone"
         self.message = f"/some/file became a non-empty file on {platform.machine()}"
 
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()
+
 
 class FileSizeShrinksAtThreshold(TestCompareRPMs):
     """Assert when a file shrinks by exactly the configured threshold, VERIFY result occurs."""
@@ -117,6 +174,20 @@ class FileSizeShrinksAtThreshold(TestCompareRPMs):
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
         self.message = f"/some/file shrank by 20% on {platform.machine()}"
+
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()
 
 
 class FileSizeShrinksAboveThreshold(TestCompareRPMs):
@@ -137,6 +208,20 @@ class FileSizeShrinksAboveThreshold(TestCompareRPMs):
         self.waiver_auth = "Anyone"
         self.message = f"/some/file shrank by 80% on {platform.machine()}"
 
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()
+
 
 class FileSizeShrinksBelowThreshold(TestCompareRPMs):
     """Assert when a file shrinks by less than the configured threshold, an INFO result occurs."""
@@ -156,6 +241,20 @@ class FileSizeShrinksBelowThreshold(TestCompareRPMs):
         self.waiver_auth = "Not Waivable"
         self.message = f"/some/file shrank by 10% on {platform.machine()}"
 
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()
+
 
 class FileSizeShrinksToEmpty(TestCompareRPMs):
     """Assert when a file shrinks to an empty file, VERIFY result occurs."""
@@ -172,3 +271,17 @@ class FileSizeShrinksToEmpty(TestCompareRPMs):
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
         self.message = f"/some/file became an empty file on {platform.machine()}"
+
+    def configFile(self):
+        super().configFile()
+
+        # modify the threshold for the test run (set it to two files)
+        instream = open(self.conffile, "r")
+        cfg = yaml.full_load(instream)
+        instream.close()
+
+        cfg["filesize"]["size_threshold"] = "20"
+
+        outstream = open(self.conffile, "w")
+        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.close()


### PR DESCRIPTION
Previously the default was to report file size changes of 20% either
growing or shrinking would be reported at the VERIFY level.  The new
default is to report all changes at the INFO level.

The test cases still run with the setting in the config file at 20% to
ensure that users who want to enable the previous behavior of the
filesize inspection will get correct results.

Signed-off-by: David Cantrell <dcantrell@redhat.com>