### PR TITLE
[fix] Do not report fallthrough changes as VERIFY in changedfiles

### DIFF
--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -454,7 +454,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (before_sum && after_sum && strcmp(before_sum, after_sum)) {
             xasprintf(&params.msg, _("File %s changed content on %s.  Please verify this change was deliberate for a non-rebased build."), file->localpath, arch);
-            params.severity = RESULT_VERIFY;
+            params.severity = RESULT_INFO;
             params.waiverauth = WAIVABLE_BY_ANYONE;
             params.verb = VERB_CHANGED;
             params.noun = _("${FILE}");


### PR DESCRIPTION
In the changedfiles inspection, the last attempt made is to compare
the checksums.  If they are different and it's not a rebase build,
report the change at the VERIFY level.  This doesn't makes sense, it
should be reported at the INFO level.  The critical reporting checks
are above this fallthrough, so really rpminspect should just be
reporting changes for non-rebased builds for informational purposes
only.

Signed-off-by: David Cantrell <dcantrell@redhat.com>