### PR TITLE
[fix] Stop resetting the patch_ignore_list when reading config files

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -856,8 +856,6 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     } else if (group == BLOCK_PATCHES) {
                         if (!strcmp(key, "ignore_list")) {
                             block = BLOCK_PATCH_FILENAMES;
-                            list_free(ri->patch_ignore_list, free);
-                            ri->patch_ignore_list = NULL;
                         }
                     } else if (group == BLOCK_RUNPATH) {
                         if (!strcmp(key, "allowed_paths")) {
@@ -2016,44 +2014,47 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
     char *kernelnames[] = KERNEL_FILENAMES;
     string_entry_t *cfg = NULL;
 
-    /* Only initialize if we were given NULL for ri */
-    if (ri == NULL) {
-        ri = calloc(1, sizeof(*ri));
-        assert(ri != NULL);
-
-        /* Initialize the struct before reading files */
-        ri->workdir = strdup(DEFAULT_WORKDIR);
-        ri->vendor_data_dir = strdup(VENDOR_DATA_DIR);
-        ri->favor_release = FAVOR_NEWEST;
-        ri->tests = ~0;
-        ri->desktop_entry_files_dir = strdup(DESKTOP_ENTRY_FILES_DIR);
-        ri->bin_paths = list_from_array(BIN_PATHS);
-        ri->bin_owner = strdup(BIN_OWNER);
-        ri->bin_group = strdup(BIN_GROUP);
-        ri->shells = list_from_array(SHELLS);
-        ri->specmatch = MATCH_FULL;
-        ri->specprimary = PRIMARY_NAME;
-        ri->abidiff_suppression_file = strdup(ABI_SUPPRESSION_FILE);
-        ri->abidiff_debuginfo_path = strdup(DEBUG_PATH);
-        ri->abidiff_include_path = strdup(INCLUDE_PATH);
-        ri->abi_security_threshold = DEFAULT_ABI_SECURITY_THRESHOLD;
-        ri->kmidiff_suppression_file = strdup(ABI_SUPPRESSION_FILE);
-        ri->kmidiff_debuginfo_path = strdup(DEBUG_PATH);
-        ri->annocheck_failure_severity = RESULT_VERIFY;
-        ri->size_threshold = -1;
-
-        /* Initialize commands */
-        ri->commands.msgunfmt = strdup(MSGUNFMT_CMD);
-        ri->commands.desktop_file_validate = strdup(DESKTOP_FILE_VALIDATE_CMD);
-        ri->commands.annocheck = strdup(ANNOCHECK_CMD);
-        ri->commands.abidiff = strdup(ABIDIFF_CMD);
-        ri->commands.kmidiff = strdup(KMIDIFF_CMD);
-
-        /* Store full paths to all config files read */
-        ri->cfgfiles = calloc(1, sizeof(*ri->cfgfiles));
-        assert(ri->cfgfiles != NULL);
-        TAILQ_INIT(ri->cfgfiles);
+    if (ri != NULL) {
+        /* do not reinitialize */
+        return ri;
     }
+
+    /* Only initialize if we were given NULL for ri */
+    ri = calloc(1, sizeof(*ri));
+    assert(ri != NULL);
+
+    /* Initialize the struct before reading files */
+    ri->workdir = strdup(DEFAULT_WORKDIR);
+    ri->vendor_data_dir = strdup(VENDOR_DATA_DIR);
+    ri->favor_release = FAVOR_NEWEST;
+    ri->tests = ~0;
+    ri->desktop_entry_files_dir = strdup(DESKTOP_ENTRY_FILES_DIR);
+    ri->bin_paths = list_from_array(BIN_PATHS);
+    ri->bin_owner = strdup(BIN_OWNER);
+    ri->bin_group = strdup(BIN_GROUP);
+    ri->shells = list_from_array(SHELLS);
+    ri->specmatch = MATCH_FULL;
+    ri->specprimary = PRIMARY_NAME;
+    ri->abidiff_suppression_file = strdup(ABI_SUPPRESSION_FILE);
+    ri->abidiff_debuginfo_path = strdup(DEBUG_PATH);
+    ri->abidiff_include_path = strdup(INCLUDE_PATH);
+    ri->abi_security_threshold = DEFAULT_ABI_SECURITY_THRESHOLD;
+    ri->kmidiff_suppression_file = strdup(ABI_SUPPRESSION_FILE);
+    ri->kmidiff_debuginfo_path = strdup(DEBUG_PATH);
+    ri->annocheck_failure_severity = RESULT_VERIFY;
+    ri->size_threshold = -1;
+
+    /* Initialize commands */
+    ri->commands.msgunfmt = strdup(MSGUNFMT_CMD);
+    ri->commands.desktop_file_validate = strdup(DESKTOP_FILE_VALIDATE_CMD);
+    ri->commands.annocheck = strdup(ANNOCHECK_CMD);
+    ri->commands.abidiff = strdup(ABIDIFF_CMD);
+    ri->commands.kmidiff = strdup(KMIDIFF_CMD);
+
+    /* Store full paths to all config files read */
+    ri->cfgfiles = calloc(1, sizeof(*ri->cfgfiles));
+    assert(ri->cfgfiles != NULL);
+    TAILQ_INIT(ri->cfgfiles);
 
     /* Read in the config file if we have it */
     if (cfgfile) {

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -169,6 +169,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* If this patch is on the ignore list, skip */
     if (list_contains(ri->patch_ignore_list, file->localpath)) {
+        DEBUG_PRINT("Per the configuration file, ignoring %s\n", file->localpath);
         return true;
     }
 


### PR DESCRIPTION
The patch_ignore_list was incorrectly being reset for each entry read,
so it would be empty by the time all config files were read in.

Fixes: #683

Signed-off-by: David Cantrell <dcantrell@redhat.com>