### PR TITLE
[lib] Rename init_rpmpeer() and free_rpmpeer() functions

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -243,8 +243,8 @@ string_list_t *get_rpm_header_string_array(Header h, rpmTagVal tag);
 char *get_rpm_header_value(const rpmfile_entry_t *file, rpmTag tag);
 
 /* peers.c */
-rpmpeer_t *init_rpmpeer(void);
-void free_rpmpeer(rpmpeer_t *);
+rpmpeer_t *init_peers(void);
+void free_peers(rpmpeer_t *);
 void add_peer(rpmpeer_t **, int, bool, const char *, Header);
 
 /**

--- a/lib/free.c
+++ b/lib/free.c
@@ -282,7 +282,7 @@ void free_rpminspect(struct rpminspect *ri) {
     list_free(ri->unicode_forbidden_codepoints, free);
     free_deprule_ignore_map(ri->deprules_ignore);
 
-    free_rpmpeer(ri->peers);
+    free_peers(ri->peers);
 
     HASH_ITER(hh, ri->header_cache, hentry, tmp_hentry) {
         HASH_DEL(ri->header_cache, hentry);

--- a/lib/init.c
+++ b/lib/init.c
@@ -2118,7 +2118,7 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
 
     /* the rest of the members are used at runtime */
     ri->buildtype = KOJI_BUILD_RPM;
-    ri->peers = init_rpmpeer();
+    ri->peers = init_peers();
     ri->threshold = RESULT_VERIFY;
     ri->worst_result = RESULT_OK;
     ri->suppress = RESULT_NULL;

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -29,7 +29,7 @@
 /*
  * Initialize a new rpmpeer_t list.
  */
-rpmpeer_t *init_rpmpeer(void)
+rpmpeer_t *init_peers(void)
 {
     rpmpeer_t *peers = NULL;
 
@@ -42,7 +42,7 @@ rpmpeer_t *init_rpmpeer(void)
 /*
  * Free memory associated with an rpmpeer_t list.
  */
-void free_rpmpeer(rpmpeer_t *peers)
+void free_peers(rpmpeer_t *peers)
 {
     rpmpeer_entry_t *entry = NULL;
 
@@ -88,7 +88,7 @@ void add_peer(rpmpeer_t **peers, int whichbuild, bool fetch_only, const char *pk
     assert(hdr != NULL);
 
     if (*peers == NULL) {
-        *peers = init_rpmpeer();
+        *peers = init_peers();
     }
 
     /* Get the package or subpackage name and arch */


### PR DESCRIPTION
These function names were mildly annoying to me.  Renamed
init_rpmpeer() to init_peers() and free_rpmpeer() to free_peers().

Signed-off-by: David Cantrell <dcantrell@redhat.com>