### PR TITLE
[fix] Honor all per-inspection ignore lists; match path prefix

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -351,6 +351,22 @@ addedfiles:
     #ignore:
     #    - /usr/lib*/libexample.so*
 
+movedfiles:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/lib*/libexample.so*
+
+removedfiles:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/lib*/libexample.so*
+
 ownership:
     # Path prefixes where executable files live
     bin_paths:
@@ -856,3 +872,59 @@ virus:
     # here will only be used during this inspection.
     #ignore:
     #    - /usr/lib*/libexample.so*
+
+capabilities:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/lib*/libexample.so*
+
+config:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /etc/something*/*.conf
+
+doc:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/share/doc/example/README*
+
+kmod:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /lib/modules/*/kernel/drivers/pcmcia/yenta_socket.ko*
+
+permissions:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/lib*/libexample.so*
+
+symlinks:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - /usr/bin/superlink
+
+upstream:
+    # Optional list of glob(7) specifications to match files to ignore
+    # for this inspection.  The format of this list is the same as the
+    # global 'ignore' list.  The difference is the items specified
+    # here will only be used during this inspection.
+    #ignore:
+    #    - upstream-archive-name-*.tar.gz

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -407,7 +407,7 @@ const char *get_before_debuginfo_path(struct rpminspect *ri, const char *binarch
  */
 const char *get_after_debuginfo_path(struct rpminspect *ri, const char *binarch, const char *subpkg);
 bool usable_path(const char *path);
-bool match_path(const char *pattern, const char *root, const char *needle);
+bool match_path(const char *pattern, const char *root, const char *path);
 
 /**
  * @brief Given a path and struct rpminspect, determine if the path

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -178,7 +178,7 @@ bool usable_path(const char *path)
  * Helper function for glob(7) matching given a path string and
  * (optional) root directory.
  */
-bool match_path(const char *pattern, const char *root, const char *needle)
+bool match_path(const char *pattern, const char *root, const char *path)
 {
     bool match = false;
     int r = 0;
@@ -192,14 +192,19 @@ bool match_path(const char *pattern, const char *root, const char *needle)
     char *n = NULL;
 
     assert(pattern != NULL);
-    assert(needle != NULL);
+    assert(path != NULL);
+
+    /* A pattern ending with '/' will match a path prefix */
+    if (strsuffix(pattern, "/") && strprefix(path, pattern)) {
+        return true;
+    }
 
 #ifdef GLOB_BRACE
     /* this is a GNU extension, see glob(3) */
     gflags |= GLOB_BRACE;
 #endif
 
-    n = strdup(needle);
+    n = strdup(path);
     assert(n != NULL);
 
     if (root != NULL) {
@@ -236,7 +241,7 @@ bool match_path(const char *pattern, const char *root, const char *needle)
     for (i = 0; i < found.gl_pathc; i++) {
         globsub = found.gl_pathv[i] + len;
 
-        if (!strcmp(globsub, needle)) {
+        if (!strcmp(globsub, path)) {
             match = true;
             break;
         }


### PR DESCRIPTION
This is a large one.  First, a number of inspections were not honored
in the config file if you specified a per-inspection ignore list.
That has been fixed and all applicable inspections that can have a
per-inspection list now have one.  Some memory management fixes are
also present as well as a fix that prevents a reset of config file
settings as subsequent files are read.  Settings are now cummulative.
This may require additional work if we find it's really common for an
end user to need to override a config file block, but by and large the
most common case is appending so that's now how all settings are read
in.

The other change is with ignore path matching.  Previously all
matching was done using glob(3).  This is fine and works well, but it
does not allow a user to specify a single directory to exclude and
have it exclude everything in that directory.  The way glob(3) handles
directories in the path name is explicit.  Basically globbing only
works for path components and not the directory names themselves.
This is in POSIX.  While glibc offers some flexibility around this,
it's not portable.

So taking a hint from how rsync does things, rpminspect will now treat
ignore list entries ending with a slash ('/') as a path prefix for
ignore purposes.  So in your rpminspect.yaml file if you specify:

    ---
    virus:
        ignore:
            - /usr/share/mysql-test/

It will ignore /usr/share/mysql-test and everything in that directory.
Without that, the package maintainer would need to explicitly list
glob(3) patterns for each subdirectory construction in that path
prefix which is tedious to maintain and unnecessary.

The data/generic.yaml template file has been updated to reflect all
inspection blocks that were added to honor a per-inspection ignore
list.

Fixes: #691

Signed-off-by: David Cantrell <dcantrell@redhat.com>