### PR TITLE
[fix] Remove temporary files in the 'changelog' inspection

### DIFF
--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -143,6 +143,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     if (logfp == NULL) {
         warn("fdopen");
         close(fd);
+        unlink(output);
         free(output);
         return NULL;
     }
@@ -154,6 +155,13 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     if (fclose(logfp) != 0) {
         warn("fclose");
         close(fd);
+        unlink(output);
+        free(output);
+        return NULL;
+    }
+
+    if (unlink(output) != 0) {
+        warn("unlink");
         free(output);
         return NULL;
     }


### PR DESCRIPTION
A bit of housekeeping.  The changelog inspection was littering on the
filesystem.

Signed-off-by: David Cantrell <dcantrell@redhat.com>