### PR TITLE
[fix] Carefully filter debug packages in gather_deprules_by_type()

### DIFF
--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -132,8 +132,6 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
             if (!strcmp(r, "debuginfo(build-id)")
                 || strsuffix(r, DEBUGSOURCE_SUFFIX)
                 || strsuffix(r, DEBUGINFO_SUFFIX)
-                || strstr(r, DEBUGSOURCE_SUFFIX)
-                || strstr(r, DEBUGINFO_SUFFIX)
                 || ((strprefix(r, "rpmlib(") || strprefix(r, "rtld(")) && strsuffix(r, ")"))) {
                 continue;
             }


### PR DESCRIPTION
Drop the use of strstr() with DEBUGSOURCE_SUFFIX and DEBUGINFO_SUFFIX.
With strstr() in place, it fails to work with the elfutils package in
Fedora which carries a subpackage called 'elfutils-debuginfod-client'
and that passes a strstr() check looking for "-debuginfo" which is
DEBUGINFO_SUFFIX.

Signed-off-by: David Cantrell <dcantrell@redhat.com>