### PR TITLE
[lib] Restrict the annocheck and lto inspections to ELF files

### DIFF
--- a/include/readelf.h
+++ b/include/readelf.h
@@ -135,11 +135,11 @@ GElf_Half get_elf_type(Elf *elf);
 GElf_Half get_elf_machine(Elf *elf);
 
 /**
- * @brief Determine if the specified file is an ELF file.
+ * @brief Determine if the specified file is any ELF file type.
  *
  * Given a path to a file, this function returns true if the file is
- * either an ELF archive or an ELF shared object.  In all other cases
- * it returns False.
+ * either an ELF archive or an ELF file.  In all other cases, it
+ * returns false.
  *
  * @param path The full path to the file in question.
  * @return True if the file is ELF, false otherwise.
@@ -156,6 +156,30 @@ bool is_elf(const char *path);
  * @return True if the file is an ELF shared library, false otherwise.
  */
 bool is_elf_shared_library(const char *path);
+
+/**
+ * @brief Determine if the specified file is an ELF file.
+ *
+ * Given a path to a file, this function returns true if the file is
+ * an ELF file.  That is, an ELF executable, shared library, or shared
+ * object.
+ *
+ * @param path The fullpath tothe file in question.
+ * @return True if the file is an ELF file, false otherwise.
+ */
+bool is_elf_file(const char *path);
+
+/**
+ * @brief Determine if the specified file is an ELF archive.
+ *
+ * Given a path to a file, this function returns true if the file is
+ * an ELF archive.  That is, a '.a' file consisting of ELF object
+ * files.
+ *
+ * @param path The fullpath tothe file in question.
+ * @return True if the file is an ELF archive, false otherwise.
+ */
+bool is_elf_archive(const char *path);
 
 /**
  * @brief Determine if the specified Elf object contains the specified

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -116,7 +116,8 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     arch = get_rpm_header_arch(file->rpm_header);
 
     /* Only run this check on ELF files */
-    if (!is_elf(file->fullpath) || (!is_elf(file->fullpath) && file->peer_file && !is_elf(file->peer_file->fullpath))) {
+    if (!is_elf_file(file->fullpath)
+        || (!is_elf_file(file->fullpath) && file->peer_file && !is_elf_file(file->peer_file->fullpath))) {
         return result;
     }
 

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -135,7 +135,7 @@ static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only valid for ELF files */
-    if (!is_elf(file->fullpath) && !strsuffix(file->localpath, STATIC_LIB_FILENAME_EXTENSION)) {
+    if (!is_elf_file(file->fullpath)) {
         return true;
     }
 

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -124,7 +124,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.verb = VERB_FAILED;
         }
 
-        if (is_elf(file->fullpath) && !strcmp(type, "application/x-pie-executable")) {
+        if (is_elf_file(file->fullpath) && !strcmp(type, "application/x-pie-executable")) {
             soname = get_elf_soname(file->fullpath);
 
             if (soname) {

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -145,36 +145,7 @@ Elf * get_elf_archive(const char *fullpath, int *out_fd)
  */
 bool is_elf(const char *path)
 {
-    int fd = 0;
-    Elf *elf = NULL;
-
-    /* try it as a shared object */
-    elf = get_elf(path, &fd);
-
-    if (elf) {
-        elf_end(elf);
-
-        if (fd) {
-            close(fd);
-        }
-
-        return true;
-    }
-
-    /* try it as a static library */
-    elf = get_elf_archive(path, &fd);
-
-    if (elf) {
-        elf_end(elf);
-
-        if (fd) {
-            close(fd);
-        }
-
-        return true;
-    }
-
-    return false;
+    return (is_elf_file(path) || is_elf_archive(path));
 }
 
 /*
@@ -199,6 +170,54 @@ bool is_elf_shared_library(const char *path)
     close(fd);
     elf_end(elf);
     return result;
+}
+
+/*
+ * Return true for any ELF file.
+ */
+bool is_elf_file(const char *path)
+{
+    int fd = 0;
+    Elf *elf = NULL;
+
+    /* try it as a shared object */
+    elf = get_elf(path, &fd);
+
+    if (elf) {
+        elf_end(elf);
+
+        if (fd) {
+            close(fd);
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+/*
+ * Return true for any ELF archive.
+ */
+bool is_elf_archive(const char *path)
+{
+    int fd = 0;
+    Elf *elf = NULL;
+
+    /* try it as a static library */
+    elf = get_elf_archive(path, &fd);
+
+    if (elf) {
+        elf_end(elf);
+
+        if (fd) {
+            close(fd);
+        }
+
+        return true;
+    }
+
+    return false;
 }
 
 bool have_elf_section(Elf *elf, int64_t section, const char *name)


### PR DESCRIPTION
The annocheck and lto inspections periodically have problems with
library archives.  The inspections were relying on the is_elf()
function, which returns true for any ELF type.  Modified readelf.c to
carry is_elf_file() and is_elf_archive() so that annocheck and lto are
restricted to ELF_K_ELF types and not both ELF_K_ELF and
ELF_K_ARCHIVE.

Signed-off-by: David Cantrell <dcantrell@redhat.com>