### PR TITLE
[fix] Double free removed in match_fileinfo_mode()

### DIFF
--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -106,7 +106,6 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
         }
     }
 
-    free(params.remedy);
     return false;
 }
 


### PR DESCRIPTION
Signed-off-by: David Cantrell <dcantrell@redhat.com>