### PR TITLE
[fix] read_file_bytes() must be restricted to S_ISREG() files

### DIFF
--- a/lib/readfile.c
+++ b/lib/readfile.c
@@ -46,8 +46,8 @@ void *read_file_bytes(const char *path, off_t *len)
         return NULL;
     }
 
-    /* zero length file, ignore */
-    if (sb.st_size == 0) {
+    /* zero length file or not a file, ignore */
+    if (sb.st_size == 0 || !S_ISREG(sb.st_mode)) {
         return NULL;
     }
 


### PR DESCRIPTION
Do not assume that paths given to this function are actually files.
They may be directories, devices, or really anything.  Verify the
input is both not zero length and a regular file before reading in
data.

Users cannot be trusted.

Fixes: #704

Signed-off-by: David Cantrell <dcantrell@redhat.com>