### PR TITLE
[fix] In rpmdeps, do not report new explicit Requires as VERIFY

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -167,7 +167,7 @@ typedef struct _deprule_entry_t {
     dep_op_t operator;                     /* dependency operator (e.g., >, >=) */
     char *version;                         /* dependency version */
     bool rich;                             /* true if this dep is a rich dependency */
-    bool need_explicit_deps;               /* true if a subpkg needs to explicit require an NVR */
+    bool explicit;                         /* true if this dep is matched for automatic shared lib deps */
     string_list_t *providers;              /* for TYPE_REQUIRES, list of subpackages providing it */
     struct _deprule_entry_t *peer_deprule; /* corresponding before/after deprule */
     TAILQ_ENTRY(_deprule_entry_t) items;

--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -156,6 +156,7 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
             }
 
             deprule_entry->rich = is_rich_dep(deprule_entry->requirement);
+            deprule_entry->explicit = false;
 
             TAILQ_INSERT_TAIL(deprules, deprule_entry, items);
         }

--- a/test/test_rpmdeps_requires.py
+++ b/test/test_rpmdeps_requires.py
@@ -221,8 +221,8 @@ class GainingRequiresCompareSRPM(TestCompareSRPM):
         self.after_rpm.add_build_requires(after_requires)
 
         self.inspection = "rpmdeps"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class GainingRequiresCompareRPMs(TestCompareRPMs):


### PR DESCRIPTION
If an explicit Requires is found that matches automatic shared library
dependencies but it happens to be new (i.e., it was not in the before
build), still just report it at the INFO level with the note that this
dependency is expected.

Signed-off-by: David Cantrell <dcantrell@redhat.com>