### PR TITLE
[cmd] Use errx() for RI_PROGRAM_ERROR conditions in rpminspect(1)

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -825,7 +825,7 @@ int main(int argc, char **argv)
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
-                err(RI_PROGRAM_ERROR, _("invalid after RPM"));
+                errx(RI_PROGRAM_ERROR, _("invalid after RPM"));
             }
 
             if (ri->before) {
@@ -835,7 +835,7 @@ int main(int argc, char **argv)
                     free_rpminspect(ri);
                     rpmFreeMacros(NULL);
                     rpmFreeRpmrc();
-                    err(RI_PROGRAM_ERROR, _("invalid before RPM"));
+                    errx(RI_PROGRAM_ERROR, _("invalid before RPM"));
                 }
             }
 
@@ -846,7 +846,7 @@ int main(int argc, char **argv)
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
-                return RI_PROGRAM_ERROR;
+                errx(RI_PROGRAM_ERROR, _("*** Unable to determine product release or none specified (-r)."));
             }
         }
 


### PR DESCRIPTION
Some exit error conditions in rpminspect(1) were using errx() which is
unnecessary.  Also, one exit condition didn't actually explain what
happened so tell the user the product release was not specified and
could not be determined.

Signed-off-by: David Cantrell <dcantrell@redhat.com>