### PR TITLE
[fix] Security path checking only applies to comparisons in addedfiles

### DIFF
--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -45,6 +45,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     char *tail = NULL;
     const char *arch = NULL;
     bool rebase = false;
+    bool peer_new = false;
     string_entry_t *entry = NULL;
     struct result_params params;
 
@@ -159,11 +160,15 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
     }
 
-    /* security path file */
-    if (ri->security_path_prefix
-        && S_ISREG(file->st.st_mode)
-        && ((ri->before != NULL && (file->peer_file == NULL || strcmp(file->localpath, file->peer_file->localpath)))
-            || get_secrule_by_path(ri, file) != NULL)) {
+    /* security path file -- only applicable for build comparisons */
+    if ((file->peer_file != NULL && strcmp(file->localpath, file->peer_file->localpath))
+        || (ri->before != NULL && file->peer_file == NULL)) {
+        peer_new = true;
+    } else {
+        peer_new = false;
+    }
+
+    if (ri->security_path_prefix && S_ISREG(file->st.st_mode) && peer_new) {
         TAILQ_FOREACH(entry, ri->security_path_prefix, items) {
             subpath = entry->data;
 

--- a/test/test_securitypath.py
+++ b/test/test_securitypath.py
@@ -18,7 +18,7 @@
 
 import rpmfluff
 
-from baseclass import TestRPMs, TestKoji, TestCompareRPMs, TestCompareKoji
+from baseclass import TestCompareRPMs, TestCompareKoji
 
 contents = """
 # Open things up
@@ -29,124 +29,6 @@ contents = """
 ################################################
 # New file present or added to a security path #
 ################################################
-
-
-# XXX: fix coming with a larger addedfiles inspection fix
-# class FileAddedToSecurityPathRPMs(TestRPMs):
-#    def setUp(self):
-#        super().setUp()
-#        self.rpm.add_installed_file(
-#            "/etc/sudoers.d/wheel", rpmfluff.SourceFile("wheel", contents)
-#        )
-#        self.inspection = "addedfiles"
-#        self.result = "BAD"
-#        self.waiver_auth = "Security"
-
-
-class SecuritySKIPFileAddedToSecurityPathRPMs(TestRPMs):
-    def setUp(self):
-        super().setUp()
-        self.rpm.add_installed_file(
-            "/etc/sudoers.d/skip", rpmfluff.SourceFile("wheel", contents)
-        )
-        self.inspection = "addedfiles"
-        self.result = "OK"
-        self.waiver_auth = "Not Waivable"
-
-
-# XXX: fix coming with a larger addedfiles inspection fix
-# class SecurityINFORMFileAddedToSecurityPathRPMs(TestRPMs):
-#    def setUp(self):
-#        super().setUp()
-#        self.rpm.add_installed_file(
-#            "/etc/sudoers.d/inform", rpmfluff.SourceFile("wheel", contents)
-#        )
-#        self.inspection = "addedfiles"
-#        self.result = "INFO"
-#        self.waiver_auth = "Security"
-
-
-# XXX: fix coming with a larger addedfiles inspection fix
-# class SecurityVERIFYFileAddedToSecurityPathRPMs(TestRPMs):
-#    def setUp(self):
-#        super().setUp()
-#        self.rpm.add_installed_file(
-#            "/etc/sudoers.d/verify", rpmfluff.SourceFile("wheel", contents)
-#        )
-#        self.inspection = "addedfiles"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Security"
-
-
-# XXX: fix coming with a larger addedfiles inspection fix
-# class SecurityFAILFileAddedToSecurityPathRPMs(TestRPMs):
-#    def setUp(self):
-#        super().setUp()
-#        self.rpm.add_installed_file(
-#            "/etc/sudoers.d/fail", rpmfluff.SourceFile("wheel", contents)
-#        )
-#        self.inspection = "addedfiles"
-#        self.result = "BAD"
-#        self.waiver_auth = "Security"
-
-
-# XXX: fix coming with a larger addedfiles inspection fix
-# class FileAddedToSecurityPathKoji(TestKoji):
-#    def setUp(self):
-#        super().setUp()
-#        self.rpm.add_installed_file(
-#            "/etc/sudoers.d/wheel", rpmfluff.SourceFile("wheel", contents)
-#        )
-#        self.inspection = "addedfiles"
-#        self.result = "BAD"
-#        self.waiver_auth = "Security"
-
-
-class SecuritySKIPFileAddedToSecurityPathKoji(TestKoji):
-    def setUp(self):
-        super().setUp()
-        self.rpm.add_installed_file(
-            "/etc/sudoers.d/skip", rpmfluff.SourceFile("wheel", contents)
-        )
-        self.inspection = "addedfiles"
-        self.result = "OK"
-        self.waiver_auth = "Not Waivable"
-
-
-# XXX: fix coming with a larger addedfiles inspection fix
-# class SecurityINFORMFileAddedToSecurityPathKoji(TestKoji):
-#    def setUp(self):
-#        super().setUp()
-#        self.rpm.add_installed_file(
-#            "/etc/sudoers.d/inform", rpmfluff.SourceFile("wheel", contents)
-#        )
-#        self.inspection = "addedfiles"
-#        self.result = "INFO"
-#        self.waiver_auth = "Security"
-
-
-# XXX: fix coming with a larger addedfiles inspection fix
-# class SecurityVERIFYFileAddedToSecurityPathKoji(TestKoji):
-#    def setUp(self):
-#        super().setUp()
-#        self.rpm.add_installed_file(
-#            "/etc/sudoers.d/verify", rpmfluff.SourceFile("wheel", contents)
-#        )
-#        self.inspection = "addedfiles"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Security"
-
-
-# XXX: fix coming with a larger addedfiles inspection fix
-# class SecurityFAILFileAddedToSecurityPathKoji(TestKoji):
-#    def setUp(self):
-#        super().setUp()
-#        self.rpm.add_installed_file(
-#            "/etc/sudoers.d/fail", rpmfluff.SourceFile("wheel", contents)
-#        )
-#        self.inspection = "addedfiles"
-#        self.result = "BAD"
-#        self.waiver_auth = "Security"
 
 
 class FileAddedToSecurityPathCompareRPMs(TestCompareRPMs):


### PR DESCRIPTION
In the addedfiles inspection, the security path check only works if
there are two builds compared.  Otherwise rpminspect cannot determine
if a file is new or not.  The other addedfiles checks, such as
forbidden paths, work even for single build inspections.

Remove the non-applicable test cases from test_securitypath.py as
well.

Signed-off-by: David Cantrell <dcantrell@redhat.com>