### PR TITLE
[lib] Add list_remove() function to librpminspect

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -160,6 +160,7 @@ string_list_t * list_copy(const string_list_t *);
 string_list_t *list_from_array(const char **);
 bool list_contains(const string_list_t *, const char *);
 string_list_t *list_add(string_list_t *list, const char *s);
+void list_remove(string_list_t *list, const char *s);
 
 /* local.c */
 bool is_local_build(const char *workdir, const char *build, const bool fetch_only);

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -521,3 +521,23 @@ string_list_t *list_add(string_list_t *list, const char *s)
 
     return list;
 }
+
+/*
+ * Remove an entry matching the string 's'.
+ */
+void list_remove(string_list_t *list, const char *s)
+{
+    string_entry_t *entry = NULL;
+
+    if (list == NULL || s == NULL) {
+        return;
+    }
+
+    TAILQ_FOREACH(entry, list, items) {
+        if (!strcmp(entry->data, s)) {
+            TAILQ_REMOVE(list, entry, items);
+        }
+    }
+
+    return;
+}


### PR DESCRIPTION
Given a string_list_t and a char *, list_remove will remove any
string_entry_t with data matching the char *.  Nothing is returned and
the string_list_t is modified in place.

Signed-off-by: David Cantrell <dcantrell@redhat.com>