### PR TITLE
[fix] Missing free() calls in the new list_remove() function

### DIFF
--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -536,6 +536,8 @@ void list_remove(string_list_t *list, const char *s)
     TAILQ_FOREACH(entry, list, items) {
         if (!strcmp(entry->data, s)) {
             TAILQ_REMOVE(list, entry, items);
+            free(entry->data);
+            free(entry);
         }
     }
 


### PR DESCRIPTION
Forgot to free the entry members and the entry itself.

Signed-off-by: David Cantrell <dcantrell@redhat.com>