### PR TITLE
[lib] Expand the patches inspection to verify patches are applied

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -616,11 +616,67 @@
 #define SPEC_MACRO_GLOBAL      "%global"
 
 /**
- * @def SPEC_SECTION_CHANGELOG
+ * @def SPEC_MACRO_AUTOPATCH
  *
- * How the change log is specified in the spec file.
+ * The %autopatch macro used to apply all defined Patches.
  */
-#define SPEC_SECTION_CHANGELOG "%changelog"
+#define SPEC_MACRO_AUTOPATCH   "%autopatch"
+
+/**
+ * @def SPEC_MACRO_AUTOSETUP
+ *
+ * The %autosetup macro used to unpack all Sources and apply all
+ * defined Patches.
+ */
+#define SPEC_MACRO_AUTOSETUP   "%autosetup"
+
+/**
+ * @def SPEC_MACRO_PATCH
+ *
+ * The %patchN macro used to apply patches.  N corresponds to the
+ * patch number defined in the header.
+ */
+#define SPEC_MACRO_PATCH       "%patch"
+
+/**
+ * @def SPEC_SECTION_PREP
+ *
+ * Command or series of commands to prepare the software to be built,
+ * for example, unpacking the archive in Source0. This directive can
+ * contain a shell script.
+ */
+#define SPEC_SECTION_PREP      "%prep"
+
+/**
+ * @def SPEC_SECTION_BUILD
+ *
+ * Command or series of commands for actually building the software
+ * into machine code (for compiled languages) or byte code (for some
+ * interpreted languages).
+ */
+#define SPEC_SECTION_BUILD     "%build"
+
+/**
+ * @def SPEC_SECTION_INSTALL
+ *
+ * Command or series of commands for copying the desired build
+ * artifacts from the %builddir (where the build happens) to the
+ * %buildroot directory (which contains the directory structure with
+ * the files to be packaged). This usually means copying files from
+ * ~/rpmbuild/BUILD to ~/rpmbuild/BUILDROOT and creating the necessary
+ * directories in ~/rpmbuild/BUILDROOT. This is only run when creating
+ * a package, not when the end-user installs the package. See Working
+ * with SPEC files for details.
+ */
+#define SPEC_SECTION_INSTALL   "%install"
+
+/**
+ * @def SPEC_SECTION_CHECK
+ *
+ * Command or series of commands to test the software. This normally
+ * includes things such as unit tests.
+ */
+#define SPEC_SECTION_CHECK     "%check"
 
 /**
  * @def SPEC_SECTION_FILES
@@ -630,11 +686,25 @@
 #define SPEC_SECTION_FILES     "%files"
 
 /**
+ * @def SPEC_SECTION_CHANGELOG
+ *
+ * How the change log is specified in the spec file.
+ */
+#define SPEC_SECTION_CHANGELOG "%changelog"
+
+/**
  * @def SPEC_TAG_RELEASE
  *
  * The name of RPMTAG_RELEASE in a spec file.
  */
 #define SPEC_TAG_RELEASE       "Release:"
+
+/**
+ * @def SPEC_TAG_PATCH
+ *
+ * The leading text of the RPMTAG_PATCH identifier in a spec file.
+ */
+#define SPEC_TAG_PATCH         "Patch"
 
 /**
  * @def SPEC_DISTTAG

--- a/include/results.h
+++ b/include/results.h
@@ -685,6 +685,10 @@
 
 #define REMEDY_PATCHES_CORRUPT _("An invalid patch file was found.  This is usually the result of generating a collection of patches by comparing two trees.  When files disappear that can lead to zero length patches in the resulting collection.  Check to see if the source package has any zero length or otherwise invalid patches and correct the problem.")
 
+#define REMEDY_PATCHES_MISSING_MACRO _("The named patch is defined in the source RPM header (this means it has a PatchN: definition in the spec file) but is not applied anywhere in the spec file.  It is missing a corresponding %%patch macro and the spec file lacks the %%autosetup or %%autopatch macros.  You can fix this by adding the appropriate %%patch macro in the spec file (usually in the %%prep section).  The number specified with the %%patch macro corresponds to the number used to define the patch at the top of the spec file.  So Patch47 is applied with a %%patch47 macro.")
+
+#define REMEDY_PATCHES_MISMATCHED_MACRO _("The named patch is defined but is mismatched by number with the %%patch macro.  Make sure all numbered patches have corresponding %%patch macros.  For example, Patch47 needs to have a %%patch47 macro.")
+
 /** @} */
 
 /**

--- a/include/types.h
+++ b/include/types.h
@@ -424,6 +424,27 @@ typedef struct _security_entry_t {
 typedef TAILQ_HEAD(security_entry_s, _security_entry_t) security_list_t;
 
 /*
+ * Patches hash table used by the patches inspection
+ * Maps the patch file name to the patch number in the spec file (that
+ * is, the PatchN: and corresponding %patchN number where N is the
+ * number).
+ */
+typedef struct _patches_t {
+    char *patch;
+    int64_t num;              /* -1 means the patch file has no PatchN line */
+    UT_hash_handle hh;
+} patches_t;
+
+/*
+ * Hash table used to record the number of %patchN macros used
+ */
+typedef struct _applied_patches_t {
+    int64_t num;
+    char *opts;
+    UT_hash_handle hh;
+} applied_patches_t;
+
+/*
  * Configuration and state instance for librpminspect run.
  * Applications using librpminspect should initialize the
  * library and retain this structure through the run of

--- a/include/types.h
+++ b/include/types.h
@@ -431,7 +431,7 @@ typedef TAILQ_HEAD(security_entry_s, _security_entry_t) security_list_t;
  */
 typedef struct _patches_t {
     char *patch;
-    int64_t num;              /* -1 means the patch file has no PatchN line */
+    long num;              /* -1 means the patch file has no PatchN line */
     UT_hash_handle hh;
 } patches_t;
 
@@ -439,7 +439,7 @@ typedef struct _patches_t {
  * Hash table used to record the number of %patchN macros used
  */
 typedef struct _applied_patches_t {
-    int64_t num;
+    long num;
     char *opts;
     UT_hash_handle hh;
 } applied_patches_t;

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -161,7 +161,7 @@ class PatchUnderFourBytes(TestSRPM):
         # parameter of add_patch() is a boolean indicating whether or
         # not to apply the patch in the spec file, so disable that for
         # this test to see if rpminspect works.
-        self.rpm.add_patch(rpmfluff.SourceFile("some.patch", "Qx"), False)
+        self.rpm.add_patch(rpmfluff.SourceFile("some.patch", "Qx"), True)
 
         self.inspection = "patches"
         self.result = "BAD"
@@ -178,8 +178,8 @@ class PatchUnderFourBytesCompare(TestCompareSRPM):
         # parameter of add_patch() is a boolean indicating whether or
         # not to apply the patch in the spec file, so disable that for
         # this test to see if rpminspect works.
-        self.before_rpm.add_patch(rpmfluff.SourceFile("some.patch", "Qx"), False)
-        self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", "Qx"), False)
+        self.before_rpm.add_patch(rpmfluff.SourceFile("some.patch", "Qx"), True)
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", "Qx"), True)
 
         self.inspection = "patches"
         self.result = "BAD"
@@ -191,9 +191,9 @@ class PatchChangedNotRebaseCompare(TestCompareSRPM):
     def setUp(self):
         super().setUp()
 
-        self.before_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+        self.before_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), True)
         self.after_rpm.add_patch(
-            rpmfluff.SourceFile("some.patch", patch_file_changed), False
+            rpmfluff.SourceFile("some.patch", patch_file_changed), True
         )
 
         self.inspection = "patches"
@@ -205,9 +205,9 @@ class PatchChangedInRebaseCompare(TestCompareSRPM):
     def setUp(self):
         super().setUp(rebase=True)
 
-        self.before_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+        self.before_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), True)
         self.after_rpm.add_patch(
-            rpmfluff.SourceFile("some.patch", patch_file_changed), False
+            rpmfluff.SourceFile("some.patch", patch_file_changed), True
         )
 
         self.inspection = "patches"
@@ -220,7 +220,7 @@ class PatchAddedNotRebaseCompare(TestCompareSRPM):
     def setUp(self):
         super().setUp()
 
-        self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), True)
 
         self.inspection = "patches"
         self.result = "INFO"
@@ -232,7 +232,7 @@ class PatchAddedInRebaseCompare(TestCompareSRPM):
     def setUp(self):
         super().setUp(rebase=True)
 
-        self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), True)
 
         self.inspection = "patches"
         self.result = "INFO"
@@ -246,7 +246,7 @@ class PatchTouchesTooManyFiles(TestSRPM):
 
         # add the large patch
         self.rpm.add_patch(
-            rpmfluff.SourceFile("some.patch", patch_file_threshold), False
+            rpmfluff.SourceFile("some.patch", patch_file_threshold), True
         )
 
         self.inspection = "patches"
@@ -260,7 +260,7 @@ class PatchTouchesTooManyFilesCompare(TestCompareSRPM):
 
         # add the large patch
         self.after_rpm.add_patch(
-            rpmfluff.SourceFile("some.patch", patch_file_threshold), False
+            rpmfluff.SourceFile("some.patch", patch_file_threshold), True
         )
 
         self.inspection = "patches"
@@ -275,7 +275,7 @@ class PatchTouchesTooManyLines(TestSRPM):
 
         # add the large patch
         self.rpm.add_patch(
-            rpmfluff.SourceFile("some.patch", patch_file_threshold), False
+            rpmfluff.SourceFile("some.patch", patch_file_threshold), True
         )
 
         self.inspection = "patches"
@@ -289,9 +289,121 @@ class PatchTouchesTooManyLinesCompare(TestCompareSRPM):
 
         # add the large patch
         self.after_rpm.add_patch(
-            rpmfluff.SourceFile("some.patch", patch_file_threshold), False
+            rpmfluff.SourceFile("some.patch", patch_file_threshold), True
         )
 
         self.inspection = "patches"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
+
+
+# patch defined and %autosetup used
+class PatchDefinedAutoSetupSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add a patch and use %autosetup
+        self.rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+        self.rpm.section_prep += "%%autosetup\n"
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class PatchDefinedAutoSetupCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add a patch and use %autosetup
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+        self.after_rpm.section_prep += "%%autosetup\n"
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# patch defined and %autopatch used
+class PatchDefinedAutoPatchSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add a patch and use %autopatch
+        self.rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+        self.rpm.section_prep += "%%autopatch\n"
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class PatchDefinedAutoPatchCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add a patch and use %autopatch
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+        self.after_rpm.section_prep += "%%autopatch\n"
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# patch defined but not applied
+class PatchDefinedButNotAppliedSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # define the patch
+        self.rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+
+        self.inspection = "patches"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"
+
+
+class PatchDefinedButNotAppliedCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # define the patch
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
+
+        self.inspection = "patches"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"
+
+
+# patches defined but some not applied
+class PatchesDefinedButSomeNotAppliedSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # define the patch
+        self.rpm.add_patch(rpmfluff.SourceFile("some1.patch", patch_file), True)
+        self.rpm.add_patch(rpmfluff.SourceFile("some2.patch", patch_file), True)
+        self.rpm.add_patch(rpmfluff.SourceFile("some3.patch", patch_file), False)
+        self.rpm.add_patch(rpmfluff.SourceFile("some4.patch", patch_file), True)
+        self.rpm.add_patch(rpmfluff.SourceFile("some5.patch", patch_file), False)
+
+        self.inspection = "patches"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"
+
+
+class PatchesDefinedButSomeNotAppliedCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # define the patch
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some1.patch", patch_file), True)
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some2.patch", patch_file), True)
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some3.patch", patch_file), False)
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some4.patch", patch_file), True)
+        self.after_rpm.add_patch(rpmfluff.SourceFile("some5.patch", patch_file), False)
+
+        self.inspection = "patches"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"


### PR DESCRIPTION
Expand the patches inspection to verify that all defined patches in
the RPM header are applied either with %autosetup, %autopatch, or a
corresponding %patchN macro.  If a defined patch is not found to have
a matching apply macro, it raises a VERIFY warning.

Fixes: #696

Signed-off-by: David Cantrell <dcantrell@redhat.com>