### PR TITLE
[cmd] Restore product release matching for single build analysis

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -835,7 +835,7 @@ int main(int argc, char **argv)
             }
 
             /* if we got here with no before and after release values, bad */
-            if (before_rel == NULL || after_rel == NULL) {
+            if ((ri->before && before_rel == NULL) && after_rel == NULL) {
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();


### PR DESCRIPTION
A followup to 21a29a221dbefa60e609f25ed9f72a092ccfe934 which fixed up
product release string detection.  I broke it for single build
analysis runs, which this patch restores functionality for.

Signed-off-by: David Cantrell <dcantrell@redhat.com>