### PR TITLE
[tst] Fix the MultipleProvidersCompareRPMs test cases

### DIFF
--- a/test/test_rpmdeps_conflicts.py
+++ b/test/test_rpmdeps_conflicts.py
@@ -1220,81 +1220,81 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-# XXX: this test needs to be rewritten to properly dupe the shared library
-# class MultipleProvidersCompareRPMs(TestCompareRPMs):
-#    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
-#    def setUp(self):
-#        super().setUp()
-#
-#        # add subpackages
-#        self.before_rpm.add_subpackage("libs")
-#        self.before_rpm.add_subpackage("morelibs")
-#        self.after_rpm.add_subpackage("libs")
-#        self.after_rpm.add_subpackage("morelibs")
-#
-#        # we need some stuff in the packages, first a shared library
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#
-#        # now add a program linked with that library
-#        sourceFileName = "main.c"
-#        installPath = "usr/bin/vaporware"
-#
-#        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.before_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.before_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.before_rpm.create_parent_dirs(installPath)
-#        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.before_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.before_rpm.add_payload_check(installPath, None)
-#
-#        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.after_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.after_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.after_rpm.create_parent_dirs(installPath)
-#        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.after_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.after_rpm.add_payload_check(installPath, None)
-#
-#        # add an explicit conflicts on the libs package
-#        self.before_rpm.add_conflicts("vaporware-libs = %{version}-%{release}")
-#        self.after_rpm.add_conflicts("vaporware-libs = %{version}-%{release}")
-#
-#        self.inspection = "rpmdeps"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Anyone"
+class MultipleProvidersCompareRPMs(TestCompareRPMs):
+    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
+    def setUp(self):
+        super().setUp()
+
+        # add subpackages
+        self.before_rpm.add_subpackage("libs")
+        self.before_rpm.add_subpackage("morelibs")
+        self.after_rpm.add_subpackage("libs")
+        self.after_rpm.add_subpackage("morelibs")
+
+        # we need some stuff in the packages, first a shared library
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+
+        # now add a program linked with that library
+        sourceFileName = "main.c"
+        installPath = "usr/bin/vaporware"
+
+        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.before_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.before_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.before_rpm.create_parent_dirs(installPath)
+        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.before_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.before_rpm.add_payload_check(installPath, None)
+
+        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.after_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.after_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.after_rpm.create_parent_dirs(installPath)
+        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.after_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.after_rpm.add_payload_check(installPath, None)
+
+        # add an explicit conflicts on the libs package
+        self.before_rpm.add_conflicts("vaporware-libs = %{version}-%{release}")
+        self.after_rpm.add_conflicts("vaporware-libs = %{version}-%{release}")
+
+        # result is OK because this check is a no-op when comparing single RPMs
+        self.inspection = "rpmdeps"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):

--- a/test/test_rpmdeps_enhances.py
+++ b/test/test_rpmdeps_enhances.py
@@ -1281,82 +1281,82 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-# XXX: this test needs to be rewritten to properly dupe the shared library
-# class MultipleProvidersCompareRPMs(TestCompareRPMs):
-#    @unittest.skipUnless(have_enhances, "librpm too old to support Enhances")
-#    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
-#    def setUp(self):
-#        super().setUp()
-#
-#        # add subpackages
-#        self.before_rpm.add_subpackage("libs")
-#        self.before_rpm.add_subpackage("morelibs")
-#        self.after_rpm.add_subpackage("libs")
-#        self.after_rpm.add_subpackage("morelibs")
-#
-#        # we need some stuff in the packages, first a shared library
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#
-#        # now add a program linked with that library
-#        sourceFileName = "main.c"
-#        installPath = "usr/bin/vaporware"
-#
-#        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.before_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.before_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.before_rpm.create_parent_dirs(installPath)
-#        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.before_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.before_rpm.add_payload_check(installPath, None)
-#
-#        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.after_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.after_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.after_rpm.create_parent_dirs(installPath)
-#        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.after_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.after_rpm.add_payload_check(installPath, None)
-#
-#        # add an explicit enhances on the libs package
-#        self.before_rpm.add_enhances("vaporware-libs = %{version}-%{release}")
-#        self.after_rpm.add_enhances("vaporware-libs = %{version}-%{release}")
-#
-#        self.inspection = "rpmdeps"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Anyone"
+class MultipleProvidersCompareRPMs(TestCompareRPMs):
+    @unittest.skipUnless(have_enhances, "librpm too old to support Enhances")
+    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
+    def setUp(self):
+        super().setUp()
+
+        # add subpackages
+        self.before_rpm.add_subpackage("libs")
+        self.before_rpm.add_subpackage("morelibs")
+        self.after_rpm.add_subpackage("libs")
+        self.after_rpm.add_subpackage("morelibs")
+
+        # we need some stuff in the packages, first a shared library
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+
+        # now add a program linked with that library
+        sourceFileName = "main.c"
+        installPath = "usr/bin/vaporware"
+
+        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.before_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.before_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.before_rpm.create_parent_dirs(installPath)
+        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.before_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.before_rpm.add_payload_check(installPath, None)
+
+        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.after_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.after_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.after_rpm.create_parent_dirs(installPath)
+        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.after_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.after_rpm.add_payload_check(installPath, None)
+
+        # add an explicit enhances on the libs package
+        self.before_rpm.add_enhances("vaporware-libs = %{version}-%{release}")
+        self.after_rpm.add_enhances("vaporware-libs = %{version}-%{release}")
+
+        # result is OK because this check is a no-op when comparing single RPMs
+        self.inspection = "rpmdeps"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):

--- a/test/test_rpmdeps_obsoletes.py
+++ b/test/test_rpmdeps_obsoletes.py
@@ -1220,81 +1220,81 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-# XXX: this test needs to be rewritten to properly dupe the shared library
-# class MultipleProvidersCompareRPMs(TestCompareRPMs):
-#    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
-#    def setUp(self):
-#        super().setUp()
-#
-#        # add subpackages
-#        self.before_rpm.add_subpackage("libs")
-#        self.before_rpm.add_subpackage("morelibs")
-#        self.after_rpm.add_subpackage("libs")
-#        self.after_rpm.add_subpackage("morelibs")
-#
-#        # we need some stuff in the packages, first a shared library
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#
-#        # now add a program linked with that library
-#        sourceFileName = "main.c"
-#        installPath = "usr/bin/vaporware"
-#
-#        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.before_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.before_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.before_rpm.create_parent_dirs(installPath)
-#        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.before_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.before_rpm.add_payload_check(installPath, None)
-#
-#        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.after_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.after_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.after_rpm.create_parent_dirs(installPath)
-#        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.after_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.after_rpm.add_payload_check(installPath, None)
-#
-#        # add an explicit obsoletes on the libs package
-#        self.before_rpm.add_obsoletes("vaporware-libs = %{version}-%{release}")
-#        self.after_rpm.add_obsoletes("vaporware-libs = %{version}-%{release}")
-#
-#        self.inspection = "rpmdeps"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Anyone"
+class MultipleProvidersCompareRPMs(TestCompareRPMs):
+    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
+    def setUp(self):
+        super().setUp()
+
+        # add subpackages
+        self.before_rpm.add_subpackage("libs")
+        self.before_rpm.add_subpackage("morelibs")
+        self.after_rpm.add_subpackage("libs")
+        self.after_rpm.add_subpackage("morelibs")
+
+        # we need some stuff in the packages, first a shared library
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+
+        # now add a program linked with that library
+        sourceFileName = "main.c"
+        installPath = "usr/bin/vaporware"
+
+        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.before_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.before_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.before_rpm.create_parent_dirs(installPath)
+        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.before_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.before_rpm.add_payload_check(installPath, None)
+
+        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.after_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.after_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.after_rpm.create_parent_dirs(installPath)
+        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.after_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.after_rpm.add_payload_check(installPath, None)
+
+        # add an explicit obsoletes on the libs package
+        self.before_rpm.add_obsoletes("vaporware-libs = %{version}-%{release}")
+        self.after_rpm.add_obsoletes("vaporware-libs = %{version}-%{release}")
+
+        # result is OK because this check is a no-op when comparing single RPMs
+        self.inspection = "rpmdeps"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):

--- a/test/test_rpmdeps_provides.py
+++ b/test/test_rpmdeps_provides.py
@@ -1220,81 +1220,81 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-# XXX: this test needs to be rewritten to properly dupe the shared library
-# class MultipleProvidersCompareRPMs(TestCompareRPMs):
-#    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
-#    def setUp(self):
-#        super().setUp()
-#
-#        # add subpackages
-#        self.before_rpm.add_subpackage("libs")
-#        self.before_rpm.add_subpackage("morelibs")
-#        self.after_rpm.add_subpackage("libs")
-#        self.after_rpm.add_subpackage("morelibs")
-#
-#        # we need some stuff in the packages, first a shared library
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#
-#        # now add a program linked with that library
-#        sourceFileName = "main.c"
-#        installPath = "usr/bin/vaporware"
-#
-#        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.before_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.before_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.before_rpm.create_parent_dirs(installPath)
-#        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.before_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.before_rpm.add_payload_check(installPath, None)
-#
-#        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.after_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.after_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.after_rpm.create_parent_dirs(installPath)
-#        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.after_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.after_rpm.add_payload_check(installPath, None)
-#
-#        # add an explicit provides on the libs package
-#        self.before_rpm.add_provides("vaporware-libs = %{version}-%{release}")
-#        self.after_rpm.add_provides("vaporware-libs = %{version}-%{release}")
-#
-#        self.inspection = "rpmdeps"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Anyone"
+class MultipleProvidersCompareRPMs(TestCompareRPMs):
+    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
+    def setUp(self):
+        super().setUp()
+
+        # add subpackages
+        self.before_rpm.add_subpackage("libs")
+        self.before_rpm.add_subpackage("morelibs")
+        self.after_rpm.add_subpackage("libs")
+        self.after_rpm.add_subpackage("morelibs")
+
+        # we need some stuff in the packages, first a shared library
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+
+        # now add a program linked with that library
+        sourceFileName = "main.c"
+        installPath = "usr/bin/vaporware"
+
+        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.before_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.before_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.before_rpm.create_parent_dirs(installPath)
+        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.before_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.before_rpm.add_payload_check(installPath, None)
+
+        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.after_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.after_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.after_rpm.create_parent_dirs(installPath)
+        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.after_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.after_rpm.add_payload_check(installPath, None)
+
+        # add an explicit provides on the libs package
+        self.before_rpm.add_provides("vaporware-libs = %{version}-%{release}")
+        self.after_rpm.add_provides("vaporware-libs = %{version}-%{release}")
+
+        # result is OK because this check is a no-op when comparing single RPMs
+        self.inspection = "rpmdeps"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):

--- a/test/test_rpmdeps_recommends.py
+++ b/test/test_rpmdeps_recommends.py
@@ -1275,82 +1275,82 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-# XXX: this test needs to be rewritten to properly dupe the shared library
-# class MultipleProvidersCompareRPMs(TestCompareRPMs):
-#    @unittest.skipUnless(have_recommends, "librpm too old to support Recommends")
-#    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
-#    def setUp(self):
-#        super().setUp()
-#
-#        # add subpackages
-#        self.before_rpm.add_subpackage("libs")
-#        self.before_rpm.add_subpackage("morelibs")
-#        self.after_rpm.add_subpackage("libs")
-#        self.after_rpm.add_subpackage("morelibs")
-#
-#        # we need some stuff in the packages, first a shared library
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#
-#        # now add a program linked with that library
-#        sourceFileName = "main.c"
-#        installPath = "usr/bin/vaporware"
-#
-#        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.before_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.before_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.before_rpm.create_parent_dirs(installPath)
-#        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.before_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.before_rpm.add_payload_check(installPath, None)
-#
-#        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.after_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.after_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.after_rpm.create_parent_dirs(installPath)
-#        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.after_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.after_rpm.add_payload_check(installPath, None)
-#
-#        # add an explicit recommends on the libs package
-#        self.before_rpm.add_recommends("vaporware-libs = %{version}-%{release}")
-#        self.after_rpm.add_recommends("vaporware-libs = %{version}-%{release}")
-#
-#        self.inspection = "rpmdeps"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Anyone"
+class MultipleProvidersCompareRPMs(TestCompareRPMs):
+    @unittest.skipUnless(have_recommends, "librpm too old to support Recommends")
+    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
+    def setUp(self):
+        super().setUp()
+
+        # add subpackages
+        self.before_rpm.add_subpackage("libs")
+        self.before_rpm.add_subpackage("morelibs")
+        self.after_rpm.add_subpackage("libs")
+        self.after_rpm.add_subpackage("morelibs")
+
+        # we need some stuff in the packages, first a shared library
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+
+        # now add a program linked with that library
+        sourceFileName = "main.c"
+        installPath = "usr/bin/vaporware"
+
+        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.before_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.before_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.before_rpm.create_parent_dirs(installPath)
+        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.before_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.before_rpm.add_payload_check(installPath, None)
+
+        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.after_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.after_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.after_rpm.create_parent_dirs(installPath)
+        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.after_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.after_rpm.add_payload_check(installPath, None)
+
+        # add an explicit recommends on the libs package
+        self.before_rpm.add_recommends("vaporware-libs = %{version}-%{release}")
+        self.after_rpm.add_recommends("vaporware-libs = %{version}-%{release}")
+
+        # result is OK because this check is a no-op when comparing single RPMs
+        self.inspection = "rpmdeps"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):

--- a/test/test_rpmdeps_requires.py
+++ b/test/test_rpmdeps_requires.py
@@ -1334,81 +1334,81 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-# XXX: this test needs to be rewritten to properly dupe the shared library
-# class MultipleProvidersCompareRPMs(TestCompareRPMs):
-#    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
-#    def setUp(self):
-#        super().setUp()
-#
-#        # add subpackages
-#        self.before_rpm.add_subpackage("libs")
-#        self.before_rpm.add_subpackage("morelibs")
-#        self.after_rpm.add_subpackage("libs")
-#        self.after_rpm.add_subpackage("morelibs")
-#
-#        # we need some stuff in the packages, first a shared library
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#
-#        # now add a program linked with that library
-#        sourceFileName = "main.c"
-#        installPath = "usr/bin/vaporware"
-#
-#        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.before_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.before_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.before_rpm.create_parent_dirs(installPath)
-#        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.before_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.before_rpm.add_payload_check(installPath, None)
-#
-#        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.after_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.after_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.after_rpm.create_parent_dirs(installPath)
-#        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.after_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.after_rpm.add_payload_check(installPath, None)
-#
-#        # add an explicit requires on the libs package
-#        self.before_rpm.add_requires("vaporware-libs = %{version}-%{release}")
-#        self.after_rpm.add_requires("vaporware-libs = %{version}-%{release}")
-#
-#        self.inspection = "rpmdeps"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Anyone"
+class MultipleProvidersCompareRPMs(TestCompareRPMs):
+    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
+    def setUp(self):
+        super().setUp()
+
+        # add subpackages
+        self.before_rpm.add_subpackage("libs")
+        self.before_rpm.add_subpackage("morelibs")
+        self.after_rpm.add_subpackage("libs")
+        self.after_rpm.add_subpackage("morelibs")
+
+        # we need some stuff in the packages, first a shared library
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+
+        # now add a program linked with that library
+        sourceFileName = "main.c"
+        installPath = "usr/bin/vaporware"
+
+        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.before_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.before_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.before_rpm.create_parent_dirs(installPath)
+        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.before_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.before_rpm.add_payload_check(installPath, None)
+
+        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.after_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.after_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.after_rpm.create_parent_dirs(installPath)
+        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.after_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.after_rpm.add_payload_check(installPath, None)
+
+        # add an explicit requires on the libs package
+        self.before_rpm.add_requires("vaporware-libs = %{version}-%{release}")
+        self.after_rpm.add_requires("vaporware-libs = %{version}-%{release}")
+
+        # result is OK because this check is a no-op when comparing single RPMs
+        self.inspection = "rpmdeps"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):

--- a/test/test_rpmdeps_suggests.py
+++ b/test/test_rpmdeps_suggests.py
@@ -1281,82 +1281,82 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-# XXX: this test needs to be rewritten to properly dupe the shared library
-# class MultipleProvidersCompareRPMs(TestCompareRPMs):
-#    @unittest.skipUnless(have_suggests, "librpm too old to support Suggests")
-#    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
-#    def setUp(self):
-#        super().setUp()
-#
-#        # add subpackages
-#        self.before_rpm.add_subpackage("libs")
-#        self.before_rpm.add_subpackage("morelibs")
-#        self.after_rpm.add_subpackage("libs")
-#        self.after_rpm.add_subpackage("morelibs")
-#
-#        # we need some stuff in the packages, first a shared library
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#
-#        # now add a program linked with that library
-#        sourceFileName = "main.c"
-#        installPath = "usr/bin/vaporware"
-#
-#        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.before_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.before_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.before_rpm.create_parent_dirs(installPath)
-#        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.before_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.before_rpm.add_payload_check(installPath, None)
-#
-#        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.after_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.after_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.after_rpm.create_parent_dirs(installPath)
-#        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.after_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.after_rpm.add_payload_check(installPath, None)
-#
-#        # add an explicit suggests on the libs package
-#        self.before_rpm.add_suggests("vaporware-libs = %{version}-%{release}")
-#        self.after_rpm.add_suggests("vaporware-libs = %{version}-%{release}")
-#
-#        self.inspection = "rpmdeps"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Anyone"
+class MultipleProvidersCompareRPMs(TestCompareRPMs):
+    @unittest.skipUnless(have_suggests, "librpm too old to support Suggests")
+    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
+    def setUp(self):
+        super().setUp()
+
+        # add subpackages
+        self.before_rpm.add_subpackage("libs")
+        self.before_rpm.add_subpackage("morelibs")
+        self.after_rpm.add_subpackage("libs")
+        self.after_rpm.add_subpackage("morelibs")
+
+        # we need some stuff in the packages, first a shared library
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+
+        # now add a program linked with that library
+        sourceFileName = "main.c"
+        installPath = "usr/bin/vaporware"
+
+        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.before_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.before_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.before_rpm.create_parent_dirs(installPath)
+        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.before_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.before_rpm.add_payload_check(installPath, None)
+
+        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.after_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.after_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.after_rpm.create_parent_dirs(installPath)
+        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.after_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.after_rpm.add_payload_check(installPath, None)
+
+        # add an explicit suggests on the libs package
+        self.before_rpm.add_suggests("vaporware-libs = %{version}-%{release}")
+        self.after_rpm.add_suggests("vaporware-libs = %{version}-%{release}")
+
+        # result is OK because this check is a no-op when comparing single RPMs
+        self.inspection = "rpmdeps"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):

--- a/test/test_rpmdeps_supplements.py
+++ b/test/test_rpmdeps_supplements.py
@@ -1281,82 +1281,82 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-# XXX: this test needs to be rewritten to properly dupe the shared library
-# class MultipleProvidersCompareRPMs(TestCompareRPMs):
-#    @unittest.skipUnless(have_supplements, "librpm too old to support Supplements")
-#    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
-#    def setUp(self):
-#        super().setUp()
-#
-#        # add subpackages
-#        self.before_rpm.add_subpackage("libs")
-#        self.before_rpm.add_subpackage("morelibs")
-#        self.after_rpm.add_subpackage("libs")
-#        self.after_rpm.add_subpackage("morelibs")
-#
-#        # we need some stuff in the packages, first a shared library
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.before_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="libs",
-#            sourceContent=library_source,
-#        )
-#        self.after_rpm.add_simple_library(
-#            libraryName="libvaporware.so",
-#            installPath="usr/lib/libvaporware.so",
-#            subpackageSuffix="morelibs",
-#            sourceContent=library_source,
-#        )
-#
-#        # now add a program linked with that library
-#        sourceFileName = "main.c"
-#        installPath = "usr/bin/vaporware"
-#
-#        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.before_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.before_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.before_rpm.create_parent_dirs(installPath)
-#        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.before_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.before_rpm.add_payload_check(installPath, None)
-#
-#        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
-#        self.after_rpm.section_build += (
-#            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
-#        )
-#        self.after_rpm.section_build += (
-#            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
-#        )
-#        self.after_rpm.create_parent_dirs(installPath)
-#        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
-#        binsub = self.after_rpm.get_subpackage(None)
-#        binsub.section_files += "/%s\n" % installPath
-#        self.after_rpm.add_payload_check(installPath, None)
-#
-#        # add an explicit supplements on the libs package
-#        self.before_rpm.add_supplements("vaporware-libs = %{version}-%{release}")
-#        self.after_rpm.add_supplements("vaporware-libs = %{version}-%{release}")
-#
-#        self.inspection = "rpmdeps"
-#        self.result = "VERIFY"
-#        self.waiver_auth = "Anyone"
+class MultipleProvidersCompareRPMs(TestCompareRPMs):
+    @unittest.skipUnless(have_supplements, "librpm too old to support Supplements")
+    @unittest.skipUnless(have_elfdeps, "system lacks %s executable" % elfdeps)
+    def setUp(self):
+        super().setUp()
+
+        # add subpackages
+        self.before_rpm.add_subpackage("libs")
+        self.before_rpm.add_subpackage("morelibs")
+        self.after_rpm.add_subpackage("libs")
+        self.after_rpm.add_subpackage("morelibs")
+
+        # we need some stuff in the packages, first a shared library
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.before_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="libs",
+            sourceContent=library_source,
+        )
+        self.after_rpm.add_simple_library(
+            libraryName="libvaporware.so",
+            installPath="usr/lib/libvaporware.so",
+            subpackageSuffix="morelibs",
+            sourceContent=library_source,
+        )
+
+        # now add a program linked with that library
+        sourceFileName = "main.c"
+        installPath = "usr/bin/vaporware"
+
+        self.before_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.before_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.before_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.before_rpm.create_parent_dirs(installPath)
+        self.before_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.before_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.before_rpm.add_payload_check(installPath, None)
+
+        self.after_rpm.add_source(SourceFile(sourceFileName, hello_lib_world))
+        self.after_rpm.section_build += (
+            "%if 0%{?__isa_bits} == 32\n%define mopt -m32\n%endif\n"
+        )
+        self.after_rpm.section_build += (
+            CC + " %%{?mopt} %s -L. -lvaporware\n" % sourceFileName
+        )
+        self.after_rpm.create_parent_dirs(installPath)
+        self.after_rpm.section_install += "cp a.out $RPM_BUILD_ROOT/%s\n" % installPath
+        binsub = self.after_rpm.get_subpackage(None)
+        binsub.section_files += "/%s\n" % installPath
+        self.after_rpm.add_payload_check(installPath, None)
+
+        # add an explicit supplements on the libs package
+        self.before_rpm.add_supplements("vaporware-libs = %{version}-%{release}")
+        self.after_rpm.add_supplements("vaporware-libs = %{version}-%{release}")
+
+        # result is OK because this check is a no-op when comparing single RPMs
+        self.inspection = "rpmdeps"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):


### PR DESCRIPTION
For rpmdeps, these test cases were expecting a VERIFY result waivable
by Anyone, but that was actually wrong.  The last commit to fix
rpmdeps actually corrected what rpminspect was doing so that these
test cases should be an OK result that are not waivable.  The reason
is the multiple providers check in rpmdeps can't work when comparing
two single RPMs, so it's effectively a no-op.  The multiple providers
check only works when comparing Koji builds because you have all the
subpackages in that case and rpminspect can examine all of them.

Signed-off-by: David Cantrell <dcantrell@redhat.com>