### PR TITLE
[lib] Change how debuginfo dirs are matched for files

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -436,6 +436,13 @@
 #define DEBUG_SUBSTRING "debug"
 
 /**
+ * @def DEBUG_FILE_SUFFIX
+ *
+ * The substring appearing at the end of debuginfo files.
+ */
+#define DEBUG_FILE_SUFFIX ".debug"
+
+/**
  * @def KERNEL_MODULES_DIR
  *
  * Linux loadable kernel modules subdirectory.

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -386,12 +386,12 @@ char *bytes_to_str(unsigned char *array, size_t len);
  * IMPORTANT: Do not free the returned string.
  *
  * @param ri The struct rpminspect for the program.
+ * @param file The file we are looking for debuginfo for.
  * @param binarch The required debuginfo architecture.
- * @param subpkg Optional subpackage name to get the debuginfo for.
  * @return Full path to the extract before build debuginfo package, or
  * NULL if not found.
  */
-const char *get_before_debuginfo_path(struct rpminspect *ri, const char *binarch, const char *subpkg);
+const char *get_before_debuginfo_path(struct rpminspect *ri, const rpmfile_entry_t *file, const char *binarch);
 
 /**
  * @brief Return the after build debuginfo package path where the
@@ -401,12 +401,13 @@ const char *get_before_debuginfo_path(struct rpminspect *ri, const char *binarch
  * IMPORTANT: Do not free the returned string.
  *
  * @param ri The struct rpminspect for the program.
+ * @param file The file we are looking for debuginfo for.
  * @param binarch The required debuginfo architecture.
- * @param subpkg Optional subpackage name to get the debuginfo for.
  * @return Full path to the extract after build debuginfo package, or
  * NULL if not found.
  */
-const char *get_after_debuginfo_path(struct rpminspect *ri, const char *binarch, const char *subpkg);
+const char *get_after_debuginfo_path(struct rpminspect *ri, const rpmfile_entry_t *file, const char *binarch);
+
 bool usable_path(const char *path);
 bool match_path(const char *pattern, const char *root, const char *path);
 
@@ -536,5 +537,25 @@ bool is_remote_rpm(const char *url);
  *         must free.
  */
 char *human_size(const unsigned long bytes);
+
+/* joinpath.c */
+/**
+ * @brief Join path substrings in to a single allocated and normalized
+ * path string.  Caller must free this string.
+ *
+ * Given a list of path components as separate strings, join them in to a
+ * correct (but unverified) Unix path.  Extra slashes are removed.  Spaces
+ * and other special characters are not escaped.  This function allocates
+ * memory for the returned value.  The caller must free this memory when
+ * done.
+ *
+ * Usage: path = joinpath(a, b, c, ..., NULL);
+ * (where a, b, and c are char *)
+ *
+ * @param path One or more strings that form path components.  These
+ *             will be joined together and delimited with slashes.
+ * @return Allocated path string that the caller must free.
+ */
+char *joinpath(const char *path, ...);
 
 #endif

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -83,8 +83,6 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool result = true;
     const char *arch = NULL;
-    const char *before = NULL;
-    const char *after = NULL;
     char **argv = NULL;
     char *before_cmd = NULL;
     char *after_cmd = NULL;
@@ -133,19 +131,15 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Run each annocheck test and report the results */
     HASH_ITER(hh, ri->annocheck, hentry, tmp_hentry) {
-        after = headerGetString(file->rpm_header, RPMTAG_NAME);
-
         /* Run the test on the file */
-        after_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, get_after_debuginfo_path(ri, arch, after), file->fullpath);
+        after_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, get_after_debuginfo_path(ri, file, arch), file->fullpath);
         argv = build_argv(after_cmd);
         after_out = run_cmd_vpe(&after_exit, ri->worksubdir, argv);
         free_argv(argv);
 
         /* If we have a before build, run the command on that */
         if (file->peer_file) {
-            before = headerGetString(file->peer_file->rpm_header, RPMTAG_NAME);
-
-            before_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, get_before_debuginfo_path(ri, arch, before), file->peer_file->fullpath);
+            before_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, get_before_debuginfo_path(ri, file, arch), file->peer_file->fullpath);
             argv = build_argv(before_cmd);
             before_out = run_cmd_vpe(&before_exit, ri->workdir, argv);
             free_argv(argv);

--- a/lib/joinpath.c
+++ b/lib/joinpath.c
@@ -1,0 +1,136 @@
+/*
+ * Given a list of path components as separate strings, join them in to a
+ * correct (but unverified) Unix path.  Extra slashes are removed.  Spaces
+ * and other special characters are not escaped.  This function allocates
+ * memory for the returned value.  The caller must free this memory when
+ * done.
+ *
+ * Usage: path = join(a, b, c, ..., NULL);
+ * (where a, b, and c are char *)
+ */
+
+/* {{{ Apache License version 2.0
+ */
+/*
+ * Copyright 2018 David Cantrell <david.l.cantrell@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* }}} */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include "rpminspect.h"
+
+char *joinpath(const char *path, ...)
+{
+    va_list ap;
+    int i = 0;
+    int extralen = 0;
+    bool needsep = false;
+    char *element = NULL;
+    char *tail = NULL;
+    char *built = NULL;
+    char *tmp = NULL;
+    char *near = NULL;
+    char *far = NULL;
+
+    assert(path != NULL);
+
+    /* Allocate a large buffer to use for building the path. */
+    built = calloc(1, PATH_MAX + 1);
+    assert(built != NULL);
+
+    /* Make sure the full path starts with a slash. */
+    if (*path == '/') {
+        /* this for loop trims multiple leading slashes down to just one */
+        while (*(path + 1) == '/') path++;
+    }
+
+    /* begin our joined path */
+    tail = stpcpy(built, path);
+
+    /* the remaining elements come in this way */
+    va_start(ap, path);
+
+    while ((element = va_arg(ap, char *)) != NULL) {
+        /* for the trailing NUL */
+        extralen = 1;
+        needsep = false;
+
+        /* trim any extra trailing slashes */
+        i = strlen(built);
+
+        while (*tail == '/') {
+            *tail = '\0';
+            tail--;
+        }
+
+        /*
+         * This loop trims multiple leading slashes down to just one.
+         * If 'i' is 1, it will preserve 1 leading slash.  Actually, set
+         * this to the number of slashes to preserve.
+         */
+        if (*element == '/' && *tail != '/') {
+            i = 1;
+        } else {
+            i = 0;
+        }
+
+        while (*(element + i) == '/') element++;
+
+        /* make sure we have at least one slash in case there are none */
+        if (*element != '/' && *tail != '/') {
+            extralen++;
+            needsep = true;
+        }
+
+        /* perform the concatenations */
+        if (needsep) {
+            tail = stpcpy(tail, "/");
+        }
+
+        tail = stpcpy(tail, element);
+    }
+
+    va_end(ap);
+
+    /* it's possible there are repeating slashes, eliminate them */
+    near = built;
+    far = built;
+
+    while ((*near = *far)) {
+        if (*near == '/') {
+            while (*far == '/') {
+                far++;
+            }
+
+            near++;
+        } else {
+            near++;
+            far++;
+        }
+    }
+
+    /* shrink memory allocation */
+    tmp = realloc(built, strlen(built) + 1);
+    built = tmp;
+
+    return built;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -77,6 +77,7 @@ librpminspect_sources = [
     'inspect_upstream.c',
     'inspect_virus.c',
     'inspect_xml.c',
+    'joinpath.c',
     'koji.c',
     'listfuncs.c',
     'local.c',


### PR DESCRIPTION
The previous debuginfo path finding code relied on the common practice
of the debuginfo packages being named after their corresponding
subpackage name.  For example if you have a package named "tuna" with
subpackages "tuna-libs" and "tuna-devel" then you will probably find
debuginfo packages named "tuna-debuginfo", "tuna-libs-debuginfo", and
"tuna-devel-debuginfo" (subject to the contents of the subpackages).
The matching code simply looked for a debuginfo package name that
matched this naming style.  But that disregards any spec file that
changes where debuginfo files land.

This commit changes how librpminspect finds debuginfo subpackages by
looking for the actual file in question based on rpm's naming pattern.
My first approach was to match based on Build-ID from the ELF
metadata, but that failed a number of test cases I had because of
using older binutils releases, older versions of rpm, or entirely
different language toolchains.  While I am not a fan of matching this
way, it is more correct than what librpminspect was doing.

Fixes: #703

Signed-off-by: David Cantrell <dcantrell@redhat.com>