### PR TITLE
[fix] Handle PatchN: lines in spec files with no space after ':'

### DIFF
--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -407,3 +407,41 @@ class PatchesDefinedButSomeNotAppliedCompareSRPM(TestCompareSRPM):
         self.inspection = "patches"
         self.result = "VERIFY"
         self.waiver_auth = "Anyone"
+
+
+# patch defined without a space after ':'
+class PatchDefinedWithoutFieldSpaceSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add a patch without a space after the ':'
+        patch = rpmfluff.SourceFile("some.patch", patch_file)
+        patchIndex = len(self.rpm.patches)
+        self.rpm.patches[patchIndex] = patch
+        self.rpm.section_patches += "Patch%s:%s\n" % (patchIndex, patch.sourceName)
+        self.rpm.add_check(rpmfluff.CheckSourceFile(patch.sourceName))
+        self.rpm.section_prep += "%%patch%i\n" % patchIndex
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class PatchDefinedWithoutFieldSpaceCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add a patch without a space after the ':'
+        patch = rpmfluff.SourceFile("some.patch", patch_file)
+        patchIndex = len(self.after_rpm.patches)
+        self.after_rpm.patches[patchIndex] = patch
+        self.after_rpm.section_patches += "Patch%s:%s\n" % (
+            patchIndex,
+            patch.sourceName,
+        )
+        self.after_rpm.add_check(rpmfluff.CheckSourceFile(patch.sourceName))
+        self.after_rpm.section_prep += "%%patch%i\n" % patchIndex
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
Some spec files may define patches like this:

    Patch47:name-of-patch-file.patch

Which is fine, but rpminspect was expecting some whitespace after the
colon.  So adapt the inspection code to handle this case as well.  Add
some test cases for it too.

Fixes: #730

Signed-off-by: David Cantrell <dcantrell@redhat.com>