### PR TITLE
[lib] Add strtrim() function to librpminspect

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -213,6 +213,7 @@ char *strappend(char *, ...);
 string_list_t *strsplit(const char *, const char *);
 const char *strtype(const mode_t mode);
 char *strshorten(const char *s, size_t width);
+char *strtrim(char *s);
 
 /**
  * @brief Return descriptive string for the given exit code.

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -641,3 +641,43 @@ const char *strexitcode(int exitcode)
 
     return "";
 }
+
+/*
+ * Trims leading and trailing whitespace from a dynamically allocated
+ * string.  NOTE:  Must call this on a string that has been malloc'ed
+ * so free() can be called.  This function uses memmove() and realloc().
+ */
+char *strtrim(char *s)
+{
+    size_t i = 0;
+
+    if (s == NULL) {
+        return s;
+    }
+
+    /* remove leading whitespace */
+    while (isspace(*s) && *s != '\0') {
+        s++;
+    }
+
+    if (s == NULL) {
+        return s;
+    }
+
+    /* go to the end and remove trailing whitespace */
+    i = strlen(s) - 1;
+
+    while (isspace(s[i])) {
+        s[i] = '\0';
+        i--;
+    }
+
+    if (s == NULL) {
+        return s;
+    }
+
+    /* reallocate memory block */
+    s = realloc(s, strlen(s) + 1);
+
+    return s;
+}


### PR DESCRIPTION
Given an allocated string, strtrim() will trim leading and trailing
whitespace and then realloc() the resulting string and return a
pointer to that.  The string is modified in place.

Signed-off-by: David Cantrell <dcantrell@redhat.com>