### PR TITLE
[lib] In strsplit(), skip empty string tokens

### DIFF
--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -534,6 +534,10 @@ string_list_t *strsplit(const char *s, const char *delim)
 
     /* split the string and build the list */
     while ((token = strsep(&walk, delim)) != NULL) {
+        if (!strcmp(token, "")) {
+            continue;
+        }
+
         entry = calloc(1, sizeof(*entry));
         assert(entry != NULL);
         entry->data = strdup(token);


### PR DESCRIPTION
When strsplit() tokenizes a string, exclude the empty string tokens
since those aren't really useful to callers anyway.  Or they shouldn't
be.

Signed-off-by: David Cantrell <dcantrell@redhat.com>