### PR TITLE
[lib] Replace rpmDefineMacro usage with rpmPushMacro

### DIFF
--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
+#include <err.h>
 #include <rpm/rpmmacro.h>
 #include "rpminspect.h"
 
@@ -251,7 +252,10 @@ bool inspect_disttag(struct rpminspect *ri)
             }
 
             /* Define the dist macro for rpminspect */
-            (void) rpmDefineMacro(NULL, "dist " DIST_TAG_MARKER, 0);
+            if (rpmPushMacro(NULL, "dist", NULL, DIST_TAG_MARKER, RMIL_GLOBAL)) {
+                warnx("rpmPushMacro");
+                _exit(EXIT_FAILURE);
+            }
 
             /* Analyze the spec file */
             result = disttag_driver(ri, file);

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -130,7 +130,6 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
     size_t n = BUFSIZ;
     char *buf = NULL;
     rpmSpec spec = NULL;
-    char *macro = NULL;
     rpmts ts = NULL;
     BTA_t ba = NULL;
     char *topdir = NULL;
@@ -164,10 +163,12 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
         /* define our top dir */
         topdir = make_source_dirs(ri->worksubdir, file->fullpath);
         assert(topdir != NULL);
-        xasprintf(&macro, "_topdir %s", topdir);
-        assert(macro != NULL);
-        (void) rpmDefineMacro(NULL, macro, 0);
-        free(macro);
+
+        if (rpmPushMacro(NULL, "_topdir", NULL, topdir, RMIL_GLOBAL)) {
+            warnx("rpmPushMacro");
+            _exit(EXIT_FAILURE);
+        }
+
         free(topdir);
 
         /* read in the spec file */


### PR DESCRIPTION
I see librpm using rpmPushMacro over rpmDefineMacro, so switching over
to that.  I am still seeing some lua lib errors when running through
valgrind, but nothing fatal.

Signed-off-by: David Cantrell <dcantrell@redhat.com>