### PR TITLE
Revert "[lib] Replace rpmDefineMacro usage with rpmPushMacro"

### DIFF
--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -24,7 +24,6 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
-#include <err.h>
 #include <rpm/rpmmacro.h>
 #include "rpminspect.h"
 
@@ -252,10 +251,7 @@ bool inspect_disttag(struct rpminspect *ri)
             }
 
             /* Define the dist macro for rpminspect */
-            if (rpmPushMacro(NULL, "dist", NULL, DIST_TAG_MARKER, RMIL_GLOBAL)) {
-                warnx("rpmPushMacro");
-                _exit(EXIT_FAILURE);
-            }
+            (void) rpmDefineMacro(NULL, "dist " DIST_TAG_MARKER, 0);
 
             /* Analyze the spec file */
             result = disttag_driver(ri, file);

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -130,6 +130,7 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
     size_t n = BUFSIZ;
     char *buf = NULL;
     rpmSpec spec = NULL;
+    char *macro = NULL;
     rpmts ts = NULL;
     BTA_t ba = NULL;
     char *topdir = NULL;
@@ -163,12 +164,10 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
         /* define our top dir */
         topdir = make_source_dirs(ri->worksubdir, file->fullpath);
         assert(topdir != NULL);
-
-        if (rpmPushMacro(NULL, "_topdir", NULL, topdir, RMIL_GLOBAL)) {
-            warnx("rpmPushMacro");
-            _exit(EXIT_FAILURE);
-        }
-
+        xasprintf(&macro, "_topdir %s", topdir);
+        assert(macro != NULL);
+        (void) rpmDefineMacro(NULL, macro, 0);
+        free(macro);
         free(topdir);
 
         /* read in the spec file */


### PR DESCRIPTION
This reverts commit f7c30050e8b09ad80cda54a180325fbde1d10f50.

Does not work on CentOS 7 or RHEL 7 hosts because the version of rpm
provided there does not provide rpmPushMacro() in the API, only
rpmDefineMacro().