### PR TITLE
[fix] Handle more auto deps in the kernel package correctly

### DIFF
--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -132,7 +132,8 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
             if (!strcmp(r, "debuginfo(build-id)")
                 || strsuffix(r, DEBUGSOURCE_SUFFIX)
                 || strsuffix(r, DEBUGINFO_SUFFIX)
-                || ((strprefix(r, "rpmlib(") || strprefix(r, "rtld(")) && strsuffix(r, ")"))) {
+                || ((strprefix(r, "rpmlib(") || strprefix(r, "rtld(")) && strsuffix(r, ")"))
+                || ((strprefix(r, "kernel(") || strprefix(r, "modalias(") || strprefix(r, "ksym(") || strprefix(r, "kmod(")) && strsuffix(r, ")"))) {
                 continue;
             }
 
@@ -403,7 +404,8 @@ const char *get_deprule_operator_desc(const dep_op_t operator)
     }
 }
 
-/*                                                                                                                                                                   * Given a deprule, construct a human-readable version of it.  Caller
+/*
+ * Given a deprule, construct a human-readable version of it.  Caller
  * must free the returned string.
  */
 char *strdeprule(const deprule_entry_t *deprule)


### PR DESCRIPTION
The kernel package has some additional deps that need handling by the
rpmdeps inspection.  Namely:

1) Ignore autodep rules of the form kernel(), modalias(), ksym(), and
kmod().  The kmod inspection handles what we need to check for kernel
modules.

2) Expected deprule changes may have the dependency version string end
with ".%{arch}", "+STRING", or ".%{arch}+STRING".  These cases are
checked for as well.

3) Some autodeps are names that do not map to a specific subpackage,
but are a virtual dependency and explicitly matches the package
version-release string.  In these cases the dependency change (if
there is one) is expected.

Fixes: #735

Signed-off-by: David Cantrell <dcantrell@redhat.com>