### PR TITLE
[fix] Correctly pick up the use of %autopatch or %autosetup

### DIFF
--- a/include/results.h
+++ b/include/results.h
@@ -685,9 +685,9 @@
 
 #define REMEDY_PATCHES_CORRUPT _("An invalid patch file was found.  This is usually the result of generating a collection of patches by comparing two trees.  When files disappear that can lead to zero length patches in the resulting collection.  Check to see if the source package has any zero length or otherwise invalid patches and correct the problem.")
 
-#define REMEDY_PATCHES_MISSING_MACRO _("The named patch is defined in the source RPM header (this means it has a PatchN: definition in the spec file) but is not applied anywhere in the spec file.  It is missing a corresponding %%patch macro and the spec file lacks the %%autosetup or %%autopatch macros.  You can fix this by adding the appropriate %%patch macro in the spec file (usually in the %%prep section).  The number specified with the %%patch macro corresponds to the number used to define the patch at the top of the spec file.  So Patch47 is applied with a %%patch47 macro.")
+#define REMEDY_PATCHES_MISSING_MACRO _("The named patch is defined in the source RPM header (this means it has a PatchN: definition in the spec file) but is not applied anywhere in the spec file.  It is missing a corresponding %patch macro and the spec file lacks the %autosetup or %autopatch macros.  You can fix this by adding the appropriate %patch macro in the spec file (usually in the %prep section).  The number specified with the %patch macro corresponds to the number used to define the patch at the top of the spec file.  So Patch47 is applied with a %patch47 macro.")
 
-#define REMEDY_PATCHES_MISMATCHED_MACRO _("The named patch is defined but is mismatched by number with the %%patch macro.  Make sure all numbered patches have corresponding %%patch macros.  For example, Patch47 needs to have a %%patch47 macro.")
+#define REMEDY_PATCHES_MISMATCHED_MACRO _("The named patch is defined but is mismatched by number with the %patch macro.  Make sure all numbered patches have corresponding %patch macros.  For example, Patch47 needs to have a %patch47 macro.")
 
 /** @} */
 
@@ -757,7 +757,7 @@
 
 #define REMEDY_RPMDEPS_EXPLICIT_EPOCH _("Add the indicated explicit Requires to the spec file for the named subpackage.  Subpackages depending on shared libraries in another subpackage must carry an explicit 'Requires: SUBPACKAGE_NAME = %{epoch}:%{version}-%{release}' in the spec file.")
 
-#define REMEDY_RPMDEPS_MULTIPLE _("Check subpackage %%files sections and explicit Provides statements.  Only one subpackage should provide a given shared library.  Shared library names are automatically added as Provides, so there is no need to specify them in the spec file but you do need to make sure only one subpackage is packaging up the shared library in question.")
+#define REMEDY_RPMDEPS_MULTIPLE _("Check subpackage %files sections and explicit Provides statements.  Only one subpackage should provide a given shared library.  Shared library names are automatically added as Provides, so there is no need to specify them in the spec file but you do need to make sure only one subpackage is packaging up the shared library in question.")
 
 #define REMEDY_RPMDEPS_CHANGED _("A dependency listed in the before build changed to the indicated dependency in the after build.  If this is a VERIFY result, it means rpminspect noticed the change in what it considers a maintenance update in a package.  An INFO result means it noticed this change, but deems it ok because it is comparing a rebased build.")
 

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -142,8 +142,12 @@ static bool have_automacro(const rpmfile_entry_t *specfile)
         }
 
         /* look for the auto macros */
+        /*
+         * this matches lines that are either the macro itself, or the
+         * macro followed by one or more options
+         */
         if (in_valid_section && (!strcmp(buf, SPEC_MACRO_AUTOPATCH) || strprefix(buf, SPEC_MACRO_AUTOPATCH" ")
-                                 || strcmp(buf, SPEC_MACRO_AUTOSETUP) || strprefix(buf, SPEC_MACRO_AUTOSETUP" "))) {
+                                 || !strcmp(buf, SPEC_MACRO_AUTOSETUP) || strprefix(buf, SPEC_MACRO_AUTOSETUP" "))) {
             r = true;
             break;
         }

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -229,7 +229,6 @@ bool match_path(const char *pattern, const char *root, const char *path)
 
     /* Try a match on the leading subdirectory */
     if ((strsuffix(pattern, "*") || strsuffix(pattern, "?")) && !fnmatch(pattern, path, FNM_LEADING_DIR)) {
-        DEBUG_PRINT("MATCH: pattern=|%s|, path=|%s|\n", pattern, path);
         return true;
     }
 

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -21,6 +21,14 @@ import rpmfluff
 from baseclass import TestSRPM, TestCompareSRPM
 
 # test data
+source_file = """#include <stdio.h>
+int main(void)
+{
+    printf("Hello, world!\n");
+    return 0;
+}
+"""
+
 patch_file = """--- fortify.c.orig      2020-09-22 14:45:41.592625821 -0400
 +++ fortify.c   2020-09-29 10:43:21.829954365 -0400
 @@ -1,13 +1,20 @@
@@ -304,7 +312,10 @@ class PatchDefinedAutoSetupSRPM(TestSRPM):
 
         # add a patch and use %autosetup
         self.rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
-        self.rpm.section_prep += "%%autosetup\n"
+        self.rpm.section_prep += "%autosetup\n"
+
+        # the %autosetup macro requires at least one SourceN definition
+        self.rpm.add_source(rpmfluff.SourceFile("hello.c", source_file))
 
         self.inspection = "patches"
         self.result = "INFO"
@@ -317,7 +328,10 @@ class PatchDefinedAutoSetupCompareSRPM(TestCompareSRPM):
 
         # add a patch and use %autosetup
         self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
-        self.after_rpm.section_prep += "%%autosetup\n"
+        self.after_rpm.section_prep += "%autosetup\n"
+
+        # the %autosetup macro requires at least one SourceN definition
+        self.after_rpm.add_source(rpmfluff.SourceFile("hello.c", source_file))
 
         self.inspection = "patches"
         self.result = "INFO"
@@ -331,7 +345,7 @@ class PatchDefinedAutoPatchSRPM(TestSRPM):
 
         # add a patch and use %autopatch
         self.rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
-        self.rpm.section_prep += "%%autopatch\n"
+        self.rpm.section_prep += "%autopatch\n"
 
         self.inspection = "patches"
         self.result = "INFO"
@@ -344,7 +358,7 @@ class PatchDefinedAutoPatchCompareSRPM(TestCompareSRPM):
 
         # add a patch and use %autopatch
         self.after_rpm.add_patch(rpmfluff.SourceFile("some.patch", patch_file), False)
-        self.after_rpm.section_prep += "%%autopatch\n"
+        self.after_rpm.section_prep += "%autopatch\n"
 
         self.inspection = "patches"
         self.result = "INFO"


### PR DESCRIPTION
I had incorrectly written this to ensure we were reading that macro from %prep, %build, %install, or %check.  But my else block match any other macro as a section and then stopped reading.  So while it found the macro, it didn't think it was in a valid section anymore.  My mistake.  This patch simplifies the spec file reading in the patches inspection.  rpminspect can't get too detailed here as spec files are difficult to parse.

This is still going to have problems with spec files that put %autopatch or %autosetup in a locally defined macro and then call that, but I guess I'll take care of that when it happens.