### PR TITLE
Fix the Slackware GHA job and test_patches.py for some platforms

### DIFF
--- a/osdeps/slackware/post.sh
+++ b/osdeps/slackware/post.sh
@@ -2,6 +2,9 @@
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
+# There is no cbindgen package in Slackware Linux
+cargo install cbindgen
+
 # There is no clamav package in Slackware Linux
 git clone https://github.com/Cisco-Talos/clamav.git
 cd clamav || exit 1
@@ -10,6 +13,7 @@ git checkout -b "${TAG}" "${TAG}"
 mkdir build
 cd build || exit 1
 cmake -D ENABLE_MILTER=OFF \
+      -D ENABLE_JSON_SHARED=OFF \
       -D CMAKE_INSTALL_PREFIX=/usr \
       -D CMAKE_INSTALL_LIBDIR=lib64 \
       -D APP_CONFIG_DIRECTORY=/etc/clamav \

--- a/osdeps/slackware/reqs.txt
+++ b/osdeps/slackware/reqs.txt
@@ -26,6 +26,7 @@ libgpg-error
 libtool
 libxml2
 libyaml
+llvm
 lz4
 m4
 mariadb
@@ -40,6 +41,7 @@ python3
 python-pip
 python-setuptools
 rpm
+rust
 serf
 sqlite
 subversion

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -16,9 +16,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+import subprocess
 import rpmfluff
+import unittest
 
 from baseclass import TestSRPM, TestCompareSRPM
+
+# Check to see if %autopatch works (requires lua)
+proc = subprocess.Popen(
+    ["rpmbuild", "-E", "%autopatch"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+)
+(out, err) = proc.communicate()
+
+if proc.returncode == 0:
+    have_autopatch = True
+else:
+    have_autopatch = False
+
+# Check to see if %autosetup works (requires lua)
+proc = subprocess.Popen(
+    ["rpmbuild", "-E", "%autosetup"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+)
+(out, err) = proc.communicate()
+
+if proc.returncode == 0:
+    have_autosetup = True
+else:
+    have_autosetup = False
 
 # test data
 source_file = """#include <stdio.h>
@@ -307,6 +331,9 @@ class PatchTouchesTooManyLinesCompare(TestCompareSRPM):
 
 # patch defined and %autosetup used
 class PatchDefinedAutoSetupSRPM(TestSRPM):
+    @unittest.skipUnless(
+        have_autosetup, "rpmbuild lacks %autosetup support (maybe missing liblua)"
+    )
     def setUp(self):
         super().setUp()
 
@@ -323,6 +350,9 @@ class PatchDefinedAutoSetupSRPM(TestSRPM):
 
 
 class PatchDefinedAutoSetupCompareSRPM(TestCompareSRPM):
+    @unittest.skipUnless(
+        have_autosetup, "rpmbuild lacks %autosetup support (maybe missing liblua)"
+    )
     def setUp(self):
         super().setUp()
 
@@ -340,6 +370,9 @@ class PatchDefinedAutoSetupCompareSRPM(TestCompareSRPM):
 
 # patch defined and %autopatch used
 class PatchDefinedAutoPatchSRPM(TestSRPM):
+    @unittest.skipUnless(
+        have_autopatch, "rpmbuild lacks %autopatch support (maybe missing liblua)"
+    )
     def setUp(self):
         super().setUp()
 
@@ -353,6 +386,9 @@ class PatchDefinedAutoPatchSRPM(TestSRPM):
 
 
 class PatchDefinedAutoPatchCompareSRPM(TestCompareSRPM):
+    @unittest.skipUnless(
+        have_autopatch, "rpmbuild lacks %autopatch support (maybe missing liblua)"
+    )
     def setUp(self):
         super().setUp()
 


### PR DESCRIPTION
The Slackware GHA job needed more packages in order to build clamav (it requires rust now).  Then test_patches.py needed to skip the %autopatch and %autosetup tests on systems that build rpm without liblua because lua is required for those macros.  I think this may also apply to Alpine Linux, but it at least applies to Slacwkare Linux.