### PR TITLE
[lib] In diagnostics, display download and unpack space reqs

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -686,6 +686,10 @@ struct rpminspect {
     char *after_rel;                /* after Release w/o ${?dist} */
     int rebase_build;               /* indicates if this is a rebased build */
 
+    /* local disk space requirements */
+    unsigned long int download_size;
+    unsigned long int unpacked_size;
+
     /* spec file macros */
     pair_list_t *macros;
 

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -166,7 +166,6 @@ void add_peer(rpmpeer_t **peers, int whichbuild, bool fetch_only, const char *pk
 int extract_peers(struct rpminspect *ri, bool fetchonly)
 {
     unsigned long avail = 0;
-    unsigned long need = 0;
     char *availh = NULL;
     char *needh = NULL;
     rpmpeer_entry_t *peer = NULL;
@@ -181,15 +180,15 @@ int extract_peers(struct rpminspect *ri, bool fetchonly)
 
     /* compute total unpacked size required and see if there's space */
     TAILQ_FOREACH(peer, ri->peers, items) {
-        need += peer->before_unpacked_size;
-        need += peer->after_unpacked_size;
+        ri->unpacked_size += peer->before_unpacked_size;
+        ri->unpacked_size += peer->after_unpacked_size;
     }
 
     avail = get_available_space(ri->workdir);
 
-    if (avail < need) {
+    if (avail < ri->unpacked_size) {
         availh = human_size(avail);
-        needh = human_size(need);
+        needh = human_size(ri->unpacked_size);
 
         fprintf(stderr, _("There is not enough available space to unpack all of the RPMs.\n"));
         fprintf(stderr, _("    Need %s in %s, have %s.\n"), needh, ri->workdir, availh);

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -358,6 +358,7 @@ int main(int argc, char **argv)
     rpmpeer_entry_t *peer = NULL;
     const char *after_rel = NULL;
     const char *before_rel = NULL;
+    char *hsz = NULL;
     struct result_params params;
     size_t cmdlen = 0;
     char *tail = NULL;
@@ -777,8 +778,27 @@ int main(int argc, char **argv)
     diags = gather_diags(ri, COMMAND_NAME, PACKAGE_VERSION);
 
     /* add version information to the results output */
-    xasprintf(&params.msg, _("Version information for libraries and programs used by %s.  This result is for informational and diagnostic purposes only."), COMMAND_NAME);
+    xasprintf(&params.msg, _("Version information for libraries and programs used by %s as well as storage requirements.  This result is for informational and diagnostic purposes only."), COMMAND_NAME);
     params.details = list_to_string(diags, "\n");
+    params.details = strappend(params.details, "\n\n", NULL);
+
+    /* add disk space requirements */
+    hsz = human_size(ri->download_size);
+    assert(hsz != NULL);
+    xasprintf(&tmp, _("Space required to download artifacts: %zu bytes (%s)\n"), ri->download_size, hsz);
+    assert(tmp != NULL);
+    params.details = strappend(params.details, tmp, NULL);
+    free(tmp);
+    free(hsz);
+
+    hsz = human_size(ri->unpacked_size);
+    assert(hsz != NULL);
+    xasprintf(&tmp, _("Space required to unpack artifacts: %zu bytes (%s)\n"), ri->unpacked_size, hsz);
+    assert(tmp != NULL);
+    params.details = strappend(params.details, tmp, NULL);
+    free(tmp);
+    free(hsz);
+
     add_result_entry(&ri->results, &params);
     free(params.msg);
     free(params.details);

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -785,7 +785,7 @@ int main(int argc, char **argv)
     /* add disk space requirements */
     hsz = human_size(ri->download_size);
     assert(hsz != NULL);
-    xasprintf(&tmp, _("Space required to download artifacts: %zu bytes (%s)\n"), ri->download_size, hsz);
+    xasprintf(&tmp, _("Space required to download artifacts: %lu bytes (%s)\n"), ri->download_size, hsz);
     assert(tmp != NULL);
     params.details = strappend(params.details, tmp, NULL);
     free(tmp);
@@ -793,7 +793,7 @@ int main(int argc, char **argv)
 
     hsz = human_size(ri->unpacked_size);
     assert(hsz != NULL);
-    xasprintf(&tmp, _("Space required to unpack artifacts: %zu bytes (%s)\n"), ri->unpacked_size, hsz);
+    xasprintf(&tmp, _("Space required to unpack artifacts: %lu bytes (%s)\n"), ri->unpacked_size, hsz);
     assert(tmp != NULL);
     params.details = strappend(params.details, tmp, NULL);
     free(tmp);


### PR DESCRIPTION
librpminspect computes the amount of disk space required to download
builds before performing the download.  If you don't have enough, it
errors out telling you why.  It then does the same thing before
unpacking.  This patch displays those totals in the diagnostics
results section for reference purposes.

Fixes: #682

Signed-off-by: David Cantrell <dcantrell@redhat.com>