### PR TITLE
[fix] Remove temporary files in the changelog inspection

### DIFF
--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -415,6 +415,18 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
     }
 
     /* cleanup */
+    if (before_output) {
+        if (unlink(before_output) != 0) {
+            warn("unlink");
+        }
+    }
+
+    if (after_output) {
+        if (unlink(after_output) != 0) {
+            warn("unlink");
+        }
+    }
+
     list_free(before_changelog, free);
     list_free(after_changelog, free);
     free(before_nevr);


### PR DESCRIPTION
This inspection was still leaving some temporary files in the workdir,
so make sure they are cleaned up on the way out.

Signed-off-by: David Cantrell <dcantrell@redhat.com>