### PR TITLE
[fix] Do not fail 'runpath' when comparing kernel builds

### DIFF
--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -263,8 +263,9 @@ static bool runpath_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     type = get_elf_type(elf);
 
+    /* From here on, we expect ET_EXEC or ET_DYN; ignore all other types */
     if (type != ET_EXEC && type != ET_DYN) {
-        result = false;
+        result = true;
         goto cleanup;
     }
 
@@ -326,7 +327,7 @@ cleanup:
  */
 bool inspect_runpath(struct rpminspect *ri)
 {
-    bool result;
+    bool result = true;
     struct result_params params;
 
     assert(ri != NULL);


### PR DESCRIPTION
Technically runpath was failing any time ELF objects of types other
than ET_DYN or ET_EXEC were encountered, which was incorrect.  That
should be a no-op in the inspection and now it is.

Signed-off-by: David Cantrell <dcantrell@redhat.com>