### PR TITLE
[fix] free before_output and after_output *after* using them

### DIFF
--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -395,8 +395,6 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
     }
 
     free(diff_output);
-    free(before_output);
-    free(after_output);
 
     /* Check for bad words */
     TAILQ_FOREACH(entry, after_changelog, items) {
@@ -427,6 +425,8 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
         }
     }
 
+    free(before_output);
+    free(after_output);
     list_free(before_changelog, free);
     list_free(after_changelog, free);
     free(before_nevr);


### PR DESCRIPTION
In the changelog inspection, free before_output and after_output after
we actually use them.

Signed-off-by: David Cantrell <dcantrell@redhat.com>