### PR TITLE
[lib] Make the kmod inspection report changes as INFO only

### DIFF
--- a/include/inspect.h
+++ b/include/inspect.h
@@ -1448,7 +1448,7 @@ bool inspect_rpmdeps(struct rpminspect *ri);
  * The description for the 'kmod' inspection.  Only defined if
  * rpminspect is built with libkmod support.
  */
-#define DESC_KMOD _("Report kernel module parameter, dependency, PCI ID, or symbol differences between builds.  Added and removed parameters are reported and if the package version is unchanged, these messages are reported as failures.  The same is true module dependencies, PCI IDs, and symbols.")
+#define DESC_KMOD _("Report kernel module parameter, dependency, PCI ID, or symbol differences between builds.  This inspection is intended as an information gathering tool to gather kernel module differences between two builds.")
 #endif
 
 /**

--- a/test/test_kmod.py
+++ b/test/test_kmod.py
@@ -172,8 +172,8 @@ class LostKmodParmsRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify kmod params are good between before and after Koji builds
@@ -212,8 +212,8 @@ class LostKmodParamsKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 #########################
@@ -256,8 +256,8 @@ class LostKmodDependsRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify kmod depends are good between before and after Koji builds
@@ -296,8 +296,8 @@ class LostKmodDependsKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 #########################
@@ -340,8 +340,8 @@ class LostKmodAliasesRPMs(TestCompareRPMs):
         )
 
         self.inspection = "kmod"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify kmod aliases are good between before and after Koji builds
@@ -380,8 +380,8 @@ class LostKmodAliasesKoji(TestCompareKoji):
         )
 
         self.inspection = "kmod"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Kernel module changing paths


### PR DESCRIPTION
While working on fixing up rpminspect results for kernel package
builds, it occurred to me that the kmod inspection (which is derived
from what existed in rpminspect's ancestor) is attempting to enforce
some policies that would ensure the Kernel Module Interface remains
the same, unless it's a rebase comparison.  rpminspect's ancestor
predates the kmidiff tool:

    https://sourceware.org/libabigail/manual/kmidiff.html

kmidiff is run by rpminspect as well, so the kmod inspection can be
used for reporting the changes between builds as information.  For
example, what module dependencies changed, what kernel parameters were
gained or lost, and so on.  None of those items impact the KMI, but
are of note for upgrades to the new kernel.  In general, removed
parameters are ignored when loading a module so the fact that one is
lost is not necessarily a bad thing.  Likewise, gaining or losting PCI
device IDs is not really a bad thing either, just the growth of
supported hardware or the retirement of formerly supported hardware.

Signed-off-by: David Cantrell <dcantrell@redhat.com>