### PR TITLE
[fix] Do not fail dsodeps if ELF type is not ET_DYN

### DIFF
--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -88,8 +88,8 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     after_type = get_elf_type(after_elf);
 
+    /* this inspection only operates on ET_DYN ELF types */
     if (after_type != ET_DYN) {
-        result = false;
         goto done;
     }
 


### PR DESCRIPTION
Just exit from the driver and keep on going.  It's not fatal.

Signed-off-by: David Cantrell <dcantrell@redhat.com>