### PR TITLE
[fix] Only report forbidden path additions as VERIFY in addedfiles

### DIFF
--- a/test/test_addedfiles.py
+++ b/test/test_addedfiles.py
@@ -326,8 +326,8 @@ class NewFileMaintBuildCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "addedfiles"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class NewFileMaintBuildCompareKoji(TestCompareKoji):
@@ -339,8 +339,8 @@ class NewFileMaintBuildCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "addedfiles"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # New file shows up in after build for rebase comparison -> INFO


### PR DESCRIPTION
In the addedfiles inspection, only report file additions in forbidden
paths at the VERIFY level.  For new files that show up when comparing
builds otherwise, just report that as INFO.

Signed-off-by: David Cantrell <dcantrell@redhat.com>