### PR TITLE
[fix] Simplify severity reporting in the changedfiles inspection

### DIFF
--- a/include/results.h
+++ b/include/results.h
@@ -292,9 +292,9 @@
 /**
  * @def REMEDY_CHANGEDFILES
  *
- * How to handle unexpected file changes.
+ * How to handle file changes.
  */
-#define REMEDY_CHANGEDFILES _("Unexpected file changes were found.  Verify these changes are correct.  If they are not, adjust the build to prevent file changes.")
+#define REMEDY_CHANGEDFILES _("File changes were found.  In most cases these are expected, but it is a good idea to verify the changes found are deliberate.")
 
 /** @} */
 


### PR DESCRIPTION
Report file reading errors at the RESULT_BAD level and
security-related path changes at the VERIFY level, but other changes
should be reported as INFO.  Regardless of the comparison being a
rebase or not.  In every instance, changes are deliberate, but we want
the warnings to catch changes to security-related paths.

Signed-off-by: David Cantrell <dcantrell@redhat.com>