### PR TITLE
[fix] Add missing free(tmp) calls in the desktop inspection

### DIFF
--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -69,7 +69,6 @@ static int find_file(const char *fpath, __attribute__((unused)) const struct sta
         return 0;
     }
 
-
     /* Look for this name as the basename */
     if (filetype == FILETYPE_EXECUTABLE) {
         list = strsplit(file_to_find, " ");
@@ -98,8 +97,11 @@ static int find_file(const char *fpath, __attribute__((unused)) const struct sta
                     free(file_to_find);
                     file_to_find = strdup(fpath);
                     list_free(list, free);
+                    free(tmp);
                     return 1;
                 }
+
+                free(tmp);
             }
         }
 


### PR DESCRIPTION
A followup for the desktop inspection fix from yesterday.  I added a
loop and created a temporary string for use in the loop, but neglected
to free() it.  Valgrind caught me.

Signed-off-by: David Cantrell <dcantrell@redhat.com>