### PR TITLE
[fix] Fail if we cannot read RPMs before downloading

### DIFF
--- a/lib/builds.c
+++ b/lib/builds.c
@@ -261,6 +261,10 @@ static int download_build(struct rpminspect *ri, const struct koji_build *build)
     assert(build != NULL);
     assert(build->builds != NULL);
 
+    if (build->total_size == 0) {
+        return -1;
+    }
+
     /* Check to see that there's enough disk space available */
     avail = get_available_space(workri->workdir);
 
@@ -558,6 +562,11 @@ static int download_task(struct rpminspect *ri, struct koji_task *task)
         }
     }
 
+    /* zero size means a read error */
+    if (task->total_size == 0) {
+        return -1;
+    }
+
     /* Check to see that there's enough disk space available */
     avail = get_available_space(workri->workdir);
 
@@ -677,6 +686,11 @@ static int download_rpm(struct rpminspect *ri, const char *rpm)
 
     /* Check to see that there's enough disk space available */
     rpmsize = curl_get_size(rpm);
+
+    if (rpmsize == 0) {
+        return -1;
+    }
+
     avail = get_available_space(workri->workdir);
 
     if (avail < rpmsize) {

--- a/lib/curl.c
+++ b/lib/curl.c
@@ -266,7 +266,8 @@ curl_off_t curl_get_size(const char *src)
     cc = curl_easy_perform(c);
 
     if (cc != CURLE_OK) {
-        warn("curl_easy_perform");
+        warnx("unable to read %s", src);
+        return 0;
     }
 
 #ifdef CURLINFO_CONTENT_LENGTH_DOWNLOAD_T
@@ -294,15 +295,11 @@ bool is_remote_rpm(const char *url)
     c = curl_easy_init();
 
     if (c) {
-      curl_easy_setopt(c, CURLOPT_URL, url);
+        curl_easy_setopt(c, CURLOPT_URL, url);
         curl_easy_setopt(c, CURLOPT_NOBODY, 1);
         r = curl_easy_perform(c);
         curl_easy_cleanup(c);
     }
 
-    if (r == CURLE_OK) {
-      return true;
-    } else {
-        return false;
-    }
+    return (r == CURLE_OK);
 }


### PR DESCRIPTION
rpminspect tries to determine the amount of storage space required of
all RPMs in a build before downloading it.  It does this by using
libcurl to get the download size of each package by URL.  If there's
an error, we get !CURLE_OK and the size is 0.  Report this, but don't
continue trying to download the packages.

Fixes: #770

Signed-off-by: David Cantrell <dcantrell@redhat.com>