### PR TITLE
[fix] Prevent repetitive results reporting in 'types'

### DIFF
--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -24,10 +24,9 @@
 #include <assert.h>
 #include "rpminspect.h"
 
-static bool result = true;
-
 static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
+    bool r = true;
     const char *arch = NULL;
     string_list_t *bmt = NULL;      /* before mime type */
     string_list_t *amt = NULL;      /* after mime type */
@@ -74,8 +73,8 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* prepare for results reporting */
     init_result_params(&params);
-    params.severity = RESULT_VERIFY;
-    params.waiverauth = WAIVABLE_BY_ANYONE;
+    params.severity = RESULT_INFO;
+    params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_TYPES;
     params.remedy = REMEDY_TYPES;
     params.arch = arch;
@@ -88,46 +87,44 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     amt = strsplit(get_mime_type(file), "/");
 
     /* A MIME type should be category/subcategory, so these lists should be length 2 */
-    if (result && list_len(bmt) != 2) {
+    if (r && list_len(bmt) != 2) {
         xasprintf(&params.msg, _("Unknown MIME type `%s' on %s in %s"), get_mime_type(file->peer_file), file->peer_file->localpath, bnevra);
-        result = false;
-        goto report;
+        r = false;
     }
 
-    if (result && list_len(amt) != 2) {
+    if (r && list_len(amt) != 2) {
         xasprintf(&params.msg, _("Unknown MIME type `%s' on %s in %s"), get_mime_type(file), file->localpath, anevra);
-        result = false;
-        goto report;
+        r = false;
     }
 
-    /* Compare the first and second parts of the MIME type */
-    bce = TAILQ_FIRST(bmt);
-    assert(bce != NULL);
-    bsce = TAILQ_NEXT(bce, items);
-    assert(bsce != NULL);
+    if (r) {
+        /* Compare the first and second parts of the MIME type */
+        bce = TAILQ_FIRST(bmt);
+        assert(bce != NULL);
+        bsce = TAILQ_NEXT(bce, items);
+        assert(bsce != NULL);
 
-    ace = TAILQ_FIRST(amt);
-    assert(ace != NULL);
-    asce = TAILQ_NEXT(ace, items);
-    assert(asce != NULL);
+        ace = TAILQ_FIRST(amt);
+        assert(ace != NULL);
+        asce = TAILQ_NEXT(ace, items);
+        assert(asce != NULL);
 
-    /*
-     * The idea with this comparison is to not fail if the type
-     * changes from something like 'text/plain' to 'text/x-makefile'.
-     * Check both parts of the MIME type independently so that 'text'
-     * matches but the subcategory doesn't, but that's still ok.
-     * Let's these changes through but will stop for larger changes
-     * like text/plain to application/x-executable.
-     */
-    if (strcmp(bce->data, ace->data) && strcmp(bsce->data, asce->data)) {
-        xasprintf(&params.msg, _("MIME type for %s in %s was `%s/%s' and became `%s/%s'"), file->localpath, anevra, bce->data, bsce->data, ace->data, asce->data);
-        result = false;
-        goto report;
+        /*
+         * The idea with this comparison is to not fail if the type
+         * changes from something like 'text/plain' to 'text/x-makefile'.
+         * Check both parts of the MIME type independently so that 'text'
+         * matches but the subcategory doesn't, but that's still ok.
+         * Let's these changes through but will stop for larger changes
+         * like text/plain to application/x-executable.
+         */
+        if (strcmp(bce->data, ace->data) && strcmp(bsce->data, asce->data)) {
+            xasprintf(&params.msg, _("MIME type for %s in %s was `%s/%s' and became `%s/%s'"), file->localpath, anevra, bce->data, bsce->data, ace->data, asce->data);
+            r = false;
+        }
     }
 
     /* Final reporting */
-report:
-    if (!result) {
+    if (!r) {
         add_result(ri, &params);
         free(params.msg);
     }
@@ -138,7 +135,7 @@ report:
     free(bnevra);
     free(anevra);
 
-    return result;
+    return r;
 }
 
 /*
@@ -146,12 +143,13 @@ report:
  */
 bool inspect_types(struct rpminspect *ri)
 {
+    bool result = false;
     struct result_params params;
 
     assert(ri != NULL);
 
     /* run the types inspection across all RPM files */
-    foreach_peer_file(ri, NAME_TYPES, types_driver);
+    result = foreach_peer_file(ri, NAME_TYPES, types_driver);
 
     /* if everything was fine, just say so */
     if (result) {

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -67,8 +67,8 @@ class ChangedTypeCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "types"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class ChangedTypeCompareRPMs(TestCompareRPMs):
@@ -84,8 +84,8 @@ class ChangedTypeCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "types"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class ChangedTypeCompareKoji(TestCompareKoji):
@@ -101,5 +101,5 @@ class ChangedTypeCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "types"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
There was a bug in the types inspection that would cause it to
continually report partial results over and over making the log
impossible to read.  Also, these results are not security-focused, so
reduce to INFO reporting level.

Signed-off-by: David Cantrell <dcantrell@redhat.com>