### PR TITLE
[lib] Remove unnecessary archive_read_open_filename() warning

### DIFF
--- a/lib/uncompress.c
+++ b/lib/uncompress.c
@@ -192,7 +192,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     r = archive_read_open_filename(input, infile, 16384);
 
     if (r != ARCHIVE_OK) {
-        warn("archive_read_open_filename: %s", archive_error_string(input));
+        /* just stop trying to uncompress if this errors */
         goto error2;
     }
 


### PR DESCRIPTION
In uncompress_file(), if archive_read_open_filename() returned
something other than ARCHIVE_OK, you'd get a warning on stderr and
then cleanup and NULL returned.  The program functions fine when it
can't uncompress something with libarchive, so the warning on stderr
is pointless.  Remove it.

Fixes: #775

Signed-off-by: David Cantrell <dcantrell@redhat.com>