### PR TITLE
[lib] Always output 'diagnostics' results even if -s specified

### DIFF
--- a/lib/output_text.c
+++ b/lib/output_text.c
@@ -91,7 +91,7 @@ void output_text(const results_t *results, const char *dest, __attribute__((unus
             displayed_header = true;
         }
 
-        if (result->severity >= suppress) {
+        if (!strcmp(header, NAME_DIAGNOSTICS) || (result->severity >= suppress)) {
             if (result->msg != NULL) {
                 xasprintf(&msg, "%d) %s\n", count++, result->msg);
 

--- a/lib/results.c
+++ b/lib/results.c
@@ -178,6 +178,11 @@ bool suppressed_results(const results_t *results, const char *header, const seve
     assert(results != NULL);
     assert(header != NULL);
 
+    /* always output diagnostics */
+    if (!strcmp(header, NAME_DIAGNOSTICS)) {
+        return false;
+    }
+
     TAILQ_FOREACH(result, results, items) {
         if (!strcmp(header, result->header) && result->severity >= suppress) {
             return false;


### PR DESCRIPTION
If the user specifies -s on the command to suppress results below a
certain severity level, still always output the diagnostics results
section.

Fixes: #781

Signed-off-by: David Cantrell <dcantrell@redhat.com>