### PR TITLE
[lib] Move ./rpminspect.yaml reading to init_rpminspect()

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -2188,6 +2188,16 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
         free(tmp);
     }
 
+    /* ./rpminspect.yaml if it exists */
+    if (access(CFGFILE, F_OK|R_OK) == 0) {
+        i = read_cfgfile(ri, CFGFILE);
+
+        if (i) {
+            warn(_("*** error reading '%s'"), CFGFILE);
+            return NULL;
+        }
+    }
+
     /* Initialize some lists if we did not get any config file data */
     if (ri->kernel_filenames == NULL) {
         ri->kernel_filenames = calloc(1, sizeof(*ri->kernel_filenames));

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -566,8 +566,13 @@ int main(int argc, char **argv)
     free(tmp_cfgfile);
     free(cfgfile);
 
-    /* ./rpminspect.yaml if it exists */
-    if (access(CFGFILE, F_OK|R_OK) == 0) {
+    /*
+     * Failsafe to try and load a config file from the current
+     * directory if we have not been able to load any already.  If we
+     * did initialize, then that process would have also loaded this
+     * file from the current directory.
+     */
+    if (!initialized && access(CFGFILE, F_OK|R_OK) == 0) {
         ri = init_rpminspect(ri, CFGFILE, profile);
         initialized = true;
 
@@ -575,7 +580,6 @@ int main(int argc, char **argv)
             errx(RI_PROGRAM_ERROR, _("Failed to read configuration file %s"), CFGFILE);
         }
     }
-
 
     if (!initialized) {
         errx(RI_PROGRAM_ERROR, _("Please specify a configuration file using '-c' or supply ./%s"), CFGFILE);


### PR DESCRIPTION
This is a small optimization.  The optional local rpminspect.yaml was
read in from the rpminspect(1) code by calling init_rpminspect()
again.  The problem there is it runs through all the initialization
code again.  It doesn't hurt anything, but is unnecessary.  So move
the ./rpminspect.yaml read in to init_rpminspect().  In the
rpminspect(1) put one last failsafe in to try and read in a local
rpminspect.yaml file if no initialization has happened yet.

Signed-off-by: David Cantrell <dcantrell@redhat.com>