### PR TITLE
[lib] Support optional product release configuration files

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -114,6 +114,18 @@
 #define CFGFILE "rpminspect.yaml"
 
 /**
+ * @def PRODUCT_RELEASE_CFGFILE_SUBDIR
+ *
+ * The name of the product release configuration file subdirectory.
+ * This will be under 'profiledir', which is defined in the main
+ * configuration file.  This directory can exist and it can hold
+ * configuration files that match product release strings.  If
+ * rpminspect finds one during initialization that matches the product
+ * release string, it will load it.
+ */
+#define PRODUCT_RELEASE_CFGFILE_SUBDIR "product-release"
+
+/**
  * @def DEFAULT_WORKDIR
  *
  * Default working directory location.  rpminspect will create
@@ -599,6 +611,13 @@
  * this extension ends with a period.
  */
 #define ELF_LIB_EXTENSION ".so."
+
+/**
+ * @def YAML_FILENAME_EXTENSION
+ *
+ * YAML filename extension
+ */
+#define YAML_FILENAME_EXTENSION ".yaml"
 
 /** @} */
 

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -133,6 +133,7 @@ bool init_rebaseable(struct rpminspect *);
 bool init_politics(struct rpminspect *ri);
 bool init_security(struct rpminspect *ri);
 bool init_icons(struct rpminspect *ri);
+struct rpminspect *calloc_rpminspect(struct rpminspect *);
 struct rpminspect *init_rpminspect(struct rpminspect *, const char *, const char *);
 
 /* free.c */

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -533,6 +533,17 @@ int main(int argc, char **argv)
         exit(RI_SUCCESS);
     }
 
+    /* Set up the main program data structure */
+    ri = calloc_rpminspect(ri);
+    ri->progname = strdup(argv[0]);
+    ri->verbose = verbose;
+    ri->product_release = release;
+    ri->threshold = getseverity(threshold, RESULT_VERIFY);
+    ri->suppress = getseverity(suppress, RESULT_NULL);
+    ri->rebase_detection = rebase_detection;
+    free(threshold);
+    free(suppress);
+
     /*
      * Find an appropriate configuration file. This involves:
      *
@@ -586,16 +597,6 @@ int main(int argc, char **argv)
     }
 
     free(profile);
-
-    /* various options from the command line or elsewhere */
-    ri->progname = strdup(argv[0]);
-    ri->verbose = verbose;
-    ri->product_release = release;
-    ri->threshold = getseverity(threshold, RESULT_VERIFY);
-    ri->suppress = getseverity(suppress, RESULT_NULL);
-    ri->rebase_detection = rebase_detection;
-    free(threshold);
-    free(suppress);
 
     /*
      * any inspection selections on the command line can override


### PR DESCRIPTION
This is a new thing that data packages can provide in addition to the
main configuration file and profiles.  rpminspect determines what
product release string to use for a specific job.  This string maps to
data files in the corresponding data package.  What this patch does is
adds support for the data package to deliver per-product-release
configuration profiles and have them automatically load.

These can now live in:
    /usr/share/rpminspect/VENDOR/product-release/PRODUCT_RELEASE_STRING.yaml

For example.  Say Fedora wanted an fc36 configuration file in
rpminspect-data-fedora.  It could add:

    /usr/share/rpminspect/fedora/product-release/fc36.yaml

If rpminspect is invoked with the fedora.yaml configuration file and
the job is for fc36 packages, it will check for the above fc36.yaml
file and if it's found, load it after it loaded the main configuration
file and optional profile, but before the ./rpminspect.yaml file that
may exist.

The purpose of this change is to allow for rule definitions across
entire product releases without needing to create a separate
rpminspect data package.

Signed-off-by: David Cantrell <dcantrell@redhat.com>