### PR TITLE
[lib] Allow local rpminspect.yaml files to extend annocheck options

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -548,6 +548,15 @@ annocheck:
     jobs:
         - hardened: --ignore-unknown --verbose
 
+    # In an optional rpminspect.yaml file in the current directory,
+    # you can supply extra arguments to defined annocheck runs.  If
+    # the run is not defined, the options are ignored.  The list here
+    # needs to have the keys match the key:value list under 'jobs'
+    # above.
+    #
+    #extra_opts:
+    #    - hardened: --skip-short-enums
+
     # Optional list of glob(7) specifications or path prefixes to
     # match files to ignore for this inspection.  The format of this
     # list is the same as the global 'ignore' list.  The difference is


### PR DESCRIPTION
Any configuration file after the initial vendor configuration file is
loaded can now carry an extra_opts block under the annocheck block to
extend the options used for that annocheck run.  For example, the
rpminspect-data-fedora package includes fedora.yaml and under the
annocheck block defines an annocheck job called 'hardened' which
specifies the options '--ignore-unknown --verbose'.

Now, you can extend those options on a per-package or per-profile
basis using the extra_opts block under annocheck.  The syntax is key:
value similar to the jobs block.  The key must match a defined
annocheck job.  If it does not, rpminspect displays a warning.

Here's an example of a local rpminspect.yaml file extending the
hardened annocheck options:

    ---
    annocheck:
        extra_opts:
            - hardened: --skip-optimization=function_name

See 'annocheck --hardened-help' for help on the options available.
For the per-function skip capability in annocheck, you need
annobin-10.74 or higher.

Fixes: #523

Signed-off-by: David Cantrell <dcantrell@redhat.com>