### PR TITLE
[bld] check the results of meson's run_command()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -105,8 +105,8 @@ endif
 
 # xmlrpc-c
 xmlrpc_cmd = find_program('xmlrpc-c-config', required : true)
-xmlrpc_libs_cmd = run_command(xmlrpc_cmd, '--libs')
-xmlrpc_cflags_cmd = run_command(xmlrpc_cmd, '--cflags')
+xmlrpc_libs_cmd = run_command(xmlrpc_cmd, '--libs', check : true)
+xmlrpc_cflags_cmd = run_command(xmlrpc_cmd, '--cflags', check : true)
 
 if xmlrpc_libs_cmd.returncode() == 0 and xmlrpc_cflags_cmd.returncode() == 0
     xmlrpc = declare_dependency(compile_args: xmlrpc_cflags_cmd.stdout().strip().split(),
@@ -119,8 +119,8 @@ if not xmlrpc.found()
 endif
 
 xmlrpc_cmd = find_program('xmlrpc-c-config', required : true)
-xmlrpc_client_libs_cmd = run_command(xmlrpc_cmd, 'client', '--libs')
-xmlrpc_client_cflags_cmd = run_command(xmlrpc_cmd, 'client', '--cflags')
+xmlrpc_client_libs_cmd = run_command(xmlrpc_cmd, 'client', '--libs', check : true)
+xmlrpc_client_cflags_cmd = run_command(xmlrpc_cmd, 'client', '--cflags', check : true)
 
 if xmlrpc_client_libs_cmd.returncode() == 0 and xmlrpc_client_cflags_cmd.returncode() == 0
     xmlrpc_client = declare_dependency(compile_args: xmlrpc_client_cflags_cmd.stdout().strip().split(),


### PR DESCRIPTION
Currently, meson doesn't do this by default.  Silences this warning from
meson:

    WARNING: You should add the boolean check kwarg to the run_command
    call.  It currently defaults to false, but it will default to true
    in future releases of meson.

See-also: https://github.com/mesonbuild/meson/issues/9300
Signed-off-by: Robbie Harwood <rharwood@redhat.com>