### PR TITLE
[fix] Get per-inspection ignore list working in 'upstream'

### DIFF
--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -184,6 +184,11 @@ bool inspect_upstream(struct rpminspect *ri)
 
         /* Iterate over the SRPM files */
         TAILQ_FOREACH(file, peer->after_files, items) {
+            /* Ignore files we should be ignoring */
+            if (ignore_path(ri, NAME_UPSTREAM, file->localpath, peer->after_root)) {
+                continue;
+            }
+
             if (!upstream_driver(ri, file)) {
                 result = false;
             }
@@ -194,6 +199,11 @@ bool inspect_upstream(struct rpminspect *ri)
 
         if (removed != NULL && !TAILQ_EMPTY(removed)) {
             TAILQ_FOREACH(entry, removed, items) {
+                /* Ignore files we should be ignoring */
+                if (ignore_path(ri, NAME_UPSTREAM, entry->data, peer->after_root)) {
+                    continue;
+                }
+
                 xasprintf(&params.msg, _("Source file `%s` removed"), entry->data);
                 params.verb = VERB_REMOVED;
                 params.noun = _("source file ${FILE} removed");

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -222,6 +222,11 @@ bool match_path(const char *pattern, const char *root, const char *path)
     assert(pattern != NULL);
     assert(path != NULL);
 
+    /* Simple check first */
+    if (!strcmp(pattern, path)) {
+        return true;
+    }
+
     /* A pattern ending with '/' will match a path prefix */
     if (strsuffix(pattern, "/") && strprefix(path, pattern)) {
         return true;


### PR DESCRIPTION
The way the upstream inspection is implemented requires special
handling of the per-inspection ignore list in rpminspect.yaml because
foreach_peer_file() is not used.

Signed-off-by: David Cantrell <dcantrell@redhat.com>