### PR TITLE
[tst] Support optional rpminspect.yaml overrides per test

### DIFF
--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -208,6 +208,7 @@ class RequiresRpminspect(unittest.TestCase):
 
         # set in configFile()
         self.conffile = None
+        self.extra_cfg = None
 
         # use for rpminspect results
         (handle, self.outputfile) = tempfile.mkstemp()
@@ -272,6 +273,10 @@ class RequiresRpminspect(unittest.TestCase):
 
             if hnd:
                 cfg["metadata"]["buildhost_subdomain"].append(hnd)
+
+        # any additional config settings for the test case
+        if self.extra_cfg is not None:
+            cfg |= self.extra_cfg
 
         # write the temporary config file for the test suite
         outstream = open(self.conffile, "w")


### PR DESCRIPTION
Each test case gets a fresh environment set up with a custom
rpminspect.yaml file directing the program to the test data.  This
patch extends that functionality so that test cases can extend the
custom rpminspect.yaml file by modifying self.extra_cfg.  The contents
of cfg and self.extra_cfg are merged before writing out for use in the
test case.

Signed-off-by: David Cantrell <dcantrell@redhat.com>