### PR TITLE
[fix] Support per-file allowed lists for the badfuncs inspection

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -759,6 +759,21 @@ badfuncs:
     - rexec
     - rresvport
 
+    # Some libraries deliberately use forbidden functions.  In these
+    # cases, you can specify an 'allowed' block listing path globs and
+    # the specific functions they are allowed to use.  It is
+    # adviseable to add a comment indicating why the function is
+    # allowed to use forbidden functions for future reference.  The
+    # path specifications can be explicit paths or patterns that are
+    # compatible with fnmatch(3) and glob(3).
+    #
+    #allowed:
+    #    /usr/lib*/libsomething.so.*:
+    #        - inet_aton
+    #        - inet_network
+    #    /usr/lib*/libsomethingelse.so.*:
+    #        - gethostbyname
+
     # Optional list of glob(7) specifications or path prefixes to
     # match files to ignore for this inspection.  The format of this
     # list is the same as the global 'ignore' list.  The difference is

--- a/include/types.h
+++ b/include/types.h
@@ -524,6 +524,12 @@ struct rpminspect {
      */
     string_list_t *bad_functions;
 
+    /*
+     * Optional: if not NULL, contains a map of file paths in packages
+     * and a list of allowed forbidden functions it can use.
+     */
+    string_list_map_t *bad_functions_allowed;
+
     /* Optional: if not NULL, contains list of architectures */
     /* if not specified on the command line, this becomes the list of
        all architectures downloaded */

--- a/lib/free.c
+++ b/lib/free.c
@@ -223,6 +223,7 @@ void free_rpminspect(struct rpminspect *ri)
     free(ri->elf_path_include_pattern);
     free(ri->elf_path_exclude_pattern);
     list_free(ri->bad_functions, free);
+    free_string_list_map(ri->bad_functions_allowed);
     free(ri->manpage_path_include_pattern);
     free(ri->manpage_path_exclude_pattern);
     free(ri->xml_path_include_pattern);

--- a/test/test_badfuncs.py
+++ b/test/test_badfuncs.py
@@ -62,3 +62,70 @@ class ForbiddenIPv6FunctionCompareKoji(TestCompareKoji):
         self.inspection = "badfuncs"
         self.waiver_auth = "Anyone"
         self.result = "VERIFY"
+
+
+# Program uses forbidden IPv6 function, but is explicitly allowed
+class AllowedForbiddenIPv6FunctionRPM(TestRPMs):
+    def setUp(self):
+        TestRPMs.setUp(self)
+
+        self.extra_cfg = {}
+        self.extra_cfg["badfuncs"] = {}
+        self.extra_cfg["badfuncs"]["allowed"] = {}
+        self.extra_cfg["badfuncs"]["allowed"]["/usr/bin/hello-world"] = ["inet_aton"]
+
+        self.rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
+
+        self.inspection = "badfuncs"
+        self.waiver_auth = "Not Waivable"
+        self.result = "OK"
+
+
+class AllowedForbiddenIPv6FunctionKoji(TestKoji):
+    def setUp(self):
+        TestKoji.setUp(self)
+
+        self.extra_cfg = {}
+        self.extra_cfg["badfuncs"] = {}
+        self.extra_cfg["badfuncs"]["allowed"] = {}
+        self.extra_cfg["badfuncs"]["allowed"]["/usr/bin/hello-world"] = ["inet_aton"]
+
+        self.rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
+
+        self.inspection = "badfuncs"
+        self.waiver_auth = "Not Waivable"
+        self.result = "OK"
+
+
+class AllowedForbiddenIPv6FunctionCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        TestCompareRPMs.setUp(self)
+
+        self.extra_cfg = {}
+        self.extra_cfg["badfuncs"] = {}
+        self.extra_cfg["badfuncs"]["allowed"] = {}
+        self.extra_cfg["badfuncs"]["allowed"]["/usr/bin/hello-world"] = ["inet_aton"]
+
+        self.before_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
+        self.after_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
+
+        self.inspection = "badfuncs"
+        self.waiver_auth = "Not Waivable"
+        self.result = "OK"
+
+
+class AllowedForbiddenIPv6FunctionCompareKoji(TestCompareKoji):
+    def setUp(self):
+        TestCompareKoji.setUp(self)
+
+        self.extra_cfg = {}
+        self.extra_cfg["badfuncs"] = {}
+        self.extra_cfg["badfuncs"]["allowed"] = {}
+        self.extra_cfg["badfuncs"]["allowed"]["/usr/bin/hello-world"] = ["inet_aton"]
+
+        self.before_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
+        self.after_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
+
+        self.inspection = "badfuncs"
+        self.waiver_auth = "Not Waivable"
+        self.result = "OK"


### PR DESCRIPTION
Some programs and libraries deliberately use functions that have been
deemed forbidden by policy.  An example would be a library providing
runtime support for older software.  In cases like this, you can
specify an allowed block listing path globs and the specific forbidden
functions they are allowed to use.  It is adviseable to add a comment
idnicating why the forbidden function is allowed so future readers
will understand why the rpminspect.yaml file is configured that way.

The path specifications can be explicit paths (local path notation,
relative to /) or patterns that are compatible with fnmatch(3) and
glob(3).

For example:

    ---
    badfuncs:
        allowed:
            /usr/sbin/somenetcmd:
                - inet_aton
                - gethostbyname
            /usr/lib*/libsomething.so.*:
                - inet_network

You can place this block in the package's rpminspect.yaml file to
further control how the badfuncs inspection works for your build.

Fixes: #573

Signed-off-by: David Cantrell <dcantrell@redhat.com>