### PR TITLE
[cmd] Fix handling of the -s and -t command line options

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -550,11 +550,7 @@ int main(int argc, char **argv)
     ri->progname = strdup(argv[0]);
     ri->verbose = verbose;
     ri->product_release = release;
-    ri->threshold = getseverity(threshold, RESULT_VERIFY);
-    ri->suppress = getseverity(suppress, RESULT_NULL);
     ri->rebase_detection = rebase_detection;
-    free(threshold);
-    free(suppress);
 
     /*
      * Find an appropriate configuration file. This involves:
@@ -609,6 +605,12 @@ int main(int argc, char **argv)
     }
 
     free(profile);
+
+    /* Reporting threshold and suppression levels */
+    ri->threshold = getseverity(threshold, RESULT_VERIFY);
+    ri->suppress = getseverity(suppress, RESULT_NULL);
+    free(threshold);
+    free(suppress);
 
     /*
      * any inspection selections on the command line can override


### PR DESCRIPTION
Because of the refactoring of how init_rpminspect() is called for
different config files, these two settings were being reset to
defaults after processing the command line options.  Move the command
line option handling to occur after all init_rpminspect() calls.

Signed-off-by: David Cantrell <dcantrell@redhat.com>