### PR TITLE
[fix] Use allowed_arch() in the arch and subpackages inspections

### DIFF
--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -95,30 +95,33 @@ bool inspect_arch(struct rpminspect *ri)
     /* Report results */
     if (lost != NULL && !TAILQ_EMPTY(lost)) {
         TAILQ_FOREACH(entry, lost, items) {
-            params.severity = RESULT_VERIFY;
-            params.remedy = REMEDY_ARCH_LOST;
-            params.verb = VERB_REMOVED;
-            params.noun = _("lost ${ARCH}");
-            params.arch = entry->data;
-            xasprintf(&params.msg, _("Architecture '%s' has disappeared"), entry->data);
-            add_result(ri, &params);
-            free(params.msg);
+            if (allowed_arch(ri, entry->data)) {
+                params.severity = RESULT_VERIFY;
+                params.remedy = REMEDY_ARCH_LOST;
+                params.verb = VERB_REMOVED;
+                params.noun = _("lost ${ARCH}");
+                params.arch = entry->data;
+                xasprintf(&params.msg, _("Architecture '%s' has disappeared"), entry->data);
+                add_result(ri, &params);
+                free(params.msg);
+            }
         }
 
         result = false;
     }
 
-
     if (gain != NULL && !TAILQ_EMPTY(gain)) {
         TAILQ_FOREACH(entry, gain, items) {
-            params.severity = RESULT_INFO;
-            params.remedy = REMEDY_ARCH_GAIN;
-            params.verb = VERB_ADDED;
-            params.noun = _("gained ${ARCH}");
-            params.arch = entry->data;
-            xasprintf(&params.msg, _("Architecture '%s' has appeared"), entry->data);
-            add_result(ri, &params);
-            free(params.msg);
+            if (allowed_arch(ri, entry->data)) {
+                params.severity = RESULT_INFO;
+                params.remedy = REMEDY_ARCH_GAIN;
+                params.verb = VERB_ADDED;
+                params.noun = _("gained ${ARCH}");
+                params.arch = entry->data;
+                xasprintf(&params.msg, _("Architecture '%s' has appeared"), entry->data);
+                add_result(ri, &params);
+                free(params.msg);
+            }
         }
 
         result = false;

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -80,16 +80,18 @@ bool inspect_subpackages(struct rpminspect *ri)
             *arch = '\0';
             arch++;
 
-            xasprintf(&params.msg, _("Subpackage '%s' has disappeared on '%s'"), entry->data, arch);
-            params.severity = RESULT_VERIFY;
-            params.waiverauth = WAIVABLE_BY_ANYONE;
-            params.remedy = REMEDY_SUBPACKAGES_LOST;
-            params.arch = arch;
-            params.file = entry->data;
-            params.verb = VERB_REMOVED;
-            params.noun = _("subpackage ${FILE}");
-            add_result(ri, &params);
-            free(params.msg);
+            if (allowed_arch(ri, arch)) {
+                xasprintf(&params.msg, _("Subpackage '%s' has disappeared on '%s'"), entry->data, arch);
+                params.severity = RESULT_VERIFY;
+                params.waiverauth = WAIVABLE_BY_ANYONE;
+                params.remedy = REMEDY_SUBPACKAGES_LOST;
+                params.arch = arch;
+                params.file = entry->data;
+                params.verb = VERB_REMOVED;
+                params.noun = _("subpackage ${FILE}");
+                add_result(ri, &params);
+                free(params.msg);
+            }
         }
 
         result = false;
@@ -102,16 +104,18 @@ bool inspect_subpackages(struct rpminspect *ri)
             *arch = '\0';
             arch++;
 
-            xasprintf(&params.msg, _("Subpackage '%s' has appeared on '%s'"), entry->data, arch);
-            params.severity = RESULT_INFO;
-            params.waiverauth = NOT_WAIVABLE;
-            params.remedy = REMEDY_SUBPACKAGES_GAIN;
-            params.arch = arch;
-            params.file = entry->data;
-            params.verb = VERB_ADDED;
-            params.noun = _("subpackage ${FILE}");
-            add_result(ri, &params);
-            free(params.msg);
+            if (allowed_arch(ri, arch)) {
+                xasprintf(&params.msg, _("Subpackage '%s' has appeared on '%s'"), entry->data, arch);
+                params.severity = RESULT_INFO;
+                params.waiverauth = NOT_WAIVABLE;
+                params.remedy = REMEDY_SUBPACKAGES_GAIN;
+                params.arch = arch;
+                params.file = entry->data;
+                params.verb = VERB_ADDED;
+                params.noun = _("subpackage ${FILE}");
+                add_result(ri, &params);
+                free(params.msg);
+            }
         }
 
         result = false;


### PR DESCRIPTION
If '-a' is specified on the command line and the program has an
explicit list of architectures, filter out other architectures with a
call to allowed_arch() for the arch and subpackages inspections.  In
some cases it appears that non-desired architectures are included in
these inspections anyway which may be because the program is skipping
the downloading part which is how -a was initially implemented.

Fixes: #807

Signed-off-by: David Cantrell <dcantrell@redhat.com>