### PR TITLE
[tst] Use .update() rather than |= to merge dicts

### DIFF
--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -276,7 +276,7 @@ class RequiresRpminspect(unittest.TestCase):
 
         # any additional config settings for the test case
         if self.extra_cfg is not None:
-            cfg |= self.extra_cfg
+            cfg.update(self.extra_cfg)
 
         # write the temporary config file for the test suite
         outstream = open(self.conffile, "w")


### PR DESCRIPTION
The |= syntax is only supported in Python 3.9 and later.

Signed-off-by: David Cantrell <dcantrell@redhat.com>