### PR TITLE
[ci] opensuse does not use yum

### DIFF
--- a/osdeps/opensuse-leap/reqs.txt
+++ b/osdeps/opensuse-leap/reqs.txt
@@ -46,7 +46,5 @@ tcsh
 valgrind
 xhtml-dtd
 xmlrpc-c-devel
-yum
-yum-downloadonly
 zlib-devel
 zsh

--- a/osdeps/opensuse-tumbleweed/reqs.txt
+++ b/osdeps/opensuse-tumbleweed/reqs.txt
@@ -48,7 +48,5 @@ tcsh
 valgrind
 xhtml-dtd
 xmlrpc-c-devel
-yum
-yum-downloadonly
 zlib-devel
 zsh


### PR DESCRIPTION
Do not try to install yum or yum-downloadonly on opensuse-leap or
opensuse-tumbleweed.

Signed-off-by: David Cantrell <dcantrell@redhat.com>