### PR TITLE
[fix] Remove unnecessary warning from failed chdir() call

### DIFF
--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -267,7 +267,6 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     TAILQ_FOREACH(peer, ri->peers, items) {
         /* move to the subpackage root */
         if (chdir(peer->after_root) == -1) {
-            warn("chdir");
             continue;
         }
 


### PR DESCRIPTION
In the symlinks inspection, if chdir fails the loop just continues on.
We don't need the warning here since we don't need to recover on that
particular entry.

Signed-off-by: David Cantrell <dcantrell@redhat.com>