### PR TITLE
[lib] In match_path(), honor common syntax of /path/to/dir/*

### DIFF
--- a/lib/paths.c
+++ b/lib/paths.c
@@ -232,6 +232,24 @@ bool match_path(const char *pattern, const char *root, const char *path)
         return true;
     }
 
+    /*
+     * Also handle the incredibly common case of the trailing '/'
+     * where users specify an asterisk after the slash to mean
+     * everything below this directory.
+     */
+    if (strsuffix(pattern, "/*")) {
+        globsub = strdup(pattern);
+        assert(globsub != NULL);
+        globsub[strlen(globsub) - 1] = '\0';
+
+        if (globsub && strprefix(path, globsub)) {
+            free(globsub);
+            return true;
+        }
+
+        free(globsub);
+    }
+
     /* Try a match on the leading subdirectory */
     if ((strsuffix(pattern, "*") || strsuffix(pattern, "?")) && !fnmatch(pattern, path, FNM_LEADING_DIR)) {
         return true;


### PR DESCRIPTION
In data/generic.yaml, I note that for the per-inspection ignore lists
you can specify explicit paths using glob(7)-style syntax or you can
specify path prefixes to ignore everything in one subdirectory tree.
The path prefix syntax is sort of like rsync in that you specify the
path prefix with a trailing '/' and then rpminspect knows to treat it
that way.

The problem I've run in to is that everyone knows you can do
"/path/to/dir/*" on commands like cp or mv to mean everything in that
tree.  So this syntax keeps showing up in rpminspect.yaml files.
Rather than die on the hill of the original syntax I introduced, just
support the /* syntax too.  Easy.  (I don't even like the trailing /
syntax, I just didn't know what else to do.  I blame the glob(3) and
fnmatch(3) functions.)

Signed-off-by: David Cantrell <dcantrell@redhat.com>