### PR TITLE
[lib] Define RESULT_DIAG for diagnostics results reporting

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -215,7 +215,8 @@ typedef enum _severity_t {
     RESULT_INFO   = 2,
     RESULT_VERIFY = 3,
     RESULT_BAD    = 4,
-    RESULT_SKIP   = 5
+    RESULT_SKIP   = 5,
+    RESULT_DIAG   = 6       /* only used by the 'diagnostics' inspection */
 } severity_t;
 
 typedef enum _waiverauth_t {

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -274,6 +274,8 @@ char *strseverity(const severity_t severity)
             return _("BAD");
         case RESULT_SKIP:
             return _("SKIP");
+        case RESULT_DIAG:
+            return _("DIAGNOSTICS");
         default:
             return _("UnKnOwN");
     }
@@ -305,6 +307,8 @@ severity_t getseverity(const char *name, const severity_t default_s)
         s = RESULT_BAD;
     } else if (!strcasecmp(name, _("SKIP"))) {
         s = RESULT_SKIP;
+    } else if (!strcasecmp(name, _("DIAGNOSTICS"))) {
+        s = RESULT_DIAG;
     }
 
     return s;

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -790,7 +790,7 @@ int main(int argc, char **argv)
 
     /* general information in the results */
     init_result_params(&params);
-    params.severity = RESULT_INFO;
+    params.severity = RESULT_DIAG;
     params.header = NAME_DIAGNOSTICS;
 
     /* gather version information for dependent programs and libraries */


### PR DESCRIPTION
Rather than calling the diagnostics results INFO as the result
severity, call them DIAGNOSTICS.

Signed-off-by: David Cantrell <dcantrell@redhat.com>