### PR TITLE
[lib] Support explicit paths for licensedb in the config file

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -59,10 +59,12 @@ vendor:
     # Main directory for the vendor-specific data.
     vendor_data_dir: /usr/share/rpminspect
 
-    # Location of the license database file under the 'licenses/'
-    # subdirectory in the vendor_data_dir.  This database is used
-    # by the 'license' inspection.
+    # Either the name of a license database file under the 'licenses/'
+    # subdirectory in the vendor_data_dir or a full path to a license
+    # database file to use.  This file is used by the 'license'
+    # inspection.
     licensedb: generic.json
+    #licensedb: /usr/share/vendor-license-data/licenses/vendor-licenses.json
 
     # Which product release string to favor.  By default, rpminspect
     # favors the newest product release string.  You can change this

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -478,7 +478,13 @@ bool inspect_license(struct rpminspect *ri)
     params.header = NAME_LICENSE;
     params.waiverauth = NOT_WAIVABLE;
 
-    xasprintf(&actual_licensedb, "%s/%s/%s", ri->vendor_data_dir, LICENSES_DIR, ri->licensedb);
+    if (ri->licensedb && ri->licensedb[0] == '/') {
+        actual_licensedb = strdup(ri->licensedb);
+    } else {
+        xasprintf(&actual_licensedb, "%s/%s/%s", ri->vendor_data_dir, LICENSES_DIR, ri->licensedb);
+    }
+
+    assert(actual_licensedb != NULL);
 
     if (ri->licensedb == NULL || access(actual_licensedb, F_OK|R_OK)) {
         xasprintf(&params.msg, _("Missing license database: %s: %s"), actual_licensedb, strerror(errno));


### PR DESCRIPTION
rpminspect needs the ability to have an externally-supplied licensedb
file.  And for that the program needs to honor an explicit path in the
licensedb setting in the config file.

Signed-off-by: David Cantrell <dcantrell@redhat.com>