### PR TITLE
[tst] Support DIAGNOSTICS as a test result and fix test_upstream

### DIFF
--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -353,7 +353,7 @@ class TestSRPM(RequiresRpminspect):
             self.dumpResults()
 
         # anything not OK or INFO is a non-zero return
-        if self.result not in ["OK", "INFO"] and self.exitcode == 0:
+        if self.result not in ["OK", "INFO", "DIAGNOSTICS"] and self.exitcode == 0:
             self.exitcode = 1
 
         # dump stdout and stderr if these do not match
@@ -448,7 +448,7 @@ class TestCompareSRPM(RequiresRpminspect):
             self.dumpResults()
 
         # anything not OK or INFO is a non-zero return
-        if self.result not in ["OK", "INFO"] and self.exitcode == 0:
+        if self.result not in ["OK", "INFO", "DIAGNOSTICS"] and self.exitcode == 0:
             self.exitcode = 1
 
         # dump stdout and stderr if these do not match
@@ -501,7 +501,7 @@ class TestRPMs(RequiresRpminspect):
         self.rpm.do_make()
 
         # anything not OK or INFO is a non-zero return
-        if self.result not in ["OK", "INFO"] and self.exitcode == 0:
+        if self.result not in ["OK", "INFO", "DIAGNOSTICS"] and self.exitcode == 0:
             self.exitcode = 1
 
         for a in self.rpm.get_build_archs():
@@ -602,7 +602,7 @@ class TestCompareRPMs(RequiresRpminspect):
         self.after_rpm.do_make()
 
         # anything not OK or INFO is a non-zero return
-        if self.result not in ["OK", "INFO"] and self.exitcode == 0:
+        if self.result not in ["OK", "INFO", "DIAGNOSTICS"] and self.exitcode == 0:
             self.exitcode = 1
 
         for a in self.before_rpm.get_build_archs():
@@ -722,7 +722,7 @@ class TestKoji(TestRPMs):
                 self.dumpResults()
 
             # anything not OK or INFO is a non-zero return
-            if self.result not in ["OK", "INFO"] and self.exitcode == 0:
+            if self.result not in ["OK", "INFO", "DIAGNOSTICS"] and self.exitcode == 0:
                 self.exitcode = 1
 
             # dump stdout and stderr if these do not match
@@ -816,7 +816,7 @@ class TestCompareKoji(TestCompareRPMs):
                 self.dumpResults()
 
             # anything not OK or INFO is a non-zero return
-            if self.result not in ["OK", "INFO"] and self.exitcode == 0:
+            if self.result not in ["OK", "INFO", "DIAGNOSTICS"] and self.exitcode == 0:
                 self.exitcode = 1
 
             # dump stdout and stderr if these do not match

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -50,7 +50,7 @@ class SkipUpstreamSRPM(TestSRPM):
 
         # since it should skip, only look for our diagnostic output
         self.result_inspection = "diagnostics"
-        self.result = "INFO"
+        self.result = "DIAGNOSTICS"
 
     def runTest(self):
         super().runTest()
@@ -72,7 +72,7 @@ class SkipUpstreamRPMs(TestRPMs):
 
         # since it should skip, only look for our diagnostic output
         self.result_inspection = "diagnostics"
-        self.result = "INFO"
+        self.result = "DIAGNOSTICS"
 
     def runTest(self):
         super().runTest()
@@ -94,7 +94,7 @@ class SkipUpstreamKoji(TestKoji):
 
         # since it should skip, only look for our diagnostic output
         self.result_inspection = "diagnostics"
-        self.result = "INFO"
+        self.result = "DIAGNOSTICS"
 
     def runTest(self):
         super().runTest()


### PR DESCRIPTION
Like OK and INFO, DIAGNOSTICS is a valid result severity with a 0 exit
code.  Fix the skip test cases in test_upstream.py that will only
return diagnostics output under the new name DIAGNOSTICS rather than
INFO.

Signed-off-by: David Cantrell <dcantrell@redhat.com>