### PR TITLE
[fix] Handle RPM payloads with individual entries >2GB

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -240,6 +240,7 @@ char *get_nevra(Header);
 const char *get_rpm_header_arch(Header);
 string_list_t *get_rpm_header_string_array(Header h, rpmTagVal tag);
 char *get_rpm_header_value(const rpmfile_entry_t *file, rpmTag tag);
+char *extract_rpm_payload(const char *rpm);
 
 /* peers.c */
 rpmpeer_t *init_peers(void);


### PR DESCRIPTION
RPM uses cpio for the payload stream.  cpio has an individual entry
size limit of 2GB.  In cases where the RPM payload carries an entry
larger than that, librpminspect fails to extract the contents of the
RPM because libarchive can't handle this stream.  The workaround is to
use librpm and libarchive to convert the payload stream to a pax
archive and then let librpminspect extract that.  The conversion is
done in a manner similar to the rpm2archive tool.

Fixes: #820

Signed-off-by: David Cantrell <dcantrell@redhat.com>