### PR TITLE
[lib] Remove realloc() call from strtrim()

### DIFF
--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -654,13 +654,12 @@ const char *strexitcode(int exitcode)
 
 /*
  * Trims leading and trailing whitespace from a dynamically allocated
- * string.  NOTE:  Must call this on a string that has been malloc'ed
- * so free() can be called.  This function uses memmove() and realloc().
+ * string.  NOTE: The string is left allocated as is but shifted to
+ * the beginning and unused chars are \0 at the end.
  */
 char *strtrim(char *s)
 {
     char *r = NULL;
-    char *begin = NULL;
     size_t i = 0;
 
     if (s == NULL) {
@@ -668,7 +667,7 @@ char *strtrim(char *s)
     }
 
     /* the beginning of the string */
-    begin = s;
+    r = s;
 
     /* remove leading whitespace */
     while (isspace(*s) && *s != '\0') {
@@ -681,7 +680,7 @@ char *strtrim(char *s)
 
     /* shift everything to the head of the string */
     while (s[i] != '\0') {
-        begin[i] = s[i];
+        r[i] = s[i];
         i++;
     }
 
@@ -696,9 +695,6 @@ char *strtrim(char *s)
     if (s == NULL) {
         return NULL;
     }
-
-    /* reallocate memory block */
-    r = realloc(begin, strlen(begin) + 1);
 
     return r;
 }

--- a/osdeps/fedora-rawhide.i686/reqs.txt
+++ b/osdeps/fedora-rawhide.i686/reqs.txt
@@ -1,4 +1,4 @@
-annobin
+annobin-annocheck
 bash
 clamav-data
 clamav-devel.i686

--- a/osdeps/fedora-rawhide/reqs.txt
+++ b/osdeps/fedora-rawhide/reqs.txt
@@ -1,4 +1,4 @@
-annobin
+annobin-annocheck
 bash
 clamav-data
 clamav-devel

--- a/osdeps/fedora.i686/reqs.txt
+++ b/osdeps/fedora.i686/reqs.txt
@@ -1,4 +1,4 @@
-annobin
+annobin-annocheck
 bash
 cargo
 clamav-data

--- a/osdeps/fedora/reqs.txt
+++ b/osdeps/fedora/reqs.txt
@@ -1,4 +1,4 @@
-annobin
+annobin-annocheck
 bash
 cargo
 clamav-data


### PR DESCRIPTION
Leave memory management to the caller, just modify the string in place
and shift the trimmed string to the beginning and return that pointer.

Signed-off-by: David Cantrell <dcantrell@redhat.com>