### PR TITLE
[cmd] Support Koji task ID number for non-scratch builds

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -103,13 +103,13 @@ Workflow Examples
 -----------------
 
 rpminspect_ runs from the command line.  The inputs must be local RPM_
-packages, a Koji_ build specification (*NVR*), a Koji_ scratch build
-task number, a Koji_ module specification, or a locally cached Koji_
-build output (regular build or module).  For inputs originating from
-Koji_, rpminspect_ talks to Koji_ and download the build artifacts.
-For repeated runs, you may want to cache a remote build locally to
-avoid downloading it with each run.  The examples below use `Fedora
-Linux <https://getfedora.org>`_, so they will reference the
+packages, a Koji_ build specification (*NVR*), a Koji_ task number, a
+Koji_ module specification, or a locally cached Koji_ build output
+(regular build or module).  For inputs originating from Koji_,
+rpminspect_ talks to Koji_ and download the build artifacts.  For
+repeated runs, you may want to cache a remote build locally to avoid
+downloading it with each run.  The examples below use `Fedora Linux
+<https://getfedora.org>`_, so they will reference the
 **rpminspect-fedora** wrapper script provided by
 rpminspect-data-fedora_ as the command to run.
 

--- a/src/rpminspect.1
+++ b/src/rpminspect.1
@@ -231,9 +231,9 @@ installed it on your operating system, you are ready to use it.  The
 only required arguments are the '-c' option to specify the
 configuration file and at least one input.  The input may be an RPM
 package (local or remote), a Koji build (either local or remote), or a
-Koji scratch build task ID.  When provided with a single input,
-rpminspect runs in analysis mode.  When two inputs are provided, it
-performs all of the analysis checks as well as comparison checks.
+Koji task ID.  When provided with a single input, rpminspect runs in
+analysis mode.  When two inputs are provided, it performs all of the
+analysis checks as well as comparison checks.
 .PP
 Use the -l option to list available inspections (add -v to get
 detailed descriptions of the inspections).  By default, all


### PR DESCRIPTION
rpminspect requires a build NVR specification in order to download
packages from Koji.  In the case of scratch builds, rpminspect
requires the Koji task ID number because scratch builds do not get a
build NVR specification.  However, you cannot use a Koji task ID
number to reference a non-scratch build.  This patch changes that
behavior and allows the use of Koji task ID numbers for regular
builds.

Signed-off-by: David Cantrell <dcantrell@redhat.com>