### PR TITLE
[ci] Prevent RPMTAG_VENDOR override on OpenSUSE Leap jobs

### DIFF
--- a/osdeps/opensuse-leap/post.sh
+++ b/osdeps/opensuse-leap/post.sh
@@ -2,6 +2,9 @@
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
+# Some RPM macros on suse try to override RPMTAG_VENDOR
+sed -i -e '/^%vendor/d' /usr/lib/rpm/macros.d/*
+
 # The mandoc package on OpenSUSE lacks libmandoc.a and
 # header files, which we need to build rpminspect
 curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz


### PR DESCRIPTION
The /usr/lib/rpm/macros.d/macros.python_all file on OpenSUSE Leap sets
%vendor if you are not building Python 2 packages.  The system
otherwise allows you to define your own vendor.  With this file in
place, all packages show up as built by "SUSE LLC".

Remove any %vendor lines present in /usr/lib/rpm/macros.d/macros.*
files on OpenSUSE Leap.

Signed-off-by: David Cantrell <dcantrell@redhat.com>