### PR TITLE
[lib] Only support RPM payload conversion with newer librpm releases

### DIFF
--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -284,6 +284,14 @@ char *get_rpm_header_value(const rpmfile_entry_t *file, rpmTag tag)
  */
 char *extract_rpm_payload(const char *rpm)
 {
+#ifdef _HAVE_OLD_RPM_API
+    /*
+     * only support payload conversion with newer librpm releases
+     * which include the rpmfiles.h and rpmarchive.h headers
+     */
+
+    return NULL;
+#else
     char *payload = NULL;
     rpmts ts;
     rpmVSFlags vsflags = RPMVSF_MASK_NODIGESTS | RPMVSF_MASK_NOSIGNATURES | RPMVSF_NOHDRCHK;
@@ -448,4 +456,5 @@ cleanup:
     rpmtsFree(ts);
 
     return payload;
+#endif
 }


### PR DESCRIPTION
At least on RHEL-7, the rpm version there lacks the rpmfiles.h and
rpmarchive.h headers which from what I can tell in the rpm source
means that API was not yet public in the release of rpm included with
RHEL-7.  Since this payload conversion is a value-add for rpminspect
for supporting large files in the payload stream, I think it's ok to
restrict it to more recent librpm versions.

Signed-off-by: David Cantrell <dcantrell@redhat.com>