### PR TITLE
[lib] Support a new config file block called 'environment'

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -18,6 +18,25 @@ common:
     # exist in the profile directory.
     profiledir: /usr/share/rpminspect/profiles/generic
 
+environment:
+    # There may be instances where rpminspect cannot easily determine
+    # the product release string from the dist tag.  The -r command
+    # line option is for those cases.  If you do not want to use the
+    # command line option, you can add this block to your
+    # rpminspect.yaml file and specify the product release this way.
+    #
+    # For example:
+    # product_release: el8
+    #
+    # If a product release is specified in a config file and then the
+    # -r option is specified (or --release) with a product release,
+    # the command line option overrides the config file value.  If a
+    # product release is specified in either a config file or via the
+    # command line, the automatic detection of the product release in
+    # the dist tag is skipped.
+    #
+    #product_release: GENERIC
+
 koji:
     # The root URL of the XMLRPC API provided by the Koji hub
     hub: http://koji-hub.example.com/api/v1

--- a/lib/init.c
+++ b/lib/init.c
@@ -1085,7 +1085,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             free(ri->profiledir);
                             ri->profiledir = strdup(t);
                         }
-                    } else if (block == BLOCK_COMMON) {
+                    } else if (block == BLOCK_ENVIRONMENT) {
                         if (!strcmp(key, "product_release")) {
                             free(ri->product_release);
                             ri->product_release = strdup(t);

--- a/lib/init.c
+++ b/lib/init.c
@@ -146,7 +146,8 @@ enum {
     BLOCK_REMOVEDFILES = 68,
     BLOCK_SYMLINKS = 69,
     BLOCK_UPSTREAM = 70,
-    BLOCK_VIRUS = 71
+    BLOCK_VIRUS = 71,
+    BLOCK_ENVIRONMENT = 72
 };
 
 static int add_regex(const char *pattern, regex_t **regex_out)
@@ -686,6 +687,9 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     if (!strcmp(key, "common")) {
                         block = BLOCK_COMMON;
                         group = BLOCK_NULL;
+                    } else if (!strcmp(key, "environment")) {
+                        block = BLOCK_ENVIRONMENT;
+                        group = BLOCK_NULL;
                     } else if (!strcmp(key, "koji")) {
                         block = BLOCK_KOJI;
                         group = BLOCK_NULL;
@@ -1080,6 +1084,11 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         } else if (!strcmp(key, "profiledir")) {
                             free(ri->profiledir);
                             ri->profiledir = strdup(t);
+                        }
+                    } else if (block == BLOCK_COMMON) {
+                        if (!strcmp(key, "product_release")) {
+                            free(ri->product_release);
+                            ri->product_release = strdup(t);
                         }
                     } else if (block == BLOCK_KOJI) {
                         if (!strcmp(key, "hub")) {

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -609,7 +609,6 @@ int main(int argc, char **argv)
     if (release) {
         free(ri->product_release);
         ri->product_release = release;
-        free(release);
     }
 
     /* Reporting threshold and suppression levels */

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -549,7 +549,6 @@ int main(int argc, char **argv)
     ri = calloc_rpminspect(ri);
     ri->progname = strdup(argv[0]);
     ri->verbose = verbose;
-    ri->product_release = release;
     ri->rebase_detection = rebase_detection;
 
     /*
@@ -605,6 +604,13 @@ int main(int argc, char **argv)
     }
 
     free(profile);
+
+    /* Product release specified on the command line overrides config file */
+    if (release) {
+        free(ri->product_release);
+        ri->product_release = release;
+        free(release);
+    }
 
     /* Reporting threshold and suppression levels */
     ri->threshold = getseverity(threshold, RESULT_VERIFY);
@@ -882,7 +888,10 @@ int main(int argc, char **argv)
             }
 
             /* get the product release */
-            ri->product_release = get_product_release(ri->products, ri->favor_release, before_rel, after_rel);
+            if (ri->product_release == NULL) {
+                ri->product_release = get_product_release(ri->products, ri->favor_release, before_rel, after_rel);
+            }
+
             DEBUG_PRINT("product_release=%s\n", ri->product_release);
 
             if (ri->product_release == NULL) {


### PR DESCRIPTION
In addition to letting users specify the product release string on the
command line, also introduce a block in the config file where you can
do the same thing.  It would look like this:

    environment:
        product_release: el8

Use this in a per-package rpminspect.yaml file where rpminspect is
unable to detect the product release string from the dist tag.  Some
packages lack a dist tag.

Fixes: #819

Signed-off-by: David Cantrell <dcantrell@redhat.com>