### PR TITLE
[fix] Correctly build the abidiff(1) command line

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -674,9 +674,6 @@ abidiff:
     # Location where debuginfo files live in RPM packages.
     debuginfo_path: /usr/lib/debug/
 
-    # Location of header files in RPM packages.
-    include_path: /usr/include/
-
     # Extra arguments for the abidiff(1) program.  These are put on
     # the command line before the two files being compared.
     #extra_args:

--- a/include/constants.h
+++ b/include/constants.h
@@ -318,22 +318,6 @@
 #define ABI_DEBUG_INFO_DIR2 "--debug-info-dir2"
 
 /**
- * @def ABI_HEADERS_DIR1
- *
- * The command line option for abidiff(1) to specify the location of
- * public headers for the files in the before build.
- */
-#define ABI_HEADERS_DIR1 "--headers-dir1"
-
-/**
- * @def ABI_HEADERS_DIR2
- *
- * The command line option for abidiff(1) to specify the location of
- * public headers for the files in the after build.
- */
-#define ABI_HEADERS_DIR2 "--headers-dir2"
-
-/**
  * @def KMIDIFF_CMD
  *
  * Executable providing kmidiff(1), the Kernel Module Interface

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -437,12 +437,10 @@ bool is_rebase(struct rpminspect *ri);
 void init_arches(struct rpminspect *ri);
 
 /* abi.c */
-void add_abi_argument(string_list_map_t *table, const char *arg, const char *path, const Header hdr);
-size_t count_abi_entries(const string_list_t *contents);
 abi_t *read_abi(const char *vendor_data_dir, const char *product_release);
 void free_abi(abi_t *list);
 string_list_t *get_abi_suppressions(const struct rpminspect *ri, const char *suppression_file);
-string_list_map_t *get_abi_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *arg, const char *path, const int type);
+string_list_map_t *get_abi_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *path, const int type);
 
 /* uncompress.c */
 char *uncompress_file(struct rpminspect *ri, const char *infile, const char *subdir);

--- a/include/types.h
+++ b/include/types.h
@@ -606,9 +606,6 @@ struct rpminspect {
     /* path where debuginfo files are found in packages */
     char *abidiff_debuginfo_path;
 
-    /* path where header filesa re found in packages */
-    char *abidiff_include_path;
-
     /* extra arguments for abidiff(1) */
     char *abidiff_extra_args;
 

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -538,7 +538,7 @@ void dump_cfg(const struct rpminspect *ri)
 
     HASH_FIND_STR(ri->inspection_ignores, NAME_ABIDIFF, mapentry);
 
-    if (ri->abidiff_suppression_file || ri->abidiff_debuginfo_path || ri->abidiff_include_path || ri->abidiff_extra_args || mapentry != NULL) {
+    if (ri->abidiff_suppression_file || ri->abidiff_debuginfo_path || ri->abidiff_extra_args || mapentry != NULL) {
         printf("abidiff:\n");
 
         if (ri->abidiff_suppression_file) {
@@ -547,10 +547,6 @@ void dump_cfg(const struct rpminspect *ri)
 
         if (ri->abidiff_debuginfo_path) {
             printf("    debuginfo_path: %s\n", ri->abidiff_debuginfo_path);
-        }
-
-        if (ri->abidiff_include_path) {
-            printf("    include_path: %s\n", ri->abidiff_include_path);
         }
 
         if (ri->abidiff_extra_args) {

--- a/lib/free.c
+++ b/lib/free.c
@@ -265,7 +265,6 @@ void free_rpminspect(struct rpminspect *ri)
     list_free(ri->forbidden_paths, free);
     free(ri->abidiff_suppression_file);
     free(ri->abidiff_debuginfo_path);
-    free(ri->abidiff_include_path);
     free(ri->abidiff_extra_args);
     free(ri->kmidiff_suppression_file);
     free(ri->kmidiff_debuginfo_path);

--- a/lib/init.c
+++ b/lib/init.c
@@ -1290,9 +1290,6 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         } else if (!strcmp(key, "debuginfo_path")) {
                             free(ri->abidiff_debuginfo_path);
                             ri->abidiff_debuginfo_path = strdup(t);
-                        } else if (!strcmp(key, "include_path")) {
-                            free(ri->abidiff_include_path);
-                            ri->abidiff_include_path = strdup(t);
                         } else if (!strcmp(key, "extra_args")) {
                             free(ri->abidiff_extra_args);
                             ri->abidiff_extra_args = strdup(t);
@@ -2175,7 +2172,6 @@ struct rpminspect *calloc_rpminspect(struct rpminspect *ri)
     ri->specprimary = PRIMARY_NAME;
     ri->abidiff_suppression_file = strdup(ABI_SUPPRESSION_FILE);
     ri->abidiff_debuginfo_path = strdup(DEBUG_PATH);
-    ri->abidiff_include_path = strdup(INCLUDE_PATH);
     ri->abi_security_threshold = DEFAULT_ABI_SECURITY_THRESHOLD;
     ri->kmidiff_suppression_file = strdup(ABI_SUPPRESSION_FILE);
     ri->kmidiff_debuginfo_path = strdup(DEBUG_PATH);

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -332,8 +332,8 @@ bool inspect_kmidiff(struct rpminspect *ri)
 
     /* get the debug info dirs (headers not used for kmidiff) */
     num_arches = list_len(ri->arches);
-    debug_info_dir1_table = get_abi_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, ABI_DEBUG_INFO_DIR1, DEBUG_PATH, BEFORE_BUILD);
-    debug_info_dir2_table = get_abi_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, ABI_DEBUG_INFO_DIR2, DEBUG_PATH, AFTER_BUILD);
+    debug_info_dir1_table = get_abi_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, BEFORE_BUILD);
+    debug_info_dir2_table = get_abi_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, AFTER_BUILD);
 
     /* build the list of first command line arguments */
     if (ri->kmidiff_extra_args) {


### PR DESCRIPTION
The abidiff(1) command line was incorrectly constructed.  It worked
for smaller packages where there tends to be a single debuginfo
package, but not larger builds with many subpackages.  Here's what has
changed:

* The debuginfo paths are collected and grouped per arch for the
  before and after builds.

* When the abidiff command line is constructed in the abidiff
  inspection, it selects the debuginfo path that is likely to contain
  the debugging symbols for the file in questions.  By likely I mean
  that I use a strstr() match and run with that.  There will probably
  be edge cases that show up later that I will need to account for.

* Dropped all of the headers-dir handling for abidiff(1) because
  that's impossible to determine.  I can only specify a single
  argument to abidiff(1), but it's not possible to figure out which
  tree will contain the necessary header file for the library in
  question since that's not 1:1 file-based matching.  So just stop
  pretending and don't do this.

The abidiff inspection should now be more stable as a result.

Fixes: #750

Signed-off-by: David Cantrell <dcantrell@redhat.com>