### PR TITLE
[fix] Make sure abidiff can find all debuginfo type files

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -305,7 +305,7 @@
  * this is a path to the corresponding directory in a debuginfo
  * package.
  */
-#define ABI_DEBUG_INFO_DIR1 "--debug-info-dir1"
+#define ABI_DEBUG_INFO_DIR1 "--d1"
 
 /**
  * @def ABI_DEBUG_INFO_DIR2
@@ -315,7 +315,7 @@
  * this is a path to the corresponding directory in a debuginfo
  * package.
  */
-#define ABI_DEBUG_INFO_DIR2 "--debug-info-dir2"
+#define ABI_DEBUG_INFO_DIR2 "--d2"
 
 /**
  * @def KMIDIFF_CMD


### PR DESCRIPTION
This is just simplifying things more and ensuring abidiff finds all
debugging data for its reporting.

The man page for abidiff(1) indicates multiple --d1 and --d2 arguments
can be specified, which I initially did, but they have to point
directly to the top of the debuginfo path.

Signed-off-by: David Cantrell <dcantrell@redhat.com>