### PR TITLE
[lib] Rename abidiff-specific helper functions

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -439,8 +439,8 @@ void init_arches(struct rpminspect *ri);
 /* abi.c */
 abi_t *read_abi(const char *vendor_data_dir, const char *product_release);
 void free_abi(abi_t *list);
-string_list_t *get_abi_suppressions(const struct rpminspect *ri, const char *suppression_file);
-string_list_map_t *get_abi_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *path, const int type);
+string_list_t *get_abidiff_suppressions(const struct rpminspect *ri, const char *suppression_file);
+string_list_map_t *get_abidiff_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *path, const int type);
 
 /* uncompress.c */
 char *uncompress_file(struct rpminspect *ri, const char *infile, const char *subdir);

--- a/lib/abi.c
+++ b/lib/abi.c
@@ -239,7 +239,7 @@ void free_abi(abi_t *table)
  * Get any .abignore files that exist in SRPM files in the build.
  * These are passed to every invocation of abidiff(1) if they exist.
  */
-string_list_t *get_abi_suppressions(const struct rpminspect *ri, const char *suppression_file)
+string_list_t *get_abidiff_suppressions(const struct rpminspect *ri, const char *suppression_file)
 {
     rpmpeer_entry_t *peer = NULL;
     rpmfile_entry_t *file = NULL;
@@ -281,7 +281,7 @@ string_list_t *get_abi_suppressions(const struct rpminspect *ri, const char *sup
  * name and the value is a string_list_t of the debug_info_dir1/2 or
  * header_dir1/2 arguments to abidiff(1) or kmidiff(1).
  */
-string_list_map_t *get_abi_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *path, const int type)
+string_list_map_t *get_abidiff_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *path, const int type)
 {
     rpmpeer_entry_t *peer = NULL;
     const char *name = NULL;
@@ -313,7 +313,7 @@ string_list_map_t *get_abi_dir_arg(struct rpminspect *ri, const size_t size, con
             continue;
         }
 
-        if (suffix && strsuffix(name, suffix)) {
+        if ((suffix && strsuffix(name, suffix)) || (suffix == NULL)) {
             tmp = joinpath(root, path, NULL);
             assert(tmp != NULL);
         } else {

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -268,14 +268,14 @@ bool inspect_abidiff(struct rpminspect *ri)
     abi = read_abi(ri->vendor_data_dir, ri->product_release);
 
     /* if there's a .abignore file in the after SRPM, we need to use it */
-    suppressions = get_abi_suppressions(ri, ri->abidiff_suppression_file);
+    suppressions = get_abidiff_suppressions(ri, ri->abidiff_suppression_file);
 
     /* number of architectures in the builds we have, for hash table size */
     num_arches = list_len(ri->arches);
 
     /* get the debug info dirs */
-    debug_info_dir1_table = get_abi_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, BEFORE_BUILD);
-    debug_info_dir2_table = get_abi_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, AFTER_BUILD);
+    debug_info_dir1_table = get_abidiff_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, BEFORE_BUILD);
+    debug_info_dir2_table = get_abidiff_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, AFTER_BUILD);
 
     /* build the list of first part of the command */
     if (ri->abidiff_extra_args) {

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -328,12 +328,12 @@ bool inspect_kmidiff(struct rpminspect *ri)
     get_kabi_dir(ri);
 
     /* if there's a .abignore file in the after SRPM, we need to use it */
-    suppressions = get_abi_suppressions(ri, ri->kmidiff_suppression_file);
+    suppressions = get_abidiff_suppressions(ri, ri->kmidiff_suppression_file);
 
     /* get the debug info dirs (headers not used for kmidiff) */
     num_arches = list_len(ri->arches);
-    debug_info_dir1_table = get_abi_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, BEFORE_BUILD);
-    debug_info_dir2_table = get_abi_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, AFTER_BUILD);
+    debug_info_dir1_table = get_abidiff_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, BEFORE_BUILD);
+    debug_info_dir2_table = get_abidiff_dir_arg(ri, num_arches, DEBUGINFO_SUFFIX, DEBUG_PATH, AFTER_BUILD);
 
     /* build the list of first command line arguments */
     if (ri->kmidiff_extra_args) {


### PR DESCRIPTION
Make these functions more clear that they are support functions for
use with abidiff(1) and not for the abi_t data type in the code.  I've
confused myself.

Signed-off-by: David Cantrell <dcantrell@redhat.com>