### PR TITLE
[cfg] Correct one small comment error in data/security/GENERIC

### DIFF
--- a/data/security/GENERIC
+++ b/data/security/GENERIC
@@ -11,7 +11,7 @@
 # number):
 #
 #     path           The file or path, can use glob(7) syntax
-#     name           The name of the package
+#     name           The name of the package, can use glob(7) syntax
 #     version        The package version, can use glob(7) syntax
 #     release        The package release, can use glob(7) syntax
 #     rules          Comma-delimited list of security rules where each


### PR DESCRIPTION
The package name in the security/PRODUCT_RELEASE files can use
wildcard glob(7) syntax.  The reason for this is that subpackages will
have different names but the same prefix (usually).

Signed-off-by: David Cantrell <dcantrell@redhat.com>