### PR TITLE
[lib] Move add_abidiff_arg() to abi.c and make non-static

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -441,6 +441,7 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release);
 void free_abi(abi_t *list);
 string_list_t *get_abidiff_suppressions(const struct rpminspect *ri, const char *suppression_file);
 string_list_map_t *get_abidiff_dir_arg(struct rpminspect *ri, const size_t size, const char *suffix, const char *path, const int type);
+char *add_abidiff_arg(char *cmd, string_list_map_t *table, const char *arch, const char *arg);
 
 /* uncompress.c */
 char *uncompress_file(struct rpminspect *ri, const char *infile, const char *subdir);

--- a/lib/abi.c
+++ b/lib/abi.c
@@ -364,3 +364,27 @@ string_list_map_t *get_abidiff_dir_arg(struct rpminspect *ri, const size_t size,
 
     return table;
 }
+
+/*
+ * Try to find the debug subdirectory containing the debuginfo for the
+ * file in question.
+ */
+char *add_abidiff_arg(char *cmd, string_list_map_t *table, const char *arch, const char *arg)
+{
+    string_list_map_t *hentry = NULL;
+    string_entry_t *entry = NULL;
+
+    if (table == NULL || arch == NULL) {
+        return cmd;
+    }
+
+    HASH_FIND_STR(table, arch, hentry);
+
+    if (hentry != NULL && hentry->value && !TAILQ_EMPTY(hentry->value)) {
+        TAILQ_FOREACH(entry, hentry->value, items) {
+            cmd = strappend(cmd, " ", arg, " ", entry->data, NULL);
+        }
+    }
+
+    return cmd;
+}

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -95,30 +95,6 @@ static severity_t check_abi(const severity_t sev, const long int threshold, cons
     return sev;
 }
 
-/*
- * Try to find the debug subdirectory containing the debuginfo for the
- * file in question.
- */
-static char *add_abidiff_arg(char *cmd, string_list_map_t *table, const char *arch, const char *arg)
-{
-    string_list_map_t *hentry = NULL;
-    string_entry_t *entry = NULL;
-
-    if (table == NULL || arch == NULL) {
-        return cmd;
-    }
-
-    HASH_FIND_STR(table, arch, hentry);
-
-    if (hentry != NULL && hentry->value && !TAILQ_EMPTY(hentry->value)) {
-        TAILQ_FOREACH(entry, hentry->value, items) {
-            cmd = strappend(cmd, " ", arg, " ", entry->data, NULL);
-        }
-    }
-
-    return cmd;
-}
-
 static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool result = true;


### PR DESCRIPTION
This function will be used by both the abidiff and kmidiff
inspections.

Signed-off-by: David Cantrell <dcantrell@redhat.com>