### PR TITLE
[fix] Get Koji module downloading working consistently

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -773,9 +773,10 @@ typedef struct _koji_buildlist_entry_t {
     int state;
     char *nvr;
     char *start_time;
+    int create_event;
     int creation_event_id;
     char *creation_time;
-    char *epoch;
+    int epoch;
     int tag_id;
     char *completion_time;
     char *tag_name;


### PR DESCRIPTION
There were a number of problems that had to be addressed.  The biggest
was around iterating over the structs returned in the XML-RPC
communication.  The second was the modulemd_str struct element
returned contains a very large string (usually).  If you use
xmlrpc_limit_set() when using libxmlrpc-c, which librpminspect was
doing, then you will have value reads truncated but then appended to
other strings since everything is still in the message.  libxmlrpc-c
does not consider this an error so no fault codes are registered.
What I found was that we can discontinue calling xmlrpc_limit_set()
and everything lines up fine.  I think a few years ago the situation
was different, but I have not checked older versions of the library.

Downloads of modules should work consistently now and rpminspect will
filter out RPMs that are marked as filtered in the module.  It also
fetches the modulemd*txt files, which we can probably add inspections
for later.

I still have some cleanups to do, but I wanted to get functionality
restored first as a patch.

Fixes: #844

Signed-off-by: David Cantrell <dcantrell@redhat.com>