### PR TITLE
[fix] Handle source packages in get_nevra() (#859)

### DIFF
--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -151,12 +151,21 @@ char *get_nevr(Header hdr)
 }
 
 /*
- * Get the RPMTAG_NEVRA extension tag.
+ * Get the RPMTAG_NEVRA extension tag equivalent.  Do not use
+ * RPMTAG_NEVRA directly here because on source RPMs, the "A" part of
+ * NEVRA will have been written at rpmbuild time and does not report
+ * "source" as the architecture but rather the architecture that you
+ * ran rpmbuild on.
  * NOTE: Caller must free this result.
  */
 char *get_nevra(Header hdr)
 {
-    return get_rpmtag_str(hdr, RPMTAG_NEVRA);
+    char *r = NULL;
+
+    r = get_nevr(hdr);
+    assert(r != NULL);
+    r = strappend(r, ".", get_rpm_header_arch(hdr), NULL);
+    return r;
 }
 
 /*


### PR DESCRIPTION
Source packages report the rpmbuild runtime architecture when asking
for RPMTAG_NEVRA.  In rpminspect, we want to show "src" for the
architecture of source packages so handle that as a special case.

Fixes: #859

Signed-off-by: David Cantrell <dcantrell@redhat.com>