### PR TITLE
[bld] Change clamav-data to Recommends in the spec file

### DIFF
--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -51,7 +51,14 @@ Summary:        Library providing RPM test API and functionality
 Group:          Development/Tools
 Requires:       desktop-file-utils
 Requires:       gettext
+
+# The clamav data is required for the virus inspection.  Either
+# install the clamav-data or download the data files directly.
+%if 0%{?rhel} >= 8 || 0%{?epel} >= 8 || 0%{?fedora}
+Recommends:     clamav-data
+%else
 Requires:       clamav-data
+%endif
 
 # If these are present, the xml inspection can try DTD validation.
 %if 0%{?rhel} >= 8 || 0%{?fedora}


### PR DESCRIPTION
Since the data package is so large, change it to a Recommends rather
than Requires.  People wanting or needing to run the virus inspection
can install the clamav-data package or manually download the data
files for libclamav.

Fixes: #856

Signed-off-by: David Cantrell <dcantrell@redhat.com>