### PR TITLE
[fix] Get reporting severity for removed files w/ WAIVABLE_BY_SECURITY

### DIFF
--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -121,7 +121,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (params.waiverauth == WAIVABLE_BY_SECURITY || (ri->tests & INSPECT_REMOVEDFILES)) {
         params.remedy = REMEDY_REMOVEDFILES;
 
-        if (sentry) {
+        if (sentry || params.waiverauth == WAIVABLE_BY_SECURITY) {
             params.severity = get_secrule_result_severity(ri, file, SECRULE_SECURITYPATH);
         } else {
             params.severity = RESULT_INFO;


### PR DESCRIPTION
Previously only files with matching secrules in the data package would
get a reporting level other than RESULT_INFO, but we also need a
reporting severity if the waiverauth is set to WAIVABLE_BY_SECURITY.

Signed-off-by: David Cantrell <dcantrell@redhat.com>