### PR TITLE
[fix] Set XML-RPC size limit to SIZE_MAX

### DIFF
--- a/lib/koji.c
+++ b/lib/koji.c
@@ -993,6 +993,7 @@ struct koji_task *get_koji_task(struct rpminspect *ri, const char *taskspec)
     task = calloc(1, sizeof(*task));
     assert(task != NULL);
     init_koji_task(task);
+    xmlrpc_limit_set(XMLRPC_XML_SIZE_LIMIT_ID, SIZE_MAX);
     xmlrpc_env_init(&env);
     xmlrpc_client_init2(&env, XMLRPC_CLIENT_NO_FLAGS, SOFTWARE_NAME, PACKAGE_VERSION, NULL, 0);
     xmlrpc_abort_on_fault(&env);
@@ -1143,6 +1144,7 @@ string_list_t *get_all_arches(const struct rpminspect *ri)
     TAILQ_INSERT_TAIL(arches, arch, items);
 
     /* initialize everything and get XMLRPC ready */
+    xmlrpc_limit_set(XMLRPC_XML_SIZE_LIMIT_ID, SIZE_MAX);
     xmlrpc_env_init(&env);
     xmlrpc_client_init2(&env, XMLRPC_CLIENT_NO_FLAGS, SOFTWARE_NAME, PACKAGE_VERSION, NULL, 0);
     xmlrpc_abort_on_fault(&env);

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -525,6 +525,7 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
     build = calloc(1, sizeof(*build));
     assert(build != NULL);
     init_koji_build(build);
+    xmlrpc_limit_set(XMLRPC_XML_SIZE_LIMIT_ID, SIZE_MAX);
     xmlrpc_env_init(&env);
     xmlrpc_client_init2(&env, XMLRPC_CLIENT_NO_FLAGS, SOFTWARE_NAME, PACKAGE_VERSION, NULL, 0);
     xmlrpc_abort_on_fault(&env);


### PR DESCRIPTION
The default is 512K which has worked up until now.  xmlrpc-c uses a
size_t for this size, so just give it SIZE_MAX and let it run with
that.

Fixes: #864

Signed-off-by: David Cantrell <dcantrell@redhat.com>