### PR TITLE
[ci] Use vbatts/slackware:latest in GitHub Actions

### DIFF
--- a/.github/workflows/slackware.yml
+++ b/.github/workflows/slackware.yml
@@ -28,7 +28,7 @@ jobs:
         # Set up the matrix of distributions to test
         strategy:
             matrix:
-                container: ["vbatts/slackware:current"]
+                container: ["vbatts/slackware:latest"]
 
         container:
             image: ${{ matrix.container }}


### PR DESCRIPTION
Rather than vbatts/slackware:current, use vbatts/slackware:latest which is the latest stable release.  The current branch is not always guaranteed to be working and I just noticed test failures because some of the packages were not built against the version of glibc in the tree.

Signed-off-by: David Cantrell <dcantrell@redhat.com>