### PR TITLE
Add firefox into baseline testing.

### DIFF
--- a/utils/gate.sh
+++ b/utils/gate.sh
@@ -45,7 +45,7 @@ failure() {
 }
 
 # Packages to diff to consider this build stable-enough
-packages="zsh kernel python3 mutt emacs tmux elfutils"
+packages="zsh kernel python3 firefox mutt emacs tmux elfutils"
 
 # Validate programs we need are present
 reqs="rpmbuild koji"


### PR DESCRIPTION
While testing rpminspect against rpmdiff, we ran into some performance issues on the runner level. We have the kernel as a test in this list for the same reason, so I believe that adding Firefox is another valuable data point to capture when testing.