### PR TITLE
[lib] Change licensdb to a string_list_t in struct rpminspect

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -467,7 +467,7 @@ struct rpminspect {
 
     /* Vendor data */
     char *vendor_data_dir;     /* main vendor data directory */
-    char *licensedb;           /* name of file under licenses/ to use */
+    string_list_t *licensedb;  /* names of files under licenses/ to use */
     favor_release_t favor_release;
 
     /* Populated at runtime for the product release */

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -158,8 +158,12 @@ void dump_cfg(const struct rpminspect *ri)
         printf("    vendor_data_dir: %s\n", ri->vendor_data_dir);
     }
 
-    if (ri->licensedb) {
-        printf("    licensedb: %s\n", ri->licensedb);
+    if (ri->licensedb && !TAILQ_EMPTY(ri->licensedb)) {
+        printf("    licensedb:\n");
+
+        TAILQ_FOREACH(entry, ri->licensedb, items) {
+            printf("        - %s\n", entry->data);
+        }
     }
 
     printf("    favor_release: %s\n", (ri->favor_release == FAVOR_NONE) ? "none" : (ri->favor_release == FAVOR_OLDEST) ? "oldest" : (ri->favor_release == FAVOR_NEWEST) ? "newest" : "?");

--- a/lib/free.c
+++ b/lib/free.c
@@ -120,7 +120,7 @@ void free_rpminspect(struct rpminspect *ri)
     free(ri->worksubdir);
 
     free(ri->vendor_data_dir);
-    free(ri->licensedb);
+    list_free(ri->licensedb, free);
 
     if (ri->fileinfo) {
         while (!TAILQ_EMPTY(ri->fileinfo)) {

--- a/lib/init.c
+++ b/lib/init.c
@@ -583,6 +583,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
     bool exclude = false;
     dep_type_t depkey = TYPE_NULL;
     deprule_ignore_map_t *drentry = NULL;
+    string_entry_t *sentry = NULL;
 
     assert(ri != NULL);
     assert(filename != NULL);
@@ -1132,8 +1133,17 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             free(ri->vendor_data_dir);
                             ri->vendor_data_dir = strdup(t);
                         } else if (!strcmp(key, "licensedb")) {
-                            free(ri->licensedb);
-                            ri->licensedb = strdup(t);
+                            if (ri->licensedb == NULL) {
+                                ri->licensedb = calloc(1, sizeof(*(ri->licensedb)));
+                                assert(ri->licensedb != NULL);
+                                TAILQ_INIT(ri->licensedb);
+                            }
+
+                            sentry = calloc(1, sizeof(*sentry));
+                            assert(sentry != NULL);
+                            sentry->data = strdup(t);
+                            assert(sentry->data != NULL);
+                            TAILQ_INSERT_TAIL(ri->licensedb, sentry, items);
                         } else if (!strcmp(key, "favor_release")) {
                             if (!strcasecmp(t, "none")) {
                                 ri->favor_release = FAVOR_NONE;


### PR DESCRIPTION
This is an internal library change to allow support for multiple license database files in the rpminspect configuration file.  The license inspection has been modified to work with a list of license databases.

Signed-off-by: David Cantrell <dcantrell@redhat.com>