### PR TITLE
[lib] Support multiple license db files in the config file

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -82,8 +82,9 @@ vendor:
     # subdirectory in the vendor_data_dir or a full path to a license
     # database file to use.  This file is used by the 'license'
     # inspection.
-    licensedb: generic.json
-    #licensedb: /usr/share/vendor-license-data/licenses/vendor-licenses.json
+    licensedb:
+        - generic.json
+        #- licensedb: /usr/share/vendor-license-data/licenses/vendor-licenses.json
 
     # Which product release string to favor.  By default, rpminspect
     # favors the newest product release string.  You can change this

--- a/include/init.h
+++ b/include/init.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#ifndef _LIBRPMINSPECT_INIT_H
+#define _LIBRPMINSPECT_INIT_H
+
+#define SECTION_VENDOR    "vendor"
+#define SECTION_LICENSEDB "licensedb"
+
+#endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,6 +1,7 @@
 # Install header files
 install_headers(
     'constants.h',
+    'init.h',
     'inspect.h',
     'output.h',
     'readelf.h',


### PR DESCRIPTION
Support the 'licensedb' setting in the config file either indicating a single license database file or listing multiple files.

Fixes: #847

Signed-off-by: David Cantrell <dcantrell@redhat.com>