### PR TITLE
[tst] Set licensedb to a list in baseclass.py

### DIFF
--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -255,7 +255,7 @@ class RequiresRpminspect(unittest.TestCase):
 
         cfg["metadata"]["vendor"] = VENDOR
         cfg["vendor"]["vendor_data_dir"] = os.environ["RPMINSPECT_TEST_DATA_PATH"]
-        cfg["vendor"]["licensedb"] = "test.json"
+        cfg["vendor"]["licensedb"] = ["test.json"]
 
         if self.buildhost_subdomain:
             cfg["metadata"]["buildhost_subdomain"] = [self.buildhost_subdomain]


### PR DESCRIPTION
librpminspect supports licensedb in the config file as a list now, so use that for the test suite.

Signed-off-by: David Cantrell <dcantrell@redhat.com>