### PR TITLE
[fix] When the subpackages inspection succeeds, report an OK message

### DIFF
--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -126,5 +126,16 @@ bool inspect_subpackages(struct rpminspect *ri)
     list_free(before_pkgs, free);
     list_free(after_pkgs, free);
 
+    /* Sound the everything-is-ok alarm if everything is, in fact, ok */
+    if (result) {
+        params.severity = RESULT_OK;
+        params.waiverauth = NOT_WAIVABLE;
+        params.msg = NULL;
+        params.verb = VERB_OK;
+        free(params.remedy);
+        params.remedy = NULL;
+        add_result(ri, &params);
+    }
+
     return result;
 }


### PR DESCRIPTION
Similar to other inspections that succeed but have nothing to report, just add a blank "OK" message so users know it ran and succeeded.

Fixes: #879

Signed-off-by: David Cantrell <dcantrell@redhat.com>