### PR TITLE
[tst] Add integration tests for annocheck inspection

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -117,6 +117,7 @@ if python.found()
     test_suites = [
         'test_abidiff.py',
         'test_addedfiles.py',
+        'test_annocheck.py',
         'test_badfuncs.py',
         'test_capabilities.py',
         'test_changedfiles.py',

--- a/test/test_annocheck.py
+++ b/test/test_annocheck.py
@@ -1,0 +1,117 @@
+# Copyright © 2022 Red Hat, Inc.
+# Author(s): Zuzana Miklankova <zmiklank@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from baseclass import TestCompareRPMs, TestCompareKoji, TestRPMs, TestKoji
+
+needed_flags = "-Wl,-z,now -fcf-protection=full -fplugin=annobin -O2 \
+        -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong"
+
+
+class AnnocheckHardenedCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_simple_library(compileFlags=needed_flags)
+        self.after_rpm.add_simple_library(compileFlags=needed_flags)
+
+        self.inspection = "annocheck"
+        self.result = "INFO"
+        self.exitcode = 0
+        self.waiver_auth = "Not Waivable"
+
+
+class AnnocheckHardenedCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_simple_library(compileFlags=needed_flags)
+        self.after_rpm.add_simple_library(compileFlags=needed_flags)
+
+        self.inspection = "annocheck"
+        self.result = "INFO"
+        self.exitcode = 0
+        self.waiver_auth = "Not Waivable"
+
+
+class AnnocheckNotHardenedCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_simple_library(compileFlags=needed_flags)
+        self.after_rpm.add_simple_library()
+
+        self.inspection = "annocheck"
+        self.result = "VERIFY"
+        self.waiver_auth = "Not Waivable"
+
+
+class AnnocheckNotHardenedCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_simple_library(compileFlags=needed_flags)
+        self.after_rpm.add_simple_library()
+
+        self.inspection = "annocheck"
+        self.result = "VERIFY"
+        self.waiver_auth = "Not Waivable"
+
+
+class AnnocheckHardenedRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_simple_library(compileFlags=needed_flags)
+
+        self.inspection = "annocheck"
+        self.result = "INFO"
+        self.exitcode = 0
+        self.waiver_auth = "Not Waivable"
+
+
+class AnnocheckHardenedKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_simple_library(compileFlags=needed_flags)
+
+        self.inspection = "annocheck"
+        self.result = "INFO"
+        self.exitcode = 0
+        self.waiver_auth = "Not Waivable"
+
+
+class AnnocheckNotHardenedRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_simple_library()
+
+        self.inspection = "annocheck"
+        self.result = "VERIFY"
+        self.waiver_auth = "Not Waivable"
+
+
+class AnnocheckNotHardenedKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_simple_library()
+
+        self.inspection = "annocheck"
+        self.result = "VERIFY"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
Sorry for taking so long, however here is a proposal for adding the annocheck inspection integration test suite.

Eight integration tests are added that cover the annocheck inspection, testing following use-cases:
    * Single binary RPM  (passing and failing case)
    * Two binary RPMs to compare  (passing and failing case)
    * A single Koji build  (passing and failing case)
    * Two Koji builds to compare  (passing and failing case)