### PR TITLE
[fix] Check for completed builds and closed tasks when fetching

### DIFF
--- a/lib/koji.c
+++ b/lib/koji.c
@@ -618,13 +618,6 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
         return NULL;
     }
 
-    /* build must be complete */
-    if (build->state != BUILD_COMPLETE) {
-        warnx(_("Koji build state is %s for %s, cannot continue."), build_state_desc(build->state), buildspec);
-        free_koji_build(build);
-        return NULL;
-    }
-
     /* read the values from the result */
     size = xmlrpc_struct_size(&env, result);
     xmlrpc_abort_on_fault(&env);
@@ -835,6 +828,13 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
     }
 
     xmlrpc_DECREF(result);
+
+    /* build must be complete */
+    if (build->state != BUILD_COMPLETE) {
+        warnx(_("Koji build state is %s for %s, cannot continue."), build_state_desc(build->state), buildspec);
+        free_koji_build(build);
+        return NULL;
+    }
 
     /* Modules have multiple builds, so collect the IDs */
     if (ri->buildtype == KOJI_BUILD_MODULE) {


### PR DESCRIPTION
When gathering a Koji build, stop if the build state is not BUILD_COMPLETED.  Likewise, when gathering a Koji task, stop if the task state is not TASK_CLOSED.  Any other state indicates a failed condition that either happened by itself or the user triggered.  In any of those cases, we do not want to try to fetch those artifacts.

Fixes: #881

Signed-off-by: David Cantrell <dcantrell@redhat.com>