### PR TITLE
[ci] Add annobin-annocheck to reqs.txt for almalinux8

### DIFF
--- a/osdeps/almalinux8/reqs.txt
+++ b/osdeps/almalinux8/reqs.txt
@@ -1,4 +1,4 @@
-annobin
+annobin-annocheck
 bash
 clamav-data
 clamav-devel


### PR DESCRIPTION
The package name containing /usr/bin/annocheck changed.

Signed-off-by: David Cantrell <dcantrell@redhat.com>