### PR TITLE
[tst] Add "-fstack-clash-protection -flto" in test_annocheck.py

### DIFF
--- a/test/test_annocheck.py
+++ b/test/test_annocheck.py
@@ -18,7 +18,8 @@
 from baseclass import TestCompareRPMs, TestCompareKoji, TestRPMs, TestKoji
 
 needed_flags = "-Wl,-z,now -fcf-protection=full -fplugin=annobin -O2 \
-        -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong"
+        -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong \
+        -fstack-clash-protection -flto"
 
 
 class AnnocheckHardenedCompareRPMs(TestCompareRPMs):


### PR DESCRIPTION
Add "-fstack-clash-protection -flto" to the needed CFLAGS in test_annocheck.py.

Signed-off-by: David Cantrell <dcantrell@redhat.com>