### PR TITLE
[tst] Skip annocheck tests if no 'annocheck' executable found

### DIFF
--- a/test/test_annocheck.py
+++ b/test/test_annocheck.py
@@ -15,13 +15,22 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+import os
+import unittest
 from baseclass import TestCompareRPMs, TestCompareKoji, TestRPMs, TestKoji
 
 needed_flags = "-Wl,-z,now -fcf-protection=full -fplugin=annobin -O2 \
         -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong \
         -fstack-clash-protection -flto"
 
+# This check requires the annocheck executable in the PATH
+have_annocheck = True
 
+if os.system("annocheck --help >/dev/null 2>&1") != 0:
+    have_annocheck = False
+
+
+@unittest.skipUnless(have_annocheck, "annocheck not available")
 class AnnocheckHardenedCompareRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
@@ -35,6 +44,7 @@ class AnnocheckHardenedCompareRPMs(TestCompareRPMs):
         self.waiver_auth = "Not Waivable"
 
 
+@unittest.skipUnless(have_annocheck, "annocheck not available")
 class AnnocheckHardenedCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
@@ -48,6 +58,7 @@ class AnnocheckHardenedCompareKoji(TestCompareKoji):
         self.waiver_auth = "Not Waivable"
 
 
+@unittest.skipUnless(have_annocheck, "annocheck not available")
 class AnnocheckNotHardenedCompareRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
@@ -60,6 +71,7 @@ class AnnocheckNotHardenedCompareRPMs(TestCompareRPMs):
         self.waiver_auth = "Not Waivable"
 
 
+@unittest.skipUnless(have_annocheck, "annocheck not available")
 class AnnocheckNotHardenedCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
@@ -72,6 +84,7 @@ class AnnocheckNotHardenedCompareKoji(TestCompareKoji):
         self.waiver_auth = "Not Waivable"
 
 
+@unittest.skipUnless(have_annocheck, "annocheck not available")
 class AnnocheckHardenedRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
@@ -84,6 +97,7 @@ class AnnocheckHardenedRPMs(TestRPMs):
         self.waiver_auth = "Not Waivable"
 
 
+@unittest.skipUnless(have_annocheck, "annocheck not available")
 class AnnocheckHardenedKoji(TestKoji):
     def setUp(self):
         super().setUp()
@@ -96,6 +110,7 @@ class AnnocheckHardenedKoji(TestKoji):
         self.waiver_auth = "Not Waivable"
 
 
+@unittest.skipUnless(have_annocheck, "annocheck not available")
 class AnnocheckNotHardenedRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
@@ -107,6 +122,7 @@ class AnnocheckNotHardenedRPMs(TestRPMs):
         self.waiver_auth = "Not Waivable"
 
 
+@unittest.skipUnless(have_annocheck, "annocheck not available")
 class AnnocheckNotHardenedKoji(TestKoji):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
The annocheck inspection requires the 'annocheck' program.  If we don't have that, just skip the tests because it means a platform where annocheck is not available.

Signed-off-by: David Cantrell <dcantrell@redhat.com>