### PR TITLE
[fix] Error on old json-c version with json_object_object_foreach()

### DIFF
--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -94,15 +94,16 @@ static struct json_object *read_licensedb(struct rpminspect *ri, const char *db)
  */
 static bool check_license_abbrev(const struct json_object *db, const char *lic)
 {
+    struct json_object *ldb = (struct json_object *) db;
     const char *fedora_abbrev = "";
     const char *fedora_name = "";
     const char *spdx_abbrev = "";
     bool approved = false;
 
-    assert(db != NULL);
+    assert(ldb != NULL);
     assert(lic != NULL);
 
-    json_object_object_foreach(db, license_name, val) {
+    json_object_object_foreach(ldb, license_name, val) {
         /* first reset our variables */
         fedora_abbrev = "";
         fedora_name = "";


### PR DESCRIPTION
This is (const struct json_object *) vs (struct json_object *) which I just don't care about because this is a loop that's only reading the structure.

Signed-off-by: David Cantrell <dcantrell@redhat.com>