### PR TITLE
[ci] Disable annocheck tests on Amazon Linux 2

### DIFF
--- a/osdeps/amzn2/reqs.txt
+++ b/osdeps/amzn2/reqs.txt
@@ -1,4 +1,3 @@
-annobin
 bash
 clamav-data
 clamav-devel


### PR DESCRIPTION
Amazon Linux 2 is too old to run the annocheck tests at this point, so just skip them.

Signed-off-by: David Cantrell <dcantrell@redhat.com>