### PR TITLE
[ci] Do not run annocheck inspection tests on CentOS 7

### DIFF
--- a/osdeps/centos7/reqs.txt
+++ b/osdeps/centos7/reqs.txt
@@ -1,4 +1,3 @@
-annobin
 bash
 clamav-data
 clamav-devel


### PR DESCRIPTION
The version of gcc here is too old for the test cases we have in test_annocheck.py, so just disable them like we do for Amazon Linux 2.

Signed-off-by: David Cantrell <dcantrell@redhat.com>