### PR TITLE
[lib] Add is_elf_executable() to readelf.c

### DIFF
--- a/include/readelf.h
+++ b/include/readelf.h
@@ -158,6 +158,17 @@ bool is_elf(const char *path);
 bool is_elf_shared_library(const char *path);
 
 /**
+ * @brief Determine if the specified file is an ELF executable.
+ *
+ * Given a path to a file, this function returns true if the file is
+ * an ELF executable.  That is, if it is ELF type ET_EXEC.
+ *
+ * @param path The fullpath tothe file in question.
+ * @return True if the file is an ELF executable, false otherwise.
+ */
+bool is_elf_executable(const char *path);
+
+/**
  * @brief Determine if the specified file is an ELF file.
  *
  * Given a path to a file, this function returns true if the file is

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -148,28 +148,41 @@ bool is_elf(const char *path)
     return (is_elf_file(path) || is_elf_archive(path));
 }
 
+static bool _is_elf_type(const char *path, int type)
+{
+    bool result = false;
+    int fd = 0;
+    Elf *elf = NULL;
+
+    assert(path != NULL);
+
+    elf = get_elf(path, &fd);
+
+    if (elf && get_elf_type(elf) == type) {
+        result = true;
+    }
+
+    close(fd);
+    elf_end(elf);
+    return result;
+}
+
 /*
  * Return true if a specified file is an ELF shared library file, that
  * is, of type ET_DYN.
  */
 bool is_elf_shared_library(const char *path)
 {
-    bool result = false;
-    int fd = 0;
-    Elf *elf = NULL;
-    char *soname = NULL;
+    return _is_elf_type(path, ET_DYN);
+}
 
-    elf = get_elf(path, &fd);
-    soname = get_elf_soname(path);
-
-    if (elf && get_elf_type(elf) == ET_DYN && soname != NULL) {
-        result = true;
-    }
-
-    free(soname);
-    close(fd);
-    elf_end(elf);
-    return result;
+/*
+ * Return true if a specified file is an ELF executable file, that
+ * is, of type ET_EXEC.
+ */
+bool is_elf_executable(const char *path)
+{
+    return _is_elf_type(path, ET_EXEC);
 }
 
 /*


### PR DESCRIPTION
Further expand readelf.c to distinguish between an ET_DYN and ET_EXEC, which is needed for some inspections.

Signed-off-by: David Cantrell <dcantrell@redhat.com>