### PR TITLE
[fix] Remove free() with module input in the upstream inspection

### DIFF
--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -79,6 +79,10 @@ static bool upstream_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         add_result(ri, &params);
         result = !(params.severity >= RESULT_VERIFY);
         reported = true;
+
+        /* clean up */
+        free(params.msg);
+        params.msg = NULL;
     } else {
         /* compare checksums to see if the upstream sources changed */
         before_sum = checksum(file->peer_file);
@@ -109,11 +113,10 @@ static bool upstream_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             /* clean up */
             free(diff_output);
+            free(params.msg);
+            params.msg = NULL;
         }
     }
-
-    free(params.msg);
-    params.msg = NULL;
 
     return result;
 }


### PR DESCRIPTION
When comparing two modules, the upstream inspection can hit a double free().  This commit eliminates that.

Fixes: #904

Signed-off-by: David Cantrell <dcantrell@redhat.com>