### PR TITLE
Support specifying Koji build type as a command line option

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -53,6 +53,9 @@ extern struct inspect inspections[];
 /* List of all output format types (output.c) */
 extern struct format formats[];
 
+/* List of all build types (koji.c) */
+extern struct buildtype buildtypes[];
+
 /* Terminal resize indicator */
 extern volatile sig_atomic_t terminal_resized;
 
@@ -179,6 +182,7 @@ struct koji_build *get_koji_build(struct rpminspect *, const char *);
 struct koji_task *get_koji_task(struct rpminspect *, const char *);
 string_list_t *get_all_arches(const struct rpminspect *);
 bool allowed_arch(const struct rpminspect *, const char *);
+const char *buildtype_desc(const koji_build_type_t type);
 
 /* kmods.c */
 #ifdef _WITH_LIBKMOD

--- a/include/types.h
+++ b/include/types.h
@@ -706,6 +706,20 @@ struct rpminspect {
 };
 
 /*
+ * Definition for a build type.
+ */
+struct buildtype {
+    /* the build type that maps to koji_build_type_t */
+    koji_build_type_t type;
+
+    /* name of the build type */
+    char *name;
+
+    /* whether or not this type is supported */
+    bool supported;
+};
+
+/*
  * Definition for an output format.
  */
 struct format {

--- a/lib/init.c
+++ b/lib/init.c
@@ -2330,7 +2330,6 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
     }
 
     /* the rest of the members are used at runtime */
-    ri->buildtype = KOJI_BUILD_RPM;
     ri->threshold = RESULT_VERIFY;
     ri->worst_result = RESULT_OK;
     ri->suppress = RESULT_NULL;

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -449,7 +449,14 @@ bool inspect_changelog(struct rpminspect *ri)
     assert(ri != NULL);
 
     /* skip this inspection on modules */
-    if (ri->buildtype == KOJI_BUILD_MODULE) {
+    if (ri->buildtype != KOJI_BUILD_RPM) {
+        init_result_params(&params);
+        xasprintf(&params.msg, _("Inspection skipped because this build's type is not `rpm'."));
+        params.severity = RESULT_INFO;
+        params.waiverauth = NOT_WAIVABLE;
+        params.header = NAME_CHANGELOG;
+        add_result(ri, &params);
+        free(params.msg);
         return true;
     }
 

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -86,6 +86,13 @@ bool inspect_modularity(struct rpminspect *ri)
     assert(ri != NULL);
 
     if (ri->buildtype != KOJI_BUILD_MODULE) {
+        init_result_params(&params);
+        xasprintf(&params.msg, _("Inspection skipped because this build's type is not `module'."));
+        params.severity = RESULT_INFO;
+        params.waiverauth = NOT_WAIVABLE;
+        params.header = NAME_MODULARITY;
+        add_result(ri, &params);
+        free(params.msg);
         return true;
     }
 
@@ -94,7 +101,7 @@ bool inspect_modularity(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = WAIVABLE_BY_ANYONE;
+        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_MODULARITY;
         add_result(ri, &params);
     }

--- a/src/rpminspect.1
+++ b/src/rpminspect.1
@@ -158,13 +158,21 @@ false positives in the output.  If you want to always disable the
 rebase checking and enforce the strict rules, you can pass this
 option.
 .TP
+.B \-b TYPE, \-\-build-type=TYPE
+Set the Koji build type to TYPE.  By default, rpminspect will try to
+automatically determine the build type of the inputs.  In some cases
+you may want to explicitly set the type if it is having trouble
+determining the build type.  This option is most useful when using
+locally provided Koji input subdirectories.  Supported build types can
+be seen with the \-l option.
+.TP
 .B \-o FILE, \-\-output=FILE
 Write the results to the name output file.  By default, results go to
 stdout.
 .TP
 .B \-F TYPE, \-\-format=TYPE
 Write the inspection results in the TYPE format.  The default format
-is text.  Available formats can be seen with the \-l option
+is text.  Available formats can be seen with the \-l option.
 .TP
 .B \-t TAG, \-\-threshold=TAG
 Result threshold that triggers a non-zero exit code.  By default this

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -206,6 +206,9 @@ class RequiresRpminspect(unittest.TestCase):
         ):
             raise MissingRpminspectConf
 
+        # let test cases override the build type
+        self.buildtype = "rpm"
+
         # set in configFile()
         self.conffile = None
         self.extra_cfg = None
@@ -324,6 +327,8 @@ class TestSRPM(RequiresRpminspect):
             "-d",
             "-c",
             self.conffile,
+            "-b",
+            self.buildtype,
             "-F",
             "json",
             "-r",
@@ -420,6 +425,8 @@ class TestCompareSRPM(RequiresRpminspect):
             "-d",
             "-c",
             self.conffile,
+            "-b",
+            self.buildtype,
             "-F",
             "json",
             "-r",
@@ -510,6 +517,8 @@ class TestRPMs(RequiresRpminspect):
                 "-d",
                 "-c",
                 self.conffile,
+                "-b",
+                self.buildtype,
                 "-F",
                 "json",
                 "-r",
@@ -611,6 +620,8 @@ class TestCompareRPMs(RequiresRpminspect):
                 "-d",
                 "-c",
                 self.conffile,
+                "-b",
+                self.buildtype,
                 "-F",
                 "json",
                 "-r",
@@ -694,6 +705,8 @@ class TestKoji(TestRPMs):
                 "-d",
                 "-c",
                 self.conffile,
+                "-b",
+                self.buildtype,
                 "-F",
                 "json",
                 "-r",
@@ -785,6 +798,8 @@ class TestCompareKoji(TestCompareRPMs):
                 "-d",
                 "-c",
                 self.conffile,
+                "-b",
+                self.buildtype,
                 "-F",
                 "json",
                 "-r",


### PR DESCRIPTION
Normally rpminspect autodetects the Koji build type of the inputs, but in some cases you may want to need to do that explicitly.  The -b or --build-type option on rpminspect now permits that.  The -l option displays supported Koji build types.

Also for the modularity and changelog inspections, when skipping due to the incorrect build type, leave an INFO result message explaining why.

Fixes: #798 