### PR TITLE
[ci] Run ldconfig as last command in post.sh on Slackware Linux

### DIFF
--- a/osdeps/slackware/post.sh
+++ b/osdeps/slackware/post.sh
@@ -91,3 +91,6 @@ autoreconf -f -i -v
 make
 make install
 cd "${CWD}" || exit 1
+
+# Update shared library cache
+ldconfig


### PR DESCRIPTION
We install libabigail and annobin, so the library cache needs updating.

Signed-off-by: David Cantrell <dcantrell@redhat.com>