### PR TITLE
Add the 'debuginfo' inspection and test cases

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -126,6 +126,7 @@ vendor:
     #changedfiles: off
     #changelog: off
     #config: off
+    #debuginfo: off
     #desktop: off
     #disttag: off
     #doc: off
@@ -1005,3 +1006,20 @@ upstream:
     # inspection.
     #ignore:
     #    - upstream-archive-name-*.tar.gz
+
+debuginfo:
+    # Optional list of glob(7) specifications or path prefixes to
+    # match files to ignore for this inspection.  The format of this
+    # list is the same as the global 'ignore' list.  The difference is
+    # the items specified here will only be used during this
+    # inspection.
+    ignore:
+        - /lib/modules/*
+        - /usr/lib/debug/.dwz/*
+        - /usr/lib/grub/*
+
+    # The ELF section name(s) required in debuginfo packages.  The
+    # default is shown here.  Some older releases may have to change
+    # this to .gdb_index, for instance.  This is a space-delimited
+    # string of section names.
+    debuginfo_sections: .gnu_debugdata

--- a/include/constants.h
+++ b/include/constants.h
@@ -774,7 +774,6 @@
  */
 #define RPMBUILD_BUILDDIR      "BUILD"
 
-
 /**
  * @def RPMBUILD_BUILDROOTDIR
  *
@@ -839,6 +838,49 @@
  * The value of the DT_RPATH or DT_RUNPATH $ORIGIN string.
  */
 #define RUNPATH_ORIGIN_STR "$ORIGIN"
+
+/** @} */
+
+/**
+ * @defgroup ELF section names used through the code.
+ *
+ * @{
+ */
+
+/**
+ * @def ELF_SYMTAB
+ *
+ * The '.symtab' ELF section.
+ */
+#define ELF_SYMTAB ".symtab"
+
+/**
+ * @def ELF_GDB_INDEX
+ *
+ * The '.gdb_index' ELF section.
+ */
+#define ELF_GDB_INDEX ".gdb_index"
+
+/**
+ * @def ELF_GNU_DEBUGDATA
+ *
+ * The '.gnu_debugdata' ELF section.
+ */
+#define ELF_GNU_DEBUGDATA ".gnu_debugdata"
+
+/**
+ * @def ELF_DEBUG_INFO
+ *
+ * The '.debug_info' ELF section.
+ */
+#define ELF_DEBUG_INFO ".debug_info"
+
+/**
+ * @def ELF_GOSYMTAB
+ *
+ * The '.gosymtab' ELF section.
+ */
+#define ELF_GOSYMTAB ".gosymtab"
 
 /** @} */
 

--- a/include/init.h
+++ b/include/init.h
@@ -36,6 +36,7 @@
 #define SECTION_COMMON                   "common"
 #define SECTION_CONFLICTS                "conflicts"
 #define SECTION_DEBUGINFO_PATH           "debuginfo_path"
+#define SECTION_DEBUGINFO_SECTIONS       "debuginfo_sections"
 #define SECTION_DESKTOP_ENTRY_FILES_DIR  "desktop_entry_files_dir"
 #define SECTION_DESKTOP_FILE_VALIDATE    "desktop-file-validate"
 #define SECTION_DOWNLOAD_MBS             "download_mbs"

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -715,6 +715,15 @@ bool inspect_unicode(struct rpminspect *ri);
  */
 bool inspect_rpmdeps(struct rpminspect *ri);
 
+/**
+ * @brief Main driver for the 'debuginfo' inspection.
+ *
+ *
+ * @param ri Pointer to the struct rpminspect for the program.
+ * @return True if the inspection passed, false otherwise.
+ */
+bool inspect_debuginfo(struct rpminspect *ri);
+
 /** @} */
 
 /**
@@ -1003,6 +1012,12 @@ bool inspect_rpmdeps(struct rpminspect *ri);
  */
 #define INSPECT_RPMDEPS                     (((uint64_t) 1) << 44)
 
+/**
+ * @def INSPECT_DEBUGINFO
+ * 'debuginfo' inspection ID.
+ */
+#define INSPECT_DEBUGINFO                   (((uint64_t) 1) << 45)
+
 /** @} */
 
 /**
@@ -1287,6 +1302,12 @@ bool inspect_rpmdeps(struct rpminspect *ri);
  */
 #define NAME_RPMDEPS                        "rpmdeps"
 
+/**
+ * @def NAME_DEBUGINFO
+ * The string "debuginfo"
+ */
+#define NAME_DEBUGINFO                      "debuginfo"
+
 /** @} */
 
 /**
@@ -1564,6 +1585,12 @@ bool inspect_rpmdeps(struct rpminspect *ri);
  * The description for the 'rpmdeps' inspection.
  */
 #define DESC_RPMDEPS _("Check for correct RPM dependency metadata.  Report incorrect or conflicting findings as well as expected changes when comparing a new build to an older build.  Changes are only reported when comparing builds, but this inspection will check for correct RPM dependency metadata when inspecting a single build and report findings.")
+
+/**
+ * @def DESC_DEBUGINFO
+ * The description for the 'debuginfo' inspection.
+ */
+#define DESC_DEBUGINFO _("Checks that files in RPM packages have their debugging symbols stripped and files in debuginfo packages carry debugging symbols.  When comparing builds, report where symbols unexpectedly appear or disappear and what corrective action is needed.")
 
 /** @} */
 

--- a/include/types.h
+++ b/include/types.h
@@ -662,6 +662,9 @@ struct rpminspect {
     /* RPM dependency ignores -- regexps to match requirements to ignore */
     deprule_ignore_map_t *deprules_ignore;
 
+    /* debuginfo ELF section name(s) when checking for debugging symbols */
+    char *debuginfo_sections;
+
     /* Options specified by the user */
     char *before;              /* before build ID arg given on cmdline */
     char *after;               /* after build ID arg given on cmdline */

--- a/lib/free.c
+++ b/lib/free.c
@@ -282,6 +282,7 @@ void free_rpminspect(struct rpminspect *ri)
     list_free(ri->unicode_excluded_mime_types, free);
     list_free(ri->unicode_forbidden_codepoints, free);
     free_deprule_ignore_map(ri->deprules_ignore);
+    free(ri->debuginfo_sections);
 
     free_peers(ri->peers);
 

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -92,6 +92,7 @@ struct inspect inspections[] = {
     { INSPECT_RUNPATH,       "runpath",       true,  &inspect_runpath },
     { INSPECT_UNICODE,       "unicode",       true,  &inspect_unicode },
     { INSPECT_RPMDEPS,       "rpmdeps",       true,  &inspect_rpmdeps },
+    { INSPECT_DEBUGINFO,     "debuginfo",     true,  &inspect_debuginfo },
     { 0, NULL, false, NULL }
 };
 
@@ -238,6 +239,8 @@ uint64_t inspection_id(const char *name)
         return INSPECT_UNICODE;
     } else if (!strcmp(name, NAME_RPMDEPS)) {
         return INSPECT_RPMDEPS;
+    } else if (!strcmp(name, NAME_DEBUGINFO)) {
+        return INSPECT_DEBUGINFO;
     } else {
         return INSPECT_NULL;
     }
@@ -341,6 +344,8 @@ const char *inspection_desc(const uint64_t inspection)
             return DESC_UNICODE;
         case INSPECT_RPMDEPS:
             return DESC_RPMDEPS;
+        case INSPECT_DEBUGINFO:
+            return DESC_DEBUGINFO;
         default:
             return NULL;
     }
@@ -443,6 +448,8 @@ const char *inspection_header_to_desc(const char *header)
         i = INSPECT_UNICODE;
     } else if (!strcmp(header, NAME_RPMDEPS)) {
         i = INSPECT_RPMDEPS;
+    } else if (!strcmp(header, NAME_DEBUGINFO)) {
+        i = INSPECT_DEBUGINFO;
     }
 
     return inspection_desc(i);

--- a/lib/inspect_debuginfo.c
+++ b/lib/inspect_debuginfo.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ * Author(s): David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <err.h>
+#include <dirent.h>
+#include <sys/types.h>
+#include "rpminspect.h"
+
+/* Flags used by the inspection */
+#define NEEDS_SYMTAB        (((uint64_t) 1) << 2)
+#define NEEDS_GDB_INDEX     (((uint64_t) 1) << 3)
+#define NEEDS_GNU_DEBUGDATA (((uint64_t) 1) << 4)
+#define NEEDS_DEBUG_INFO    (((uint64_t) 1) << 5)
+
+static uint64_t get_flags(const char *s)
+{
+    uint64_t r = 0;
+    string_list_t *sections = NULL;
+    string_entry_t *entry = NULL;
+
+    assert(s != NULL);
+
+    sections = strsplit(s, " \t");
+    assert(sections != NULL);
+
+    TAILQ_FOREACH(entry, sections, items) {
+        if (!strcasecmp(entry->data, ELF_SYMTAB)) {
+            r |= NEEDS_SYMTAB;
+        } else if (!strcasecmp(entry->data, ELF_GDB_INDEX)) {
+            r |= NEEDS_GDB_INDEX;
+        } else if (!strcasecmp(entry->data, ELF_GNU_DEBUGDATA)) {
+            r |= NEEDS_GNU_DEBUGDATA;
+        } else if (!strcasecmp(entry->data, ELF_DEBUG_INFO)) {
+            r |= NEEDS_DEBUG_INFO;
+        }
+    }
+
+    list_free(sections, free);
+    return r;
+}
+
+static uint64_t missing_sections(const char *fullpath, const uint64_t flags)
+{
+    uint64_t missing = 0;
+    int fd = 0;
+    Elf *elf = NULL;
+
+    assert(fullpath != NULL);
+
+    elf = get_elf(fullpath, &fd);
+    assert(elf != NULL);
+
+    if ((flags & NEEDS_SYMTAB) && !have_elf_section(elf, -1, ELF_SYMTAB)) {
+        missing |= NEEDS_SYMTAB;
+    }
+
+    if ((flags & NEEDS_GDB_INDEX) && !have_elf_section(elf, -1, ELF_GDB_INDEX)) {
+        missing |= NEEDS_GDB_INDEX;
+    }
+
+    if ((flags & NEEDS_GNU_DEBUGDATA) && !have_elf_section(elf, -1, ELF_GNU_DEBUGDATA)) {
+        missing |= NEEDS_GNU_DEBUGDATA;
+    }
+
+    if ((flags & NEEDS_DEBUG_INFO) && !have_elf_section(elf, -1, ELF_DEBUG_INFO)) {
+        missing |= NEEDS_DEBUG_INFO;
+    }
+
+    close(fd);
+    elf_end(elf);
+    return missing;
+}
+
+static char *strflags(const uint64_t flags)
+{
+    string_list_t *list = NULL;
+    char *r = NULL;
+
+    if (flags & NEEDS_SYMTAB) {
+        list = list_add(list, ELF_SYMTAB);
+    } else if (flags & NEEDS_GDB_INDEX) {
+        list = list_add(list, ELF_GDB_INDEX);
+    } else if (flags & NEEDS_GNU_DEBUGDATA) {
+        list = list_add(list, ELF_GNU_DEBUGDATA);
+    } else if (flags & NEEDS_DEBUG_INFO) {
+        list = list_add(list, ELF_DEBUG_INFO);
+    }
+
+    r = list_to_string(list, " ");
+    list_free(list, free);
+    return r;
+}
+
+static bool debuginfo_driver(struct rpminspect *ri, rpmfile_entry_t *file)
+{
+    bool result = true;
+    const char *arch = NULL;
+    const char *name = NULL;
+    char *nvr = NULL;
+    char *tmp = NULL;
+    bool debugpkg = false;
+    uint64_t flags = 0;
+    uint64_t missing = 0;
+    int fd = 0;
+    Elf *elf = NULL;
+    struct result_params params;
+
+    assert(ri != NULL);
+    assert(file != NULL);
+
+    /* skip source packages */
+    if (headerIsSource(file->rpm_header)) {
+        return true;
+    }
+
+    /* Only deal with ELF shared libraries or executables */
+    if (!is_elf_shared_library(file->fullpath) && !is_elf_executable(file->fullpath)) {
+        return true;
+    }
+
+    if (file->peer_file) {
+        if (!is_elf_shared_library(file->peer_file->fullpath) && !is_elf_executable(file->peer_file->fullpath)) {
+            return true;
+        }
+    }
+
+    /* the package nvr and arch is used for reporting */
+    name = headerGetString(file->rpm_header, RPMTAG_NAME);
+    nvr = get_nevr(file->rpm_header);
+    arch = get_rpm_header_arch(file->rpm_header);
+
+    /* debuginfo and debugsource packages have special handling */
+    if (strsuffix(name, DEBUGINFO_SUFFIX) || strsuffix(name, DEBUGSOURCE_SUFFIX)) {
+        debugpkg = true;
+    }
+
+    /* set the sections to check for */
+    if (debugpkg) {
+        /* debugging packages need debugging symbols */
+        flags |= NEEDS_SYMTAB;
+        flags |= NEEDS_DEBUG_INFO;
+    } else {
+        /* default section (set in config file usually) */
+        flags = get_flags(ri->debuginfo_sections);
+    }
+
+    /* Golang packages should not have .gnu_debugdata */
+    elf = get_elf(file->fullpath, &fd);
+    assert(elf != NULL);
+
+    if (have_elf_section(elf, -1, ELF_GOSYMTAB)) {
+        flags &= ~NEEDS_GNU_DEBUGDATA;
+    }
+
+    elf_end(elf);
+    close(fd);
+
+    /* Initialize the result parameters */
+    init_result_params(&params);
+    params.header = NAME_DEBUGINFO;
+
+    /* Check for and report missing sections for single builds */
+    missing = missing_sections(file->fullpath, flags);
+
+    if (missing) {
+        xasprintf(&params.msg, _("%s in %s on %s is missing ELF sections "), file->localpath, nvr, arch);
+        params.severity = RESULT_BAD;
+        params.waiverauth = WAIVABLE_BY_ANYONE;
+        params.verb = VERB_FAILED;
+        params.noun = _("missing debugging symbols");
+        params.file = file->localpath;
+        params.arch = arch;
+
+        tmp = strflags(missing);
+        xasprintf(&params.details, _("Missing: %s"), tmp);
+        free(tmp);
+
+        add_result(ri, &params);
+
+        free(params.msg);
+        free(params.details);
+    }
+
+    /* When comparing builds, report changes */
+    if (file->peer_file) {
+        /* stripped in the before file but not the after file */
+        missing = missing_sections(file->peer_file->fullpath, flags);
+
+        if (missing && !missing_sections(file->fullpath, flags)) {
+            xasprintf(&params.msg, _("%s in %s on %s is no longer stripped"), file->localpath, nvr, arch);
+            params.verb = VERB_FAILED;
+            params.noun = _("need debugging symbols");
+            params.file = file->localpath;
+            params.arch = arch;
+
+            tmp = strflags(missing);
+            xasprintf(&params.details, _("Need: %s"), tmp);
+            free(tmp);
+
+            if (debugpkg) {
+                params.severity = RESULT_INFO;
+                params.waiverauth = NOT_WAIVABLE;
+            } else {
+                params.severity = RESULT_BAD;
+                params.waiverauth = WAIVABLE_BY_ANYONE;
+            }
+
+            add_result(ri, &params);
+
+            free(params.msg);
+            free(params.details);
+        }
+
+        /* not stripped in the before file, stripped in the after file */
+        missing = missing_sections(file->fullpath, flags);
+
+        if (!missing_sections(file->peer_file->fullpath, flags) && missing) {
+            xasprintf(&params.msg, _("%s in %s on %s became stripped"), file->localpath, nvr, arch);
+            params.verb = VERB_FAILED;
+            params.noun = _("lost debugging symbols");
+            params.file = file->localpath;
+            params.arch = arch;
+
+            tmp = strflags(missing);
+            xasprintf(&params.details, _("Lost: %s"), tmp);
+            free(tmp);
+
+            if (debugpkg) {
+                params.severity = RESULT_BAD;
+                params.waiverauth = WAIVABLE_BY_ANYONE;
+            } else {
+                params.severity = RESULT_INFO;
+                params.waiverauth = NOT_WAIVABLE;
+            }
+
+            add_result(ri, &params);
+
+            free(params.msg);
+            free(params.details);
+        }
+    }
+
+    free(nvr);
+    return result;
+}
+
+bool inspect_debuginfo(struct rpminspect *ri)
+{
+    bool result = false;
+    struct result_params params;
+
+    assert(ri != NULL);
+
+    result = foreach_peer_file(ri, NAME_DEBUGINFO, debuginfo_driver);
+
+    if (result) {
+        init_result_params(&params);
+        params.severity = RESULT_OK;
+        params.waiverauth = NOT_WAIVABLE;
+        params.header = NAME_DEBUGINFO;
+        params.verb = VERB_OK;
+        params.noun = NULL;
+        params.file = NULL;
+        params.arch = NULL;
+        add_result(ri, &params);
+    }
+
+    return result;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -43,6 +43,7 @@ librpminspect_sources = [
     'inspect_changedfiles.c',
     'inspect_changelog.c',
     'inspect_config.c',
+    'inspect_debuginfo.c',
     'inspect_desktop.c',
     'inspect_disttag.c',
     'inspect_doc.c',

--- a/test/meson.build
+++ b/test/meson.build
@@ -125,6 +125,7 @@ if python.found()
         'test_command.py',
         'test_config.py',
         'test_default.py',
+        'test_debuginfo.py',
         'test_desktop.py',
         'test_disttag.py',
         'test_doc.py',

--- a/test/test_debuginfo.py
+++ b/test/test_debuginfo.py
@@ -1,0 +1,276 @@
+#
+# Copyright 2022 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from baseclass import (
+    TestSRPM,
+    TestCompareSRPM,
+    TestRPMs,
+    TestKoji,
+    TestCompareRPMs,
+    TestCompareKoji,
+)
+
+
+debuginfo_remove = "\n%define _find_debuginfo_opts "
+debuginfo_remove += '"--remove-section .symtab '
+debuginfo_remove += '--remove-section .debug_info"\n'
+
+debuginfo_keep = "\n%define _find_debuginfo_opts "
+debuginfo_keep += '"--keep-section .symtab '
+debuginfo_keep += "--keep-section .debug_info "
+debuginfo_keep += '--keep-section .gnu_debugdata"\n'
+
+
+# Missing sections in the debuginfo package (BAD, except for SRPMs)
+class MissingSectionsInDebuginfoPkgSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += debuginfo_remove
+        self.rpm.add_simple_compilation(compileFlags="-g")
+
+        # this inspection is a no-op on SRPMs
+        self.inspection = "debuginfo"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
+
+
+class MissingSectionsInDebuginfoPkgCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += debuginfo_remove
+        self.before_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.after_rpm.header += debuginfo_remove
+        self.after_rpm.add_simple_compilation(compileFlags="-g")
+
+        # this inspection is a no-op on SRPMs
+        self.inspection = "debuginfo"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
+
+
+class MissingSectionsInDebuginfoPkgRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += debuginfo_remove
+        self.rpm.add_simple_compilation(compileFlags="-g")
+
+        self.inspection = "debuginfo"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+class MissingSectionsInDebuginfoPkgCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += debuginfo_remove
+        self.before_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.after_rpm.header += debuginfo_remove
+        self.after_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.inspection = "debuginfo"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+class MissingSectionsInDebuginfoPkgKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += debuginfo_remove
+        self.rpm.add_simple_compilation(compileFlags="-g")
+
+        self.inspection = "debuginfo"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+class MissingSectionsInDebuginfoPkgCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += debuginfo_remove
+        self.before_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.after_rpm.header += debuginfo_remove
+        self.after_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.inspection = "debuginfo"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+# Has debugging sections in the main package (BAD, except for SRPMs)
+class HaveDebuggingSectionsInRegularPkgSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += debuginfo_keep
+        self.rpm.add_simple_compilation(compileFlags="-g")
+
+        # this inspection is a no-op on SRPMs
+        self.inspection = "debuginfo"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
+
+
+class HaveDebuggingSectionsInRegularPkgCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += debuginfo_keep
+        self.before_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.after_rpm.header += debuginfo_keep
+        self.after_rpm.add_simple_compilation(compileFlags="-g")
+
+        # this inspection is a no-op on SRPMs
+        self.inspection = "debuginfo"
+        self.result = "OK"
+        self.waiver_auth = "Not Waivable"
+
+
+class HaveDebuggingSectionsInRegularPkgRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += debuginfo_keep
+        self.rpm.add_simple_compilation(compileFlags="-g")
+
+        self.inspection = "debuginfo"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+class HaveDebuggingSectionsInRegularPkgCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += debuginfo_keep
+        self.before_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.after_rpm.header += debuginfo_keep
+        self.after_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.inspection = "debuginfo"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+class HaveDebuggingSectionsInRegularPkgKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.header += debuginfo_keep
+        self.rpm.add_simple_compilation(compileFlags="-g")
+
+        self.inspection = "debuginfo"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+class HaveDebuggingSectionsInRegularPkgCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.header += debuginfo_keep
+        self.before_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.after_rpm.header += debuginfo_keep
+        self.after_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.inspection = "debuginfo"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+# Before build is stripped but now not stripped in the after build
+class BeforeStrippedAfterNotStrippedCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.after_rpm.header += debuginfo_keep
+        self.after_rpm.add_simple_compilation(compileFlags="-g")
+
+        self.inspection = "debuginfo"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+# XXX: need to figure out find_debuginfo_opts more
+# class BeforeStrippedAfterNotStrippedDebugInfoCompareKoji(TestCompareKoji):
+#    def setUp(self):
+#        super().setUp()
+#
+#        self.extra_cfg = {}
+#        self.extra_cfg["debuginfo"] = {}
+#        self.extra_cfg["debuginfo"]["debuginfo_sections"] = ".debug_info"
+#
+#        self.before_rpm.header += debuginfo_remove
+#        self.before_rpm.add_simple_compilation(compileFlags="")
+#
+#        self.after_rpm.add_simple_compilation(compileFlags="-g")
+#
+#        self.inspection = "debuginfo"
+#        self.result = "INFO"
+#        self.waiver_auth = "Not Waivable"
+
+
+# XXX:
+# Before build is not stripped, but the after build is
+# class BeforeNotStrippedAfterStrippedCompareKoji(TestCompareKoji):
+#    def setUp(self):
+#        super().setUp()
+#
+#        self.extra_cfg = {}
+#        self.extra_cfg["debuginfo"] = {}
+#        self.extra_cfg["debuginfo"]["debuginfo_sections"] = ".debug_info"
+#
+#        self.after_rpm.header += debuginfo_keep
+#        self.before_rpm.add_simple_compilation(compileFlags="-g")
+#
+#        self.after_rpm.add_simple_compilation(compileFlags="-g")
+#
+#        self.inspection = "debuginfo"
+#        self.result = "INFO"
+#        self.waiver_auth = "Not Waivable"
+
+# XXX:
+# class BeforeNotStrippedAfterStrippedCompareKoji(TestCompareKoji):
+#    def setUp(self):
+#        super().setUp()
+#
+#        self.extra_cfg = {}
+#        self.extra_cfg["debuginfo"] = {}
+#        self.extra_cfg["debuginfo"]["debuginfo_sections"] = ".debug_info"
+#
+#        self.after_rpm.header += debuginfo_keep
+#        self.before_rpm.add_simple_compilation(compileFlags="-g")
+#
+#        self.after_rpm.add_simple_compilation(compileFlags="-g")
+#
+#        self.inspection = "debuginfo"
+#        self.result = "BAD"
+#        self.waiver_auth = "Anyone"


### PR DESCRIPTION
In rpminspect's ancestor, this was called the "stripped" inspection.  It ensures built packages have debugging symbols stripped and debugdata sections linking them to the corresponding debuginfo packages.  It also ensures debuginfo packages carry debugging symbols.