### PR TITLE
[tst] Support KEEP=y when running 'make check'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ setup:
 # The environment variable is easier.
 export QA_RPATHS = 63
 
+# To keep intermediate files and results files for each test case, set
+# KEEP=y (or to any value) in the calling environment when you run
+# 'make check'.  For example: make check KEEP=y
 check: setup
 	@test_name="$(call TARGET_ARG,)" ; \
 	if [ -z "$${test_name}" ]; then \

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -40,9 +40,13 @@ AFTER_REL = "2"
 # Test suite Vendor name
 VENDOR = "rpminspect Test Vendor Ltd."
 
-# Set this to True to keep rpminspect results (useful to debug the test
-# suite but will make a big mess)
-KEEP_RESULTS = False
+# Run the test suite with KEEP=y (or set to anything) in the
+# environment to instruct the test suite to keep intermediate files
+# and results.
+if os.getenv("KEEP") is None:
+    KEEP_RESULTS = False
+else:
+    KEEP_RESULTS = True
 
 
 # Exceptions used by the test suite


### PR DESCRIPTION
To retain intermediate and results files when debugging test cases, support running "make check KEEP=y" to keep those files.  Normally these are removed after each test case is run.

Signed-off-by: David Cantrell <dcantrell@redhat.com>