### PR TITLE
[fix]: remove leading dot from product release in javabytecode inspection

### DIFF
--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -249,8 +249,11 @@ bool inspect_javabytecode(struct rpminspect *ri)
         return false;
     }
 
-    /* look up the JVM major version; fall back on default if not found */
-    HASH_FIND_STR(ri->jvm, ri->product_release, hentry);
+    /*
+     * Look up the JVM major version; fall back on default if not found.
+     * From the product_release is trimmed the leading '.'.
+     */
+    HASH_FIND_STR(ri->jvm, ri->product_release+1, hentry);
 
     if (hentry == NULL) {
         HASH_FIND_STR(ri->jvm, "default", hentry);


### PR DESCRIPTION
The product_release is obtained from dist tag in the rpm's NVR. It contains leading dot. In javabytecode inspection is the dot not needed.

Please feel free to close this, if there exists more appropriate fix or if current behavior is correct and does not need fixing.