### PR TITLE
[cmd] Trim the leading period from the product_release string

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -160,7 +160,13 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
 
     assert(after != NULL);
 
+    /* skip up to the dist tag */
     while (*after != '.' && *after != '\0') {
+        after++;
+    }
+
+    /* trim the leading period */
+    while (*after == '.' && *after != '\0') {
         after++;
     }
 
@@ -187,7 +193,13 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
     after_candidate[strcspn(after_candidate, "/")] = 0;
 
     if (before) {
+        /* skip up to the dist tag */
         while (*before != '.' && *before != '\0') {
+            before++;
+        }
+
+        /* trim the leading period */
+        while (*before == '.' && *before != '\0') {
             before++;
         }
 


### PR DESCRIPTION
The product release string is based on the concept of "dist tags" seen in Fedora-derived distributions.  When matching it, rpminspect starts with the RPMTAG_RELEASE value and captures the part of the string starting with a period since this is typically where the dist tag begins.  However, it should not save the period as ri->product_release.  The product_release value is used throughout librpminspect when determining per-product rules from the vendor data.

Signed-off-by: David Cantrell <dcantrell@redhat.com>