### PR TITLE
[lib] Get list of %*auto* macros from the config file in 'patches'

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -747,6 +747,16 @@ kmidiff:
     #    - /usr/lib*/libexample.so*
 
 patches:
+    # List of spec file macros that handle automatic patching.  If one
+    # of these is found, rpminspect will not report defined patches
+    # missing corresponding %patch macros.  NOTE: Do not list the
+    # macros here with '%' prefixes or braces ('{' or '}').  Just list
+    # their names.
+    automacros:
+        - autopatch
+        - autosetup
+        - forgeautosetup
+
     # List of patch files to ignore in the 'patches' inspection.
     # These should match the name as specified on a PatchN: line in
     # the spec file.

--- a/include/constants.h
+++ b/include/constants.h
@@ -644,21 +644,6 @@
 #define SPEC_MACRO_GLOBAL      "%global"
 
 /**
- * @def SPEC_MACRO_AUTOPATCH
- *
- * The %autopatch macro used to apply all defined Patches.
- */
-#define SPEC_MACRO_AUTOPATCH   "%autopatch"
-
-/**
- * @def SPEC_MACRO_AUTOSETUP
- *
- * The %autosetup macro used to unpack all Sources and apply all
- * defined Patches.
- */
-#define SPEC_MACRO_AUTOSETUP   "%autosetup"
-
-/**
  * @def SPEC_MACRO_PATCH
  *
  * The %patchN macro used to apply patches.  N corresponds to the

--- a/include/init.h
+++ b/include/init.h
@@ -27,6 +27,7 @@
 #define SECTION_ALLOWED_ORIGIN_PATHS     "allowed_origin_paths"
 #define SECTION_ALLOWED_PATHS            "allowed_paths"
 #define SECTION_ANNOCHECK                "annocheck"
+#define SECTION_AUTOMACROS               "automacros"
 #define SECTION_BADWORDS                 "badwords"
 #define SECTION_BIN_GROUP                "bin_group"
 #define SECTION_BIN_OWNER                "bin_owner"

--- a/include/types.h
+++ b/include/types.h
@@ -524,6 +524,11 @@ struct rpminspect {
     string_list_t *forbidden_directories;
 
     /*
+     * Optional: List of auto macros that handle patch setup.
+     */
+    string_list_t *automacros;
+
+    /*
      * Optional: if not NULL, contains a list of forbidden function
      * names.
      */

--- a/lib/free.c
+++ b/lib/free.c
@@ -222,6 +222,7 @@ void free_rpminspect(struct rpminspect *ri)
 
     free(ri->elf_path_include_pattern);
     free(ri->elf_path_exclude_pattern);
+    list_free(ri->automacros, free);
     list_free(ri->bad_functions, free);
     free_string_list_map(ri->bad_functions_allowed);
     free(ri->manpage_path_include_pattern);

--- a/lib/init.c
+++ b/lib/init.c
@@ -150,7 +150,8 @@ enum {
     BLOCK_VIRUS = 71,
     BLOCK_ENVIRONMENT = 72,
     BLOCK_LICENSEDB = 73,
-    BLOCK_DEBUGINFO = 74
+    BLOCK_DEBUGINFO = 74,
+    BLOCK_PATCH_AUTOMACROS = 75
 };
 
 static int add_regex(const char *pattern, regex_t **regex_out)
@@ -951,6 +952,8 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     } else if (group == BLOCK_PATCHES) {
                         if (!strcmp(key, SECTION_IGNORE_LIST)) {
                             block = BLOCK_PATCH_FILENAMES;
+                        } else if (!strcmp(key, SECTION_AUTOMACROS)) {
+                            block = BLOCK_PATCH_AUTOMACROS;
                         }
                     } else if (group == BLOCK_RUNPATH) {
                         if (!strcmp(key, SECTION_ALLOWED_PATHS)) {
@@ -1452,6 +1455,8 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         add_entry(&ri->kernel_filenames, t);
                     } else if (block == BLOCK_PATCH_FILENAMES) {
                         add_entry(&ri->patch_ignore_list, t);
+                    } else if (block == BLOCK_PATCH_AUTOMACROS) {
+                        add_entry(&ri->automacros, t);
                     } else if (group == BLOCK_PATHMIGRATION_EXCLUDED_PATHS) {
                         add_entry(&ri->pathmigration_excluded_paths, t);
                     } else if (block == BLOCK_RUNPATH_ALLOWED_PATHS) {


### PR DESCRIPTION
The patches inspection looks for any defined Patch files that do not have a corresponding %patch macro.  It reports any missing a %patch macro as an error, unless it finds an auto patching macro.  Until this patch, that was just %autosetup or %autopatch.  But since auto patching macros can be defined at runtime in rpm macro files, move the list of auto patching macros to check for to the config file.

The config file section now adds an "automacros" list under the "patches" section.  Like this:

    patches:
        # List of spec file macros that handle automatic patching.  If
        # one of these is found, rpminspect will not report defined
        # patches missing corresponding %patch macros.  NOTE: Do not
        # list the macros here with '%' prefixes or braces ('{' or
        # '}').  Just list their names.
        automacros:
            - autopatch
            - autosetup
            - forgeautosetup

Now, when a new auto patching macro is created, only the vendor data package and rpminspect config file need to change rather than the rpminspect code.

Fixes: #921

Signed-off-by: David Cantrell <dcantrell@redhat.com>