### PR TITLE
[lib] Change how RPMs are unpacked when peering happens

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -135,6 +135,29 @@
 #define DEFAULT_WORKDIR "/var/tmp/rpminspect"
 
 /**
+ * @def ROOT_SUBDIR
+ *
+ * The name of the root subdirectory used in the working directory.
+ * This is where packages are extracted as a simulated root
+ * filesystem.
+ */
+#define ROOT_SUBDIR "root"
+
+/**
+ * @def BEFORE_SUBDIR
+ *
+ * The name of the before build subdirectory in the working directory.
+ */
+#define BEFORE_SUBDIR "before"
+
+/**
+ * @def AFTER_SUBDIR
+ *
+ * The name of the after build subdirectory in the working directory.
+ */
+#define AFTER_SUBDIR "after"
+
+/**
  * @def VENDOR_DATA_DIR
  *
  * Default location for the vendor-specific data.  These files should

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -269,10 +269,10 @@ int extract_peers(struct rpminspect *ri, bool fetchonly);
 
 /* files.c */
 void free_files(rpmfile_t *files);
-rpmfile_t * extract_rpm(const char *, Header, char **output_dir);
-bool process_file_path(const rpmfile_entry_t *, regex_t *, regex_t *);
-void find_file_peers(rpmfile_t *, rpmfile_t *);
-bool is_debug_or_build_path(const char *);
+rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const char *subdir, char **output_dir);
+bool process_file_path(const rpmfile_entry_t *file, regex_t *include_regex, regex_t *exclude_regex);
+void find_file_peers(rpmfile_t *before, rpmfile_t *after);
+bool is_debug_or_build_path(const char *path);
 
 /* tty.c */
 size_t tty_width(void);

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -203,12 +203,12 @@ int extract_peers(struct rpminspect *ri, bool fetchonly)
     TAILQ_FOREACH(peer, ri->peers, items) {
         /* extract the before peer */
         if (peer->before_hdr && peer->before_rpm) {
-            peer->before_files = extract_rpm(peer->before_rpm, peer->before_hdr, &peer->before_root);
+            peer->before_files = extract_rpm(ri, peer->before_rpm, peer->before_hdr, BEFORE_SUBDIR, &peer->before_root);
         }
 
         /* extract the after peer */
         if (peer->after_hdr && peer->after_rpm) {
-            peer->after_files = extract_rpm(peer->after_rpm, peer->after_hdr, &peer->after_root);
+            peer->after_files = extract_rpm(ri, peer->after_rpm, peer->after_hdr, AFTER_SUBDIR, &peer->after_root);
         }
 
         /* match up file peers between builds */


### PR DESCRIPTION
Previously rpminspect would unpack each RPM in to its own subdirectory.  Lots of inspections need to examine the files inside an RPM, so this seemed like a reasonable way to do that.  However, some inspections need a view of the entire built package installed.  Things like abidiff want to see the debuginfo and libraries and headers. Depending on what the packager did, those files may all be in one package or multiple subpackages.  To make this easier for inspections that need to see all files extracted, rpminspect now extracts all RPMs for each build to the same root tree (technically one per architecture with src and noarch separated out).  rpminspect still has all of the RPM header information and knows what subpackage a file belongs to, so this is just an on-disk representation to make things easier for different inspections.

Signed-off-by: David Cantrell <dcantrell@redhat.com>