### PR TITLE
[doc] Adjust git.md category description for cmd

### DIFF
--- a/doc/git.md
+++ b/doc/git.md
@@ -21,7 +21,7 @@ To categorize commits and make release log generation easier, please use categor
 | [fix]  | General bug fix in the library or frontend program |
 | [lib]  | librpminspect feature or significant change |
 | [new]  | New inspections or inspection changes (not bug fixes) |
-| [cmd]  | rpminspect(1) changes |
+| [cmd]  | rpminspect(1) changes or improvements related to it |
 | [cfg]  | Config file or data/ file changes |
 | [ci]   | Changes to the GitHub Actions CI scripts and files |
 | [doc]  | Documentation changes |


### PR DESCRIPTION
The commit prefixes which I rely on to autogenerate release information and changes files.

Signed-off-by: David Cantrell <dcantrell@redhat.com>