### PR TITLE
[tst] Sync up Copyright lines with format used in lib and src

### DIFF
--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_abidiff.py
+++ b/test/test_abidiff.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_addedfiles.py
+++ b/test/test_addedfiles.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_annocheck.py
+++ b/test/test_annocheck.py
@@ -1,4 +1,5 @@
-# Copyright © 2022 Red Hat, Inc.
+#
+# Copyright 2022 Red Hat, Inc.
 # Author(s): Zuzana Miklankova <zmiklank@redhat.com>
 #            David Cantrell <dcantrell@redhat.com>
 #

--- a/test/test_badfuncs.py
+++ b/test/test_badfuncs.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_capabilities.py
+++ b/test/test_capabilities.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_changedfiles.py
+++ b/test/test_changedfiles.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_default.py
+++ b/test/test_default.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_desktop.py
+++ b/test/test_desktop.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_elf.py
+++ b/test/test_elf.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_emptyrpm.py
+++ b/test/test_emptyrpm.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_filesize.py
+++ b/test/test_filesize.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): Jeremy Cline <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_kmod.py
+++ b/test/test_kmod.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_lostpayload.py
+++ b/test/test_lostpayload.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_lto.py
+++ b/test/test_lto.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_manpage.py
+++ b/test/test_manpage.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_ownership.py
+++ b/test/test_ownership.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #            Jim Bair <jbair@redhat.com>
 #

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_pathmigration.py
+++ b/test/test_pathmigration.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_politics.py
+++ b/test/test_politics.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_removedfiles.py
+++ b/test/test_removedfiles.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2022 Red Hat, Inc.
+# Copyright 2022 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #            Preston Watson <prwatson@redhat.com>
 #

--- a/test/test_rpmdeps_conflicts.py
+++ b/test/test_rpmdeps_conflicts.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_rpmdeps_enhances.py
+++ b/test/test_rpmdeps_enhances.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_rpmdeps_obsoletes.py
+++ b/test/test_rpmdeps_obsoletes.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_rpmdeps_provides.py
+++ b/test/test_rpmdeps_provides.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_rpmdeps_recommends.py
+++ b/test/test_rpmdeps_recommends.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_rpmdeps_requires.py
+++ b/test/test_rpmdeps_requires.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_rpmdeps_suggests.py
+++ b/test/test_rpmdeps_suggests.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_rpmdeps_supplements.py
+++ b/test/test_rpmdeps_supplements.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_runpath.py
+++ b/test/test_runpath.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_securitypath.py
+++ b/test/test_securitypath.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_shellsyntax.py
+++ b/test/test_shellsyntax.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_specname.py
+++ b/test/test_specname.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_symlinks.py
+++ b/test/test_symlinks.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_unicode.py
+++ b/test/test_unicode.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 Red Hat, Inc.
+# Copyright 2021 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_virus.py
+++ b/test/test_virus.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #
 # This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Strike the copyright symbol (a circled capital letter C) and just use the word Copyright.  The symbol is Unicode character U+00A9 and occassionally I would hear from people asking why there's a question mark after Copyright because they would be using a non-Unicode capable text editor or some other environment improperly configured for Unicode.  Because of this, I removed the symbol from the lib and src files, but forgot test.  Copyright statements do not need to actually use the symbol.  You can use the symbol, "Copyright", or "Copr.". This is from US Copyright Law.  While the enclosed C is still used all over the place, it is not generally required under the Berne Convention.  Also, ownership of a work is implied unless explicitly disclaimed anyway and lawyers have all sorts of fun figured out ownership of things.

SO...to make the copyright notices in this project simple, the format of "Copyright YEAR" will be used.  Note that "year ranges" are not really a thing either.  You set the year and then that's it.  Do not use year ranges in these files.

Signed-off-by: David Cantrell <dcantrell@redhat.com>