### PR TITLE
[lib] Modify the result reporting functions so waiverauth is optional

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -216,11 +216,11 @@ typedef TAILQ_HEAD(rpmpeer_s, _rpmpeer_entry_t) rpmpeer_t;
 typedef enum _severity_t {
     RESULT_NULL   = 0,      /* used to indicate internal error */
     RESULT_DIAG   = 1,      /* only used by the 'diagnostics' inspection */
-    RESULT_OK     = 2,
-    RESULT_INFO   = 3,
-    RESULT_VERIFY = 4,
-    RESULT_BAD    = 5,
-    RESULT_SKIP   = 6
+    RESULT_SKIP   = 2,
+    RESULT_OK     = 3,
+    RESULT_INFO   = 4,
+    RESULT_VERIFY = 5,
+    RESULT_BAD    = 6
 } severity_t;
 
 typedef enum _waiverauth_t {

--- a/lib/output_json.c
+++ b/lib/output_json.c
@@ -76,7 +76,10 @@ void output_json(const results_t *results, const char *dest, __attribute__((unus
         /* create the object for this result */
         jr = json_object_new_object();
         json_object_object_add(jr, "result", json_object_new_string(strseverity(result->severity)));
-        json_object_object_add(jr, "waiver authorization", json_object_new_string(strwaiverauth(result->waiverauth)));
+
+        if (result->waiverauth > NULL_WAIVERAUTH) {
+            json_object_object_add(jr, "waiver authorization", json_object_new_string(strwaiverauth(result->waiverauth)));
+        }
 
         if (result->msg != NULL) {
             json_object_object_add(jr, "message", json_object_new_string(result->msg));

--- a/lib/output_text.c
+++ b/lib/output_text.c
@@ -107,7 +107,9 @@ void output_text(const results_t *results, const char *dest, __attribute__((unus
 
             fprintf(fp, _("Result: %s\n"), strseverity(result->severity));
 
-            fprintf(fp, _("Waiver Authorization: %s\n\n"), strwaiverauth(result->waiverauth));
+            if (result->waiverauth > NULL_WAIVERAUTH) {
+                fprintf(fp, _("Waiver Authorization: %s\n\n"), strwaiverauth(result->waiverauth));
+            }
 
             if (result->details != NULL) {
                 fprintf(fp, _("Details:\n%s\n\n"), result->details);

--- a/lib/output_xunit.c
+++ b/lib/output_xunit.c
@@ -96,7 +96,7 @@ void output_xunit(const results_t *results, const char *dest, const severity_t t
             assert(msg != NULL);
         }
 
-        xasprintf(&rawcdata, _("Result: %s\nWaiver Authorization: %s\n\n"), strseverity(result->severity), strwaiverauth(result->waiverauth));
+        xasprintf(&rawcdata, _("Result: %s\n"), strseverity(result->severity));
         assert(rawcdata != NULL);
 
         if (msg) {
@@ -107,6 +107,20 @@ void output_xunit(const results_t *results, const char *dest, const severity_t t
 
         assert(msg != NULL);
         free(rawcdata);
+
+        if (result->waiverauth > NULL_WAIVERAUTH) {
+            xasprintf(&rawcdata, _("Waiver Authorization: %s\n\n"), strwaiverauth(result->waiverauth));
+            assert(rawcdata != NULL);
+
+            if (msg) {
+                msg = strappend(msg, rawcdata, NULL);
+            } else {
+                msg = strdup(rawcdata);
+            }
+
+            assert(msg != NULL);
+            free(rawcdata);
+        }
 
         if (result->details != NULL) {
             xasprintf(&rawcdata, _("Details:\n%s\n\n"), result->details);


### PR DESCRIPTION
waiverauth is technically optional.  I mean, it shouldn't even exist in the first place, but that's a discussion for another day.  In cases where an inspection is skipped or is otherwise OK, there's actually nothing to waive.  Not Waivable is not wrong, but also not correct. In these cases I just don't want it to show anything.  So modify the results reporting function to not assume waiverauth is actually set to anything.

Signed-off-by: David Cantrell <dcantrell@redhat.com>