### PR TITLE
Show skipped inspections in verbose mode and results

### DIFF
--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -278,7 +278,6 @@ bool inspect_abidiff(struct rpminspect *ri)
     /* report the inspection results */
     if (result) {
         init_result_params(&params);
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_ABIDIFF;
         params.severity = RESULT_OK;
         params.verb = VERB_OK;

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -280,7 +280,6 @@ bool inspect_addedfiles(struct rpminspect *ri)
     if (result && !reported) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_ADDEDFILES;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -264,7 +264,6 @@ bool inspect_annocheck(struct rpminspect *ri)
     if (result && !reported) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_ANNOCHECK;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -232,7 +232,6 @@ bool inspect_badfuncs(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_BADFUNCS;
         add_result(ri, &params);
     }

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -201,7 +201,6 @@ bool inspect_capabilities(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_CAPABILITIES;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -489,7 +489,6 @@ bool inspect_changedfiles(struct rpminspect *ri)
     if (result && !reported) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_CHANGEDFILES;
         add_result(ri, &params);
     }

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -489,7 +489,6 @@ bool inspect_changelog(struct rpminspect *ri)
         if (params.severity == RESULT_OK) {
             init_result_params(&params);
             params.severity = RESULT_OK;
-            params.waiverauth = NOT_WAIVABLE;
             params.header = NAME_CHANGELOG;
             add_result(ri, &params);
         }

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -207,7 +207,6 @@ bool inspect_config(struct rpminspect *ri)
     if (result && !reported) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_CONFIG;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_debuginfo.c
+++ b/lib/inspect_debuginfo.c
@@ -277,12 +277,8 @@ bool inspect_debuginfo(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_DEBUGINFO;
         params.verb = VERB_OK;
-        params.noun = NULL;
-        params.file = NULL;
-        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -508,7 +508,6 @@ bool inspect_desktop(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_DESKTOP;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -263,7 +263,6 @@ bool inspect_disttag(struct rpminspect *ri)
 
     /* Set up result parameters */
     init_result_params(&params);
-    params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_DISTTAG;
     params.verb = VERB_OK;
 
@@ -273,6 +272,7 @@ bool inspect_disttag(struct rpminspect *ri)
         add_result(ri, &params);
     } else if (!src) {
         params.severity = RESULT_INFO;
+        params.waiverauth = NOT_WAIVABLE;
         params.msg = _("Specified package is not a source RPM, skipping.");
         add_result(ri, &params);
     }

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -152,7 +152,6 @@ bool inspect_doc(struct rpminspect *ri)
     if (result && !reported) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_DOC;
         add_result(ri, &params);
     }

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -228,7 +228,6 @@ bool inspect_dsodeps(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_DSODEPS;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -920,7 +920,6 @@ bool inspect_elf(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_ELF;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -147,12 +147,10 @@ bool inspect_emptyrpm(struct rpminspect *ri)
     }
 
     if (good & !reported) {
+        init_result_params(&params);
+        params.header = NAME_EMPTYRPM;
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.verb = VERB_OK;
-        params.noun = NULL;
-        params.file = NULL;
-        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_files.c
+++ b/lib/inspect_files.c
@@ -176,7 +176,6 @@ bool inspect_files(struct rpminspect *ri)
     }
 
     init_result_params(&params);
-    params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_FILES;
     params.verb = VERB_OK;
 
@@ -185,6 +184,7 @@ bool inspect_files(struct rpminspect *ri)
         add_result(ri, &params);
     } else if (!src) {
         params.severity = RESULT_INFO;
+        params.waiverauth = NOT_WAIVABLE;
         xasprintf(&params.msg, _("The files inspection is only for source packages, skipping."));
         add_result(ri, &params);
         free(params.msg);

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -157,7 +157,6 @@ bool inspect_filesize(struct rpminspect *ri)
     if (result && !reported) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_FILESIZE;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -295,7 +295,6 @@ bool inspect_javabytecode(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_JAVABYTECODE;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -367,7 +367,6 @@ bool inspect_kmidiff(struct rpminspect *ri)
     /* report the inspection results */
     if (result) {
         init_result_params(&params);
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_KMIDIFF;
         params.severity = RESULT_OK;
         params.verb = VERB_OK;

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -312,7 +312,6 @@ bool inspect_kmod(struct rpminspect *ri)
     /* if everything was fine, just say so */
     if (result && !reported) {
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.verb = VERB_OK;
         add_result(ri, &params);
     }

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -492,8 +492,10 @@ bool inspect_license(struct rpminspect *ri)
     }
 
     if (good == seen) {
+        init_result_params(&params);
+        params.header = NAME_LICENSE;
         params.severity = RESULT_OK;
-        params.msg = NULL;
+        params.verb = VERB_OK;
         add_result(ri, &params);
         result = true;
     }

--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -116,12 +116,10 @@ bool inspect_lostpayload(struct rpminspect *ri)
     }
 
     if (!messaged) {
+        init_result_params(&params);
+        params.header = NAME_LOSTPAYLOAD;
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.verb = VERB_OK;
-        params.noun = NULL;
-        params.file = NULL;
-        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -217,7 +217,6 @@ bool inspect_lto(struct rpminspect *ri)
 
     if (result) {
         init_result_params(&params);
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_LTO;
         params.severity = RESULT_OK;
         params.verb = VERB_OK;

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -364,7 +364,6 @@ bool inspect_manpage(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_MANPAGE;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_metadata.c
+++ b/lib/inspect_metadata.c
@@ -236,12 +236,8 @@ bool inspect_metadata(struct rpminspect *ri)
     if (good) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_METADATA;
         params.verb = VERB_OK;
-        params.noun = NULL;
-        params.file = NULL;
-        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -101,8 +101,8 @@ bool inspect_modularity(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_MODULARITY;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -88,12 +88,10 @@ bool inspect_movedfiles(struct rpminspect *ri)
 
     result = foreach_peer_file(ri, NAME_MOVEDFILES, movedfiles_driver);
 
-    init_result_params(&params);
-    params.waiverauth = NOT_WAIVABLE;
-    params.header = NAME_MOVEDFILES;
-    params.verb = VERB_OK;
-
     if (result) {
+        init_result_params(&params);
+        params.header = NAME_MOVEDFILES;
+        params.verb = VERB_OK;
         params.severity = RESULT_OK;
         add_result(ri, &params);
     }

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -277,7 +277,6 @@ bool inspect_ownership(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_OWNERSHIP;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -772,7 +772,7 @@ bool inspect_patches(struct rpminspect *ri)
         init_result_params(&params);
         params.header = NAME_PATCHES;
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
+        params.verb = VERB_OK;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -131,7 +131,6 @@ bool inspect_pathmigration(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_PATHMIGRATION;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -140,7 +140,6 @@ bool inspect_permissions(struct rpminspect *ri)
     if (result && !reported) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_PERMISSIONS;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -180,12 +180,8 @@ bool inspect_politics(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_POLITICS;
         params.verb = VERB_OK;
-        params.noun = NULL;
-        params.file = NULL;
-        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -213,7 +213,6 @@ bool inspect_removedfiles(struct rpminspect *ri)
     if (result && !reported) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_REMOVEDFILES;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -938,7 +938,6 @@ bool inspect_rpmdeps(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_RPMDEPS;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -335,7 +335,6 @@ bool inspect_runpath(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_RUNPATH;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -267,7 +267,6 @@ bool inspect_shellsyntax(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_SHELLSYNTAX;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_specname.c
+++ b/lib/inspect_specname.c
@@ -113,7 +113,6 @@ bool inspect_specname(struct rpminspect *ri)
     foreach_peer_file(ri, NAME_SPECNAME, specname_driver);
 
     init_result_params(&params);
-    params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_SPECNAME;
     params.verb = VERB_OK;
 
@@ -122,6 +121,7 @@ bool inspect_specname(struct rpminspect *ri)
         add_result(ri, &params);
     } else if (!seen) {
         params.severity = RESULT_INFO;
+        params.waiverauth = NOT_WAIVABLE;
         xasprintf(&params.msg, _("The specname inspection is only for source packages, skipping."));
         add_result(ri, &params);
         free(params.msg);

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -128,12 +128,10 @@ bool inspect_subpackages(struct rpminspect *ri)
 
     /* Sound the everything-is-ok alarm if everything is, in fact, ok */
     if (result) {
+        init_result_params(&params);
+        params.header = NAME_SUBPACKAGES;
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
-        params.msg = NULL;
         params.verb = VERB_OK;
-        free(params.remedy);
-        params.remedy = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -333,7 +333,6 @@ bool inspect_symlinks(struct rpminspect *ri)
 
     if (result) {
         init_result_params(&params);
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_SYMLINKS;
         params.severity = RESULT_OK;
         params.verb = VERB_OK;

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -158,7 +158,6 @@ bool inspect_types(struct rpminspect *ri)
     if (!reported) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_TYPES;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -640,7 +640,6 @@ bool inspect_unicode(struct rpminspect *ri)
 
     /* report */
     init_result_params(&params);
-    params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_UNICODE;
     params.verb = VERB_OK;
 
@@ -649,6 +648,7 @@ bool inspect_unicode(struct rpminspect *ri)
         add_result(ri, &params);
     } else if (!seen) {
         params.severity = RESULT_INFO;
+        params.waiverauth = NOT_WAIVABLE;
         xasprintf(&params.msg, _("The unicode inspection is only for source packages, skipping."));
         add_result(ri, &params);
         free(params.msg);

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -222,18 +222,17 @@ bool inspect_upstream(struct rpminspect *ri)
         list_free(source, free);
     }
 
+    free(params.remedy);
+    params.remedy = NULL;
+    params.msg = NULL;
+
     /* Sound the everything-is-ok alarm if everything is, in fact, ok */
     if (result && !reported) {
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
-        params.msg = NULL;
+        params.waiverauth = NULL_WAIVERAUTH;
         params.verb = VERB_OK;
-        free(params.remedy);
-        params.remedy = NULL;
         add_result(ri, &params);
     }
-
-    free(params.remedy);
 
     return result;
 }

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -201,12 +201,8 @@ bool inspect_virus(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_VIRUS;
         params.verb = VERB_OK;
-        params.noun = NULL;
-        params.file = NULL;
-        params.arch = NULL;
         add_result(ri, &params);
     }
 

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -233,7 +233,6 @@ bool inspect_xml(struct rpminspect *ri)
     if (result) {
         init_result_params(&params);
         params.severity = RESULT_OK;
-        params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_XML;
         params.verb = VERB_OK;
         add_result(ri, &params);

--- a/lib/results.c
+++ b/lib/results.c
@@ -31,7 +31,7 @@ void init_result_params(struct result_params *params)
     assert(params != NULL);
 
     params->severity = RESULT_OK;
-    params->waiverauth = NOT_WAIVABLE;
+    params->waiverauth = NULL_WAIVERAUTH;
     params->header = NULL;
     params->msg = NULL;
     params->details = NULL;

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -958,6 +958,27 @@ int main(int argc, char **argv)
         for (i = 0; inspections[i].name != NULL; i++) {
             /* test not selected by user */
             if (!(ri->tests & inspections[i].flag)) {
+                /*
+                 * tell the user this inspection is skipped when in
+                 * verbose mode
+                 */
+                if (verbose) {
+                    xasprintf(&r, _("Skipping %s inspection..."), inspections[i].name);
+                    assert(r != NULL);
+                    printf("%-36s", r);
+                    free(r);
+
+                    printf("%5s\n", _("skip"));
+                }
+
+                /* add a skipped result for this inspection */
+                init_result_params(&params);
+                params.header = inspections[i].name;
+                params.severity = RESULT_SKIP;
+                params.verb = VERB_SKIP;
+                add_result(ri, &params);
+
+                /* next inspection */
                 continue;
             }
 
@@ -978,6 +999,10 @@ int main(int argc, char **argv)
             if (verbose) {
                 printf("%5s\n", ires ? _("pass") : _("FAIL"));
             }
+        }
+
+        if (verbose) {
+            printf("\n");
         }
 
         /* output the results */

--- a/test/test_abidiff.py
+++ b/test/test_abidiff.py
@@ -76,7 +76,6 @@ class AbidiffRebaseNoABIChangeRPMs(TestCompareRPMs):
         self.inspection = "abidiff"
         self.exitcode = 0
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class AbidiffRebaseNoABIChangeKoji(TestCompareKoji):
@@ -93,7 +92,6 @@ class AbidiffRebaseNoABIChangeKoji(TestCompareKoji):
         self.inspection = "abidiff"
         self.exitcode = 0
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Test two builds that are a rebase and break the ABI (OK)
@@ -117,7 +115,6 @@ class AbidiffRebaseWithABIChangeRPMs(TestCompareRPMs):
         self.inspection = "abidiff"
         self.exitcode = 0
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class AbidiffRebaseWithABIChangeKoji(TestCompareKoji):
@@ -140,7 +137,6 @@ class AbidiffRebaseWithABIChangeKoji(TestCompareKoji):
         self.inspection = "abidiff"
         self.exitcode = 0
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Test two builds that are not a rebase and break the ABI (VERIFY)

--- a/test/test_addedfiles.py
+++ b/test/test_addedfiles.py
@@ -293,7 +293,6 @@ class SecurityFileContinuesToExistCompareRPMs(TestCompareRPMs):
 
         self.inspection = "addedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityFileContinuesToExistCompareKoji(TestCompareKoji):
@@ -313,7 +312,6 @@ class SecurityFileContinuesToExistCompareKoji(TestCompareKoji):
 
         self.inspection = "addedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # New file shows up in after build for maintenance comparison -> VERIFY

--- a/test/test_badfuncs.py
+++ b/test/test_badfuncs.py
@@ -77,7 +77,6 @@ class AllowedForbiddenIPv6FunctionRPM(TestRPMs):
         self.rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
 
         self.inspection = "badfuncs"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -93,7 +92,6 @@ class AllowedForbiddenIPv6FunctionKoji(TestKoji):
         self.rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
 
         self.inspection = "badfuncs"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -110,7 +108,6 @@ class AllowedForbiddenIPv6FunctionCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
 
         self.inspection = "badfuncs"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -127,5 +124,4 @@ class AllowedForbiddenIPv6FunctionCompareKoji(TestCompareKoji):
         self.after_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
 
         self.inspection = "badfuncs"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"

--- a/test/test_capabilities.py
+++ b/test/test_capabilities.py
@@ -132,7 +132,6 @@ class ApprovedCapabilitiesKoji(TestKoji):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ApprovedCapabilitiesCompareRPMs(TestCompareRPMs):
@@ -148,7 +147,6 @@ class ApprovedCapabilitiesCompareRPMs(TestCompareRPMs):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ApprovedCapabilitiesCompareKoji(TestCompareKoji):
@@ -164,7 +162,6 @@ class ApprovedCapabilitiesCompareKoji(TestCompareKoji):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPUnapprovedCapabilitiesRPMs(TestRPMs):
@@ -180,7 +177,6 @@ class SecuritySKIPUnapprovedCapabilitiesRPMs(TestRPMs):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityFAILUnapprovedCapabilitiesCompareRPMs(TestCompareRPMs):
@@ -228,7 +224,6 @@ class SecuritySKIPUnapprovedCapabilitiesKoji(TestKoji):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPUnapprovedCapabilitiesCompareRPMs(TestCompareRPMs):
@@ -244,7 +239,6 @@ class SecuritySKIPUnapprovedCapabilitiesCompareRPMs(TestCompareRPMs):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPUnapprovedCapabilitiesCompareKoji(TestCompareKoji):
@@ -260,7 +254,6 @@ class SecuritySKIPUnapprovedCapabilitiesCompareKoji(TestCompareKoji):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMUnapprovedCapabilitiesRPMs(TestRPMs):
@@ -436,7 +429,6 @@ class SecuritySKIPCapabilitiesMismatchRPMs(TestRPMs):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPCapabilitiesMismatchKoji(TestKoji):
@@ -452,7 +444,6 @@ class SecuritySKIPCapabilitiesMismatchKoji(TestKoji):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPCapabilitiesMismatchCompareRPMs(TestCompareRPMs):
@@ -468,7 +459,6 @@ class SecuritySKIPCapabilitiesMismatchCompareRPMs(TestCompareRPMs):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPCapabilitiesMismatchCompareKoji(TestCompareKoji):
@@ -484,7 +474,6 @@ class SecuritySKIPCapabilitiesMismatchCompareKoji(TestCompareKoji):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMCapabilitiesMismatchRPMs(TestRPMs):
@@ -692,7 +681,6 @@ class SecuritySKIPUnexpectedCapabilitiesRPMs(TestRPMs):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPUnexpectedCapabilitiesKoji(TestKoji):
@@ -708,7 +696,6 @@ class SecuritySKIPUnexpectedCapabilitiesKoji(TestKoji):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPUnexpectedCapabilitiesCompareRPMs(TestCompareRPMs):
@@ -724,7 +711,6 @@ class SecuritySKIPUnexpectedCapabilitiesCompareRPMs(TestCompareRPMs):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPUnexpectedCapabilitiesCompareKoji(TestCompareKoji):
@@ -740,7 +726,6 @@ class SecuritySKIPUnexpectedCapabilitiesCompareKoji(TestCompareKoji):
 
         self.inspection = "capabilities"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMUnexpectedCapabilitiesRPMs(TestRPMs):

--- a/test/test_changedfiles.py
+++ b/test/test_changedfiles.py
@@ -47,7 +47,6 @@ class GzipFileNoChangeRPMs(TestCompareRPMs):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class GzipFileNoChangeKoji(TestCompareKoji):
@@ -71,7 +70,6 @@ class GzipFileNoChangeKoji(TestCompareKoji):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # gzip file changes between builds and has different compression ratios
@@ -96,7 +94,6 @@ class GzipFileChangesRPMs(TestCompareRPMs):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class GzipFileChangesKoji(TestCompareKoji):
@@ -120,7 +117,6 @@ class GzipFileChangesKoji(TestCompareKoji):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # bzip2 file does not change between builds despite having different
@@ -146,7 +142,6 @@ class Bzip2FileNoChangeRPMs(TestCompareRPMs):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class Bzip2FileNoChangeKoji(TestCompareKoji):
@@ -170,7 +165,6 @@ class Bzip2FileNoChangeKoji(TestCompareKoji):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # bzip2 file changes between builds and has different compression ratios
@@ -195,7 +189,6 @@ class Bzip2FileChangesRPMs(TestCompareRPMs):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class Bzip2FileChangesKoji(TestCompareKoji):
@@ -219,7 +212,6 @@ class Bzip2FileChangesKoji(TestCompareKoji):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # xz file does not change between builds despite having different
@@ -245,7 +237,6 @@ class XzFileNoChangeRPMs(TestCompareRPMs):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class XzFileNoChangeKoji(TestCompareKoji):
@@ -269,7 +260,6 @@ class XzFileNoChangeKoji(TestCompareKoji):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # xz file changes between builds and has different compression ratios
@@ -294,7 +284,6 @@ class XzFileChangesRPMs(TestCompareRPMs):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class XzFileChangesKoji(TestCompareKoji):
@@ -318,4 +307,3 @@ class XzFileChangesKoji(TestCompareKoji):
 
         self.inspection = "changedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -281,7 +281,6 @@ class AddChangeLogEntryCompareSRPM(TestCompareSRPM):
         # indicates a failure in the SRPM only changelog inspection.
         self.inspection = "changelog"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class AddChangeLogEntryCompareRPMs(TestCompareRPMs):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -263,7 +263,6 @@ class ConfigChangesWhitespaceCompareRPMs(TestCompareRPMs):
 
         self.inspection = "config"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ConfigChangesWhitespaceCompareKoji(TestCompareKoji):
@@ -284,7 +283,6 @@ class ConfigChangesWhitespaceCompareKoji(TestCompareKoji):
 
         self.inspection = "config"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ConfigChangesWhitespaceRebaseCompareRPMs(TestCompareRPMs):
@@ -305,7 +303,6 @@ class ConfigChangesWhitespaceRebaseCompareRPMs(TestCompareRPMs):
 
         self.inspection = "config"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ConfigChangesWhitespaceRebaseCompareKoji(TestCompareKoji):
@@ -326,7 +323,6 @@ class ConfigChangesWhitespaceRebaseCompareKoji(TestCompareKoji):
 
         self.inspection = "config"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # %config content differences (VERIFY)

--- a/test/test_debuginfo.py
+++ b/test/test_debuginfo.py
@@ -47,7 +47,6 @@ class MissingSectionsInDebuginfoPkgSRPM(TestSRPM):
         # this inspection is a no-op on SRPMs
         self.inspection = "debuginfo"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingSectionsInDebuginfoPkgCompareSRPM(TestCompareSRPM):
@@ -63,7 +62,6 @@ class MissingSectionsInDebuginfoPkgCompareSRPM(TestCompareSRPM):
         # this inspection is a no-op on SRPMs
         self.inspection = "debuginfo"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingSectionsInDebuginfoPkgRPMs(TestRPMs):
@@ -131,7 +129,6 @@ class HaveDebuggingSectionsInRegularPkgSRPM(TestSRPM):
         # this inspection is a no-op on SRPMs
         self.inspection = "debuginfo"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class HaveDebuggingSectionsInRegularPkgCompareSRPM(TestCompareSRPM):
@@ -147,7 +144,6 @@ class HaveDebuggingSectionsInRegularPkgCompareSRPM(TestCompareSRPM):
         # this inspection is a no-op on SRPMs
         self.inspection = "debuginfo"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class HaveDebuggingSectionsInRegularPkgRPMs(TestRPMs):

--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -209,7 +209,6 @@ class DistTagInMacroSRPM(RequiresRpminspect):
         self.exitcode = 0
         self.inspection = "disttag"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
     def runTest(self):
         self.configFile()
@@ -308,7 +307,6 @@ class TabbedDistTagInMacroSRPM(RequiresRpminspect):
         self.exitcode = 0
         self.inspection = "disttag"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
     def runTest(self):
         self.configFile()

--- a/test/test_elf.py
+++ b/test/test_elf.py
@@ -74,7 +74,6 @@ class WithoutExecStackRPM(TestRPMs):
         TestRPMs.setUp(self)
         self.rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -83,7 +82,6 @@ class WithoutExecStackKoji(TestKoji):
         TestKoji.setUp(self)
         self.rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -93,7 +91,6 @@ class WithoutExecStackCompareRPM(TestCompareRPMs):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -103,7 +100,6 @@ class WithoutExecStackCompareKoji(TestCompareKoji):
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -126,7 +122,6 @@ class SecuritySKIPWithExecStackRPM(TestRPMs):
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,execstack"
         )
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -181,7 +176,6 @@ class SecuritySKIPWithExecStackKoji(TestKoji):
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,execstack"
         )
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -242,7 +236,6 @@ class SecuritySKIPWithExecStackCompareRPMs(TestCompareRPMs):
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,execstack"
         )
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -312,7 +305,6 @@ class SecuritySKIPWithExecStackCompareKoji(TestCompareKoji):
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,execstack"
         )
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -379,7 +371,6 @@ class SecuritySKIPLostFullRELROCompareRPMs(TestCompareRPMs):
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,norelro"
         )
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -445,7 +436,6 @@ class SecuritySKIPLostFullRELROCompareKoji(TestCompareKoji):
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,norelro"
         )
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -512,7 +502,6 @@ class SecuritySKIPFulltoPartialRELROCompareRPMs(TestCompareRPMs):
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,relro,-z,lazy"
         )
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -578,7 +567,6 @@ class SecuritySKIPFulltoPartialRELROCompareKoji(TestCompareKoji):
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,relro,-z,lazy"
         )
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -695,7 +683,6 @@ class SecuritySKIPLostPICCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_payload_check(installPath, None)
 
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -890,7 +877,6 @@ class SecuritySKIPHasTEXTRELRPMs(TestRPMs):
         self.rpm.add_payload_check(installPath, None)
 
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -1041,7 +1027,6 @@ class SecuritySKIPHasTEXTRELCompareRPMs(TestCompareRPMs):
         self.after_rpm.add_payload_check(installPath, None)
 
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 
@@ -1246,7 +1231,6 @@ class SecuritySKIPHasTEXTRELCompareKoji(TestCompareKoji):
         self.after_rpm.add_payload_check(installPath, None)
 
         self.inspection = "elf"
-        self.waiver_auth = "Not Waivable"
         self.result = "OK"
 
 

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -49,7 +49,6 @@ class ValidFilesSectionSRPM(TestSRPM):
         # the inspection results expected
         self.inspection = "files"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidFilesSectionKoji(TestKoji):
@@ -75,7 +74,6 @@ class ValidFilesSectionKoji(TestKoji):
         # the inspection results expected
         self.inspection = "files"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidFilesSectionCompareSRPM(TestCompareSRPM):
@@ -103,7 +101,6 @@ class ValidFilesSectionCompareSRPM(TestCompareSRPM):
         # the inspection results expected
         self.inspection = "files"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidFilesSectionCompareKoji(TestCompareKoji):
@@ -131,7 +128,6 @@ class ValidFilesSectionCompareKoji(TestCompareKoji):
         # the inspection results expected
         self.inspection = "files"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class InvalidFilesSectionSRPM(TestSRPM):

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -31,6 +31,7 @@ class EmptyLicenseTagSRPM(TestSRPM):
         self.rpm.license = ""
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Empty License tag fails on RPMs (BAD)
@@ -43,6 +44,7 @@ class EmptyLicenseTagRPMs(TestRPMs):
         self.rpm.license = ""
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Empty License tag fails on Koji build (BAD)
@@ -55,6 +57,7 @@ class EmptyLicenseTagKoji(TestKoji):
         self.rpm.license = ""
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Forbidden License tag fails on SRPM (BAD)
@@ -64,6 +67,7 @@ class ForbiddenLicenseTagSRPM(TestSRPM):
         self.rpm.addLicense("APSL-1.2")
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Forbidden License tag fails on RPMs (BAD)
@@ -73,6 +77,7 @@ class ForbiddenLicenseTagRPMs(TestRPMs):
         self.rpm.addLicense("APSL-1.2")
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Forbidden License tag fails on Koji build (BAD)
@@ -82,6 +87,7 @@ class ForbiddenLicenseTagKoji(TestKoji):
         self.rpm.addLicense("APSL-1.2")
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # License tag with unprofessional language fails on SRPM (BAD)
@@ -91,6 +97,7 @@ class BadWordLicenseTagSRPM(TestSRPM):
         self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # License tag with unprofessional language fails on RPMs (BAD)
@@ -100,6 +107,7 @@ class BadWordLicenseTagRPMs(TestRPMs):
         self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # License tag with unprofessional language fails on Koji build (BAD)
@@ -109,6 +117,7 @@ class BadWordLicenseTagKoji(TestKoji):
         self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag passes on SRPM (OK)
@@ -118,6 +127,7 @@ class ValidLicenseTagSRPM(TestSRPM):
         self.rpm.addLicense("GPLv3+")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag passes on RPMs (OK)
@@ -127,6 +137,7 @@ class ValidLicenseTagRPMs(TestRPMs):
         self.rpm.addLicense("GPLv3+")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag passes on Koji build (OK)
@@ -136,6 +147,7 @@ class ValidLicenseTagKoji(TestKoji):
         self.rpm.addLicense("GPLv3+")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces passes on SRPM (OK)
@@ -145,6 +157,7 @@ class ValidLicenseTagWithSpacesSRPM(TestSRPM):
         self.rpm.addLicense("ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces passes on RPMs (OK)
@@ -154,6 +167,7 @@ class ValidLicenseTagWithSpacesRPMs(TestRPMs):
         self.rpm.addLicense("ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces passes on Koji build (OK)
@@ -163,6 +177,7 @@ class ValidLicenseTagWithSpacesKoji(TestKoji):
         self.rpm.addLicense("ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces passes on SRPM (OK)
@@ -172,6 +187,7 @@ class ValidLicenseTagWithBooleanSpacesSRPM(TestSRPM):
         self.rpm.addLicense("GPLv3+ and ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces passes on RPMs (OK)
@@ -181,6 +197,7 @@ class ValidLicenseTagWithBooleanSpacesRPMs(TestRPMs):
         self.rpm.addLicense("ASL 2.0 and GPLv3+")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces passes on Koji build (OK)
@@ -190,6 +207,7 @@ class ValidLicenseTagWithBooleanSpacesKoji(TestKoji):
         self.rpm.addLicense("GPLv3+ or ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces and parens passes on SRPM (OK)
@@ -199,6 +217,7 @@ class ValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
         self.rpm.addLicense("Artistic 2.0 and (GPL+ or Artistic)")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces and parens passes on RPMs (OK)
@@ -208,6 +227,7 @@ class ValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
         self.rpm.addLicense("Artistic 2.0 and (GPL+ or Artistic)")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces and parens passes on Koji build (OK)
@@ -217,6 +237,7 @@ class ValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
         self.rpm.addLicense("Artistic 2.0 and (GPL+ or Artistic)")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces and parens passes on SRPM (OK)
@@ -226,6 +247,7 @@ class AnotherValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
         self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces and parens passes on RPMs (OK)
@@ -235,6 +257,7 @@ class AnotherValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
         self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License tag with spaces and parens passes on Koji build (OK)
@@ -244,6 +267,7 @@ class AnotherValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
         self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid glibc License tag on Koji build (OK)
@@ -256,6 +280,7 @@ class ValidGlibcLicenseTagKoji(TestKoji):
         )
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid perl-HTTP-Message License tag on Koji build (OK)
@@ -265,6 +290,7 @@ class ValidPerlHTTPMessageLicenseTagKoji(TestKoji):
         self.rpm.addLicense("(GPL+ or Artistic) and CC0")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Valid License string without any official abbreviations (OK)
@@ -276,6 +302,7 @@ class ValidLoremIpsonLicenseTagSRPM(TestSRPM):
         )
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class ValidLoremIpsonLicenseTagRPMs(TestRPMs):
@@ -286,6 +313,7 @@ class ValidLoremIpsonLicenseTagRPMs(TestRPMs):
         )
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class ValidLoremIpsonLicenseTagKoji(TestKoji):
@@ -296,6 +324,7 @@ class ValidLoremIpsonLicenseTagKoji(TestKoji):
         )
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # Invalid use of fedora_name string when an abbreviation is available (BAD)
@@ -305,6 +334,7 @@ class InvalidUseOfLicenseStringSRPM(TestSRPM):
         self.rpm.addLicense("Apache Software License 2.0")
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 class InvalidUseOfLicenseStringRPMs(TestRPMs):
@@ -313,6 +343,7 @@ class InvalidUseOfLicenseStringRPMs(TestRPMs):
         self.rpm.addLicense("Apache Software License 2.0")
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 class InvalidUseOfLicenseStringKoji(TestKoji):
@@ -321,3 +352,4 @@ class InvalidUseOfLicenseStringKoji(TestKoji):
         self.rpm.addLicense("Apache Software License 2.0")
         self.inspection = "license"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"

--- a/test/test_lto.py
+++ b/test/test_lto.py
@@ -44,7 +44,6 @@ class NoLTOSymbolsRelocRPMs(TestRPMs):
         )
         self.inspection = "lto"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class NoLTOSymbolsRelocKoji(TestKoji):
@@ -57,7 +56,6 @@ class NoLTOSymbolsRelocKoji(TestKoji):
         )
         self.inspection = "lto"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class NoLTOSymbolsRelocCompareRPMs(TestCompareRPMs):
@@ -70,7 +68,6 @@ class NoLTOSymbolsRelocCompareRPMs(TestCompareRPMs):
         )
         self.inspection = "lto"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class NoLTOSymbolsRelocCompareKoji(TestCompareKoji):
@@ -83,7 +80,6 @@ class NoLTOSymbolsRelocCompareKoji(TestCompareKoji):
         )
         self.inspection = "lto"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # No LTO symbols in .a files (OK)
@@ -107,7 +103,6 @@ class NoLTOSymbolsStaticLibRPMs(TestRPMs):
 
         self.inspection = "lto"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class NoLTOSymbolsStaticLibKoji(TestKoji):
@@ -130,7 +125,6 @@ class NoLTOSymbolsStaticLibKoji(TestKoji):
 
         self.inspection = "lto"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class NoLTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
@@ -153,7 +147,6 @@ class NoLTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
 
         self.inspection = "lto"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class NoLTOSymbolsStaticLibCompareKoji(TestCompareKoji):
@@ -176,7 +169,6 @@ class NoLTOSymbolsStaticLibCompareKoji(TestCompareKoji):
 
         self.inspection = "lto"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # LTO symbols present in .o files (BAD)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -61,6 +61,7 @@ class InvalidVendorSRPM(TestSRPM):
         self.rpm.addVendor("Amalgamated Amalgamations LLC")
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify invalid Vendor fails on binary RPMs (BAD)
@@ -70,6 +71,7 @@ class InvalidVendorRPMs(TestRPMs):
         self.rpm.addVendor("Amalgamated Amalgamations LLC")
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify invalid Vendor fails on Koji build (BAD)
@@ -79,6 +81,7 @@ class InvalidVendorKojiBuild(TestKoji):
         self.rpm.addVendor("Amalgamated Amalgamations LLC")
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify gaining Vendor reports verify on SRPM (VERIFY)
@@ -185,6 +188,7 @@ class InvalidBuildhostSubdomainSRPM(TestSRPM):
         self.rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify invalid Buildhost subdomain fails on binary RPMs (BAD)
@@ -195,6 +199,7 @@ class InvalidBuildhostSubdomainRPMs(TestRPMs):
         self.rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify invalid Buildhost subdomain fails on Koji build (BAD)
@@ -205,6 +210,7 @@ class InvalidBuildhostSubdomainKojiBuild(TestKoji):
         self.rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify Summary without bad words passes on an SRPM (OK)
@@ -241,6 +247,7 @@ class DirtySummarySRPM(TestSRPM):
         self.rpm.add_summary("Lorem ipsum reallybadword dolor sit amet")
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify Summary with bad words fails on binary RPMs (BAD)
@@ -250,6 +257,7 @@ class DirtySummaryRPMs(TestRPMs):
         self.rpm.add_summary("Lorem ipsum reallybadword dolor sit amet")
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify Summary with bad words fails on Koji build (BAD)
@@ -259,6 +267,7 @@ class DirtySummaryKojiBuild(TestKoji):
         self.rpm.add_summary("Lorem ipsum reallybadword dolor sit amet")
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify changing Summary reports verify on SRPM (INFO)
@@ -356,6 +365,7 @@ class DirtyDescriptionSRPM(TestSRPM):
         )
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify Description with bad words fails on binary RPMs (BAD)
@@ -372,6 +382,7 @@ class DirtyDescriptionRPMs(TestRPMs):
         )
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify Description with bad words fails on Koji build (BAD)
@@ -388,6 +399,7 @@ class DirtyDescriptionKojiBuild(TestKoji):
         )
         self.inspection = "metadata"
         self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
 
 
 # Verify changing Description reports verify on SRPM (INFO)

--- a/test/test_ownership.py
+++ b/test/test_ownership.py
@@ -1676,7 +1676,6 @@ class SecuritySKIPCapSETUIDWithOtherExecRPMs(TestRPMs):
 
         self.inspection = "ownership"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMCapSETUIDWithOtherExecRPMs(TestRPMs):
@@ -1826,7 +1825,6 @@ class SecuritySKIPCapSETUIDWithOtherExecKoji(TestKoji):
 
         self.inspection = "ownership"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMCapSETUIDWithOtherExecKoji(TestKoji):
@@ -1980,7 +1978,6 @@ class SecuritySKIPCapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
 
         self.inspection = "ownership"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMCapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
@@ -2140,7 +2137,6 @@ class SecuritySKIPCapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
 
         self.inspection = "ownership"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMCapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
@@ -2301,7 +2297,6 @@ class SecuritySKIPCapSETUIDWithGroupExecRPMs(TestRPMs):
 
         self.inspection = "ownership"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMCapSETUIDWithGroupExecRPMs(TestRPMs):
@@ -2451,7 +2446,6 @@ class SecuritySKIPCapSETUIDWithGroupExecKoji(TestKoji):
 
         self.inspection = "ownership"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMCapSETUIDWithGroupExecKoji(TestKoji):
@@ -2605,7 +2599,6 @@ class SecuritySKIPCapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
 
         self.inspection = "ownership"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMCapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
@@ -2765,7 +2758,6 @@ class SecuritySKIPCapSETUIDWithGroupExecCompareKoji(TestCompareKoji):
 
         self.inspection = "ownership"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMCapSETUIDWithGroupExecCompareKoji(TestCompareKoji):

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -54,6 +54,7 @@ class ExecutableWithSetUIDRPMs(TestRPMs):
 
         self.inspection = "permissions"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class ExecutableWithSetUIDKoji(TestKoji):
@@ -71,6 +72,7 @@ class ExecutableWithSetUIDKoji(TestKoji):
 
         self.inspection = "permissions"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class ExecutableWithSetUIDCompareSRPM(TestCompareSRPM):
@@ -105,6 +107,7 @@ class ExecutableWithSetUIDCompareRPMs(TestCompareRPMs):
 
         self.inspection = "permissions"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class ExecutableWithSetUIDCompareKoji(TestCompareKoji):
@@ -122,6 +125,7 @@ class ExecutableWithSetUIDCompareKoji(TestCompareKoji):
 
         self.inspection = "permissions"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class UnapprovedExecutableWithSetUIDSRPM(TestSRPM):
@@ -174,7 +178,6 @@ class SecuritySKIPUnapprovedExecutableWithSetUIDRPMs(TestRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMUnapprovedExecutableWithSetUIDRPMs(TestRPMs):
@@ -264,7 +267,6 @@ class SecuritySKIPUnapprovedExecutableWithSetUIDKoji(TestKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMUnapprovedExecutableWithSetUIDKoji(TestKoji):
@@ -371,7 +373,6 @@ class SecuritySKIPUnapprovedExecutableWithSetUIDCompareRPMs(TestCompareRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMUnapprovedExecutableWithSetUIDCompareRPMs(TestCompareRPMs):
@@ -461,7 +462,6 @@ class SecuritySKIPUnapprovedExecutableWithSetUIDCompareKoji(TestCompareKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMUnapprovedExecutableWithSetUIDCompareKoji(TestCompareKoji):
@@ -568,7 +568,6 @@ class SecuritySKIPFileIWOTHProhibitedRPMs(TestRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileIWOTHProhibitedRPMs(TestRPMs):
@@ -658,7 +657,6 @@ class SecuritySKIPFileIWOTHProhibitedKoji(TestKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileIWOTHProhibitedKoji(TestKoji):
@@ -765,7 +763,6 @@ class SecuritySKIPFileIWOTHProhibitedCompareRPMs(TestCompareRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileIWOTHProhibitedCompareRPMs(TestCompareRPMs):
@@ -855,7 +852,6 @@ class SecuritySKIPFileIWOTHProhibitedCompareKoji(TestCompareKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileIWOTHProhibitedCompareKoji(TestCompareKoji):
@@ -962,7 +958,6 @@ class SecuritySKIPFileIWOTHandISVTXProhibitedRPMs(TestRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileIWOTHandISVTXProhibitedRPMs(TestRPMs):
@@ -1052,7 +1047,6 @@ class SecuritySKIPFileIWOTHandISVTXProhibitedKoji(TestKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileIWOTHandISVTXProhibitedKoji(TestKoji):
@@ -1159,7 +1153,6 @@ class SecuritySKIPFileIWOTHandISVTXProhibitedCompareRPMs(TestCompareRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileIWOTHandISVTXProhibitedCompareRPMs(TestCompareRPMs):
@@ -1249,7 +1242,6 @@ class SecuritySKIPFileIWOTHandISVTXProhibitedCompareKoji(TestCompareKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileIWOTHandISVTXProhibitedCompareKoji(TestCompareKoji):
@@ -1368,7 +1360,6 @@ class SecuritySKIPDirIWOTHProhibitedRPMs(TestRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMDirIWOTHProhibitedRPMs(TestRPMs):
@@ -1478,7 +1469,6 @@ class SecuritySKIPDirIWOTHProhibitedKoji(TestKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMDirIWOTHProhibitedKoji(TestKoji):
@@ -1609,7 +1599,6 @@ class SecuritySKIPDirIWOTHProhibitedCompareRPMs(TestCompareRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMDirIWOTHProhibitedCompareRPMs(TestCompareRPMs):
@@ -1719,7 +1708,6 @@ class SecuritySKIPDirIWOTHProhibitedCompareKoji(TestCompareKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMDirIWOTHProhibitedCompareKoji(TestCompareKoji):
@@ -1850,7 +1838,6 @@ class SecuritySKIPDirIWOTHandISVTXProhibitedRPMs(TestRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMDirIWOTHandISVTXProhibitedRPMs(TestRPMs):
@@ -1960,7 +1947,6 @@ class SecuritySKIPDirIWOTHandISVTXProhibitedKoji(TestKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMDirIWOTHandISVTXProhibitedKoji(TestKoji):
@@ -2091,7 +2077,6 @@ class SecuritySKIPDirIWOTHandISVTXProhibitedCompareRPMs(TestCompareRPMs):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMDirIWOTHandISVTXProhibitedCompareRPMs(TestCompareRPMs):
@@ -2201,7 +2186,6 @@ class SecuritySKIPDirIWOTHandISVTXProhibitedCompareKoji(TestCompareKoji):
 
         self.inspection = "permissions"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMDirIWOTHandISVTXProhibitedCompareKoji(TestCompareKoji):

--- a/test/test_rpmdeps_conflicts.py
+++ b/test/test_rpmdeps_conflicts.py
@@ -80,7 +80,6 @@ class ConflictsCorrectRPMs(TestRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ConflictsCorrectKoji(TestKoji):
@@ -91,7 +90,6 @@ class ConflictsCorrectKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Retaining Conflicts dependency in rebase comparison (INFO)
@@ -129,7 +127,6 @@ class RetainingConflictsCompareRPMs(TestCompareRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RetainingConflictsCompareKoji(TestCompareKoji):
@@ -141,7 +138,6 @@ class RetainingConflictsCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Gaining a new Conflicts in a rebase comparison (INFO)
@@ -248,7 +244,6 @@ class ChangingConflictsExpectedCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ChangingConflictsExpectedCompareRPMs(TestCompareRPMs):
@@ -342,7 +337,6 @@ class MissingEpochConflictsSRPM(TestSRPM):
         # the result is OK here because the Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochConflictsRPMs(TestRPMs):
@@ -373,7 +367,6 @@ class MissingEpochConflictsRPMs(TestRPMs):
         # doesn't fail
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochConflictsKoji(TestKoji):
@@ -438,7 +431,6 @@ class MissingEpochConflictsCompareSRPM(TestCompareSRPM):
         # this is 'OK' because the missing Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochConflictsCompareRPMs(TestCompareRPMs):
@@ -477,7 +469,6 @@ class MissingEpochConflictsCompareRPMs(TestCompareRPMs):
         # entire collection of RPMs, it does it iteratively
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochConflictsCompareKoji(TestCompareKoji):
@@ -553,7 +544,6 @@ class MissingEpochConflictsRebaseCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochConflictsRebaseCompareRPMs(TestCompareRPMs):
@@ -641,7 +631,6 @@ class UnexpandedMacroConflictsSRPM(TestSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroConflictsRPMs(TestRPMs):
@@ -679,7 +668,6 @@ class UnexpandedMacroConflictsCompareSRPM(TestCompareSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroConflictsCompareRPMs(TestCompareRPMs):
@@ -743,7 +731,6 @@ class MissingExplicitConflictsSRPM(TestSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitConflictsRPMs(TestRPMs):
@@ -781,7 +768,6 @@ class MissingExplicitConflictsRPMs(TestRPMs):
         # looking at a single RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitConflictsKoji(TestKoji):
@@ -876,7 +862,6 @@ class MissingExplicitConflictsCompareSRPM(TestCompareSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitConflictsCompareRPMs(TestCompareRPMs):
@@ -935,7 +920,6 @@ class MissingExplicitConflictsCompareRPMs(TestCompareRPMs):
         # RPM comparisons
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitConflictsCompareKoji(TestCompareKoji):
@@ -1043,7 +1027,6 @@ class MultipleProvidersSRPM(TestSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersRPMs(TestRPMs):
@@ -1092,7 +1075,6 @@ class MultipleProvidersRPMs(TestRPMs):
         # result is OK because this check is a no-op for single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersKoji(TestKoji):
@@ -1140,7 +1122,6 @@ class MultipleProvidersKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareSRPM(TestCompareSRPM):
@@ -1217,7 +1198,6 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareRPMs(TestCompareRPMs):
@@ -1294,7 +1274,6 @@ class MultipleProvidersCompareRPMs(TestCompareRPMs):
         # result is OK because this check is a no-op when comparing single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):
@@ -1370,4 +1349,3 @@ class MultipleProvidersCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"

--- a/test/test_rpmdeps_enhances.py
+++ b/test/test_rpmdeps_enhances.py
@@ -94,7 +94,6 @@ class EnhancesCorrectRPMs(TestRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class EnhancesCorrectKoji(TestKoji):
@@ -106,7 +105,6 @@ class EnhancesCorrectKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Retaining Enhances dependency in rebase comparison (INFO)
@@ -147,7 +145,6 @@ class RetainingEnhancesCompareRPMs(TestCompareRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RetainingEnhancesCompareKoji(TestCompareKoji):
@@ -160,7 +157,6 @@ class RetainingEnhancesCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Gaining a new Enhances in a rebase comparison (INFO)
@@ -276,7 +272,6 @@ class ChangingEnhancesExpectedCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ChangingEnhancesExpectedCompareRPMs(TestCompareRPMs):
@@ -377,7 +372,6 @@ class MissingEpochEnhancesSRPM(TestSRPM):
         # the result is OK here because the Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochEnhancesRPMs(TestRPMs):
@@ -409,7 +403,6 @@ class MissingEpochEnhancesRPMs(TestRPMs):
         # doesn't fail
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochEnhancesKoji(TestKoji):
@@ -438,7 +431,6 @@ class MissingEpochEnhancesKoji(TestKoji):
         # result is OK for Enhances weak dep; Epoch check is for Provides/Requires pairs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochEnhancesCompareSRPM(TestCompareSRPM):
@@ -477,7 +469,6 @@ class MissingEpochEnhancesCompareSRPM(TestCompareSRPM):
         # this is 'OK' because the missing Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochEnhancesCompareRPMs(TestCompareRPMs):
@@ -517,7 +508,6 @@ class MissingEpochEnhancesCompareRPMs(TestCompareRPMs):
         # entire collection of RPMs, it does it iteratively
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochEnhancesCompareKoji(TestCompareKoji):
@@ -556,7 +546,6 @@ class MissingEpochEnhancesCompareKoji(TestCompareKoji):
         # result is OK for Enhances weak dep; Epoch check is for Provides/Requires pairs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Missing Epoch prefix on rebase compare (INFO)
@@ -596,7 +585,6 @@ class MissingEpochEnhancesRebaseCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochEnhancesRebaseCompareRPMs(TestCompareRPMs):
@@ -687,7 +675,6 @@ class UnexpandedMacroEnhancesSRPM(TestSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroEnhancesRPMs(TestRPMs):
@@ -728,7 +715,6 @@ class UnexpandedMacroEnhancesCompareSRPM(TestCompareSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroEnhancesCompareRPMs(TestCompareRPMs):
@@ -795,7 +781,6 @@ class MissingExplicitEnhancesSRPM(TestSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitEnhancesRPMs(TestRPMs):
@@ -834,7 +819,6 @@ class MissingExplicitEnhancesRPMs(TestRPMs):
         # looking at a single RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitEnhancesKoji(TestKoji):
@@ -931,7 +915,6 @@ class MissingExplicitEnhancesCompareSRPM(TestCompareSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitEnhancesCompareRPMs(TestCompareRPMs):
@@ -991,7 +974,6 @@ class MissingExplicitEnhancesCompareRPMs(TestCompareRPMs):
         # RPM comparisons
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitEnhancesCompareKoji(TestCompareKoji):
@@ -1101,7 +1083,6 @@ class MultipleProvidersSRPM(TestSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersRPMs(TestRPMs):
@@ -1151,7 +1132,6 @@ class MultipleProvidersRPMs(TestRPMs):
         # result is OK because this check is a no-op for single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersKoji(TestKoji):
@@ -1200,7 +1180,6 @@ class MultipleProvidersKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareSRPM(TestCompareSRPM):
@@ -1278,7 +1257,6 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareRPMs(TestCompareRPMs):
@@ -1356,7 +1334,6 @@ class MultipleProvidersCompareRPMs(TestCompareRPMs):
         # result is OK because this check is a no-op when comparing single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):
@@ -1433,4 +1410,3 @@ class MultipleProvidersCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"

--- a/test/test_rpmdeps_obsoletes.py
+++ b/test/test_rpmdeps_obsoletes.py
@@ -80,7 +80,6 @@ class ObsoletesCorrectRPMs(TestRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ObsoletesCorrectKoji(TestKoji):
@@ -91,7 +90,6 @@ class ObsoletesCorrectKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Retaining Obsoletes dependency in rebase comparison (INFO)
@@ -129,7 +127,6 @@ class RetainingObsoletesCompareRPMs(TestCompareRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RetainingObsoletesCompareKoji(TestCompareKoji):
@@ -141,7 +138,6 @@ class RetainingObsoletesCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Gaining a new Obsoletes in a rebase comparison (INFO)
@@ -248,7 +244,6 @@ class ChangingObsoletesExpectedCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ChangingObsoletesExpectedCompareRPMs(TestCompareRPMs):
@@ -342,7 +337,6 @@ class MissingEpochObsoletesSRPM(TestSRPM):
         # the result is OK here because the Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochObsoletesRPMs(TestRPMs):
@@ -373,7 +367,6 @@ class MissingEpochObsoletesRPMs(TestRPMs):
         # doesn't fail
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochObsoletesKoji(TestKoji):
@@ -438,7 +431,6 @@ class MissingEpochObsoletesCompareSRPM(TestCompareSRPM):
         # this is 'OK' because the missing Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochObsoletesCompareRPMs(TestCompareRPMs):
@@ -477,7 +469,6 @@ class MissingEpochObsoletesCompareRPMs(TestCompareRPMs):
         # entire collection of RPMs, it does it iteratively
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochObsoletesCompareKoji(TestCompareKoji):
@@ -553,7 +544,6 @@ class MissingEpochObsoletesRebaseCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochObsoletesRebaseCompareRPMs(TestCompareRPMs):
@@ -641,7 +631,6 @@ class UnexpandedMacroObsoletesSRPM(TestSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroObsoletesRPMs(TestRPMs):
@@ -679,7 +668,6 @@ class UnexpandedMacroObsoletesCompareSRPM(TestCompareSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroObsoletesCompareRPMs(TestCompareRPMs):
@@ -743,7 +731,6 @@ class MissingExplicitObsoletesSRPM(TestSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitObsoletesRPMs(TestRPMs):
@@ -781,7 +768,6 @@ class MissingExplicitObsoletesRPMs(TestRPMs):
         # looking at a single RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitObsoletesKoji(TestKoji):
@@ -876,7 +862,6 @@ class MissingExplicitObsoletesCompareSRPM(TestCompareSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitObsoletesCompareRPMs(TestCompareRPMs):
@@ -935,7 +920,6 @@ class MissingExplicitObsoletesCompareRPMs(TestCompareRPMs):
         # RPM comparisons
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitObsoletesCompareKoji(TestCompareKoji):
@@ -1043,7 +1027,6 @@ class MultipleProvidersSRPM(TestSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersRPMs(TestRPMs):
@@ -1092,7 +1075,6 @@ class MultipleProvidersRPMs(TestRPMs):
         # result is OK because this check is a no-op for single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersKoji(TestKoji):
@@ -1140,7 +1122,6 @@ class MultipleProvidersKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareSRPM(TestCompareSRPM):
@@ -1217,7 +1198,6 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareRPMs(TestCompareRPMs):
@@ -1294,7 +1274,6 @@ class MultipleProvidersCompareRPMs(TestCompareRPMs):
         # result is OK because this check is a no-op when comparing single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):
@@ -1370,4 +1349,3 @@ class MultipleProvidersCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"

--- a/test/test_rpmdeps_provides.py
+++ b/test/test_rpmdeps_provides.py
@@ -80,7 +80,6 @@ class ProvidesCorrectRPMs(TestRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ProvidesCorrectKoji(TestKoji):
@@ -91,7 +90,6 @@ class ProvidesCorrectKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Retaining Provides dependency in rebase comparison (INFO)
@@ -129,7 +127,6 @@ class RetainingProvidesCompareRPMs(TestCompareRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RetainingProvidesCompareKoji(TestCompareKoji):
@@ -141,7 +138,6 @@ class RetainingProvidesCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Gaining a new Provides in a rebase comparison (INFO)
@@ -248,7 +244,6 @@ class ChangingProvidesExpectedCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ChangingProvidesExpectedCompareRPMs(TestCompareRPMs):
@@ -342,7 +337,6 @@ class MissingEpochProvidesSRPM(TestSRPM):
         # the result is OK here because the Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochProvidesRPMs(TestRPMs):
@@ -373,7 +367,6 @@ class MissingEpochProvidesRPMs(TestRPMs):
         # doesn't fail
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochProvidesKoji(TestKoji):
@@ -438,7 +431,6 @@ class MissingEpochProvidesCompareSRPM(TestCompareSRPM):
         # this is 'OK' because the missing Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochProvidesCompareRPMs(TestCompareRPMs):
@@ -477,7 +469,6 @@ class MissingEpochProvidesCompareRPMs(TestCompareRPMs):
         # entire collection of RPMs, it does it iteratively
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochProvidesCompareKoji(TestCompareKoji):
@@ -553,7 +544,6 @@ class MissingEpochProvidesRebaseCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochProvidesRebaseCompareRPMs(TestCompareRPMs):
@@ -641,7 +631,6 @@ class UnexpandedMacroProvidesSRPM(TestSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroProvidesRPMs(TestRPMs):
@@ -679,7 +668,6 @@ class UnexpandedMacroProvidesCompareSRPM(TestCompareSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroProvidesCompareRPMs(TestCompareRPMs):
@@ -743,7 +731,6 @@ class MissingExplicitProvidesSRPM(TestSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitProvidesRPMs(TestRPMs):
@@ -781,7 +768,6 @@ class MissingExplicitProvidesRPMs(TestRPMs):
         # looking at a single RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitProvidesKoji(TestKoji):
@@ -876,7 +862,6 @@ class MissingExplicitProvidesCompareSRPM(TestCompareSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitProvidesCompareRPMs(TestCompareRPMs):
@@ -935,7 +920,6 @@ class MissingExplicitProvidesCompareRPMs(TestCompareRPMs):
         # RPM comparisons
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitProvidesCompareKoji(TestCompareKoji):
@@ -1043,7 +1027,6 @@ class MultipleProvidersSRPM(TestSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersRPMs(TestRPMs):
@@ -1092,7 +1075,6 @@ class MultipleProvidersRPMs(TestRPMs):
         # result is OK because this check is a no-op for single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersKoji(TestKoji):
@@ -1140,7 +1122,6 @@ class MultipleProvidersKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareSRPM(TestCompareSRPM):
@@ -1217,7 +1198,6 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareRPMs(TestCompareRPMs):
@@ -1294,7 +1274,6 @@ class MultipleProvidersCompareRPMs(TestCompareRPMs):
         # result is OK because this check is a no-op when comparing single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):
@@ -1370,4 +1349,3 @@ class MultipleProvidersCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"

--- a/test/test_rpmdeps_recommends.py
+++ b/test/test_rpmdeps_recommends.py
@@ -94,7 +94,6 @@ class RecommendsCorrectRPMs(TestRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RecommendsCorrectKoji(TestKoji):
@@ -106,7 +105,6 @@ class RecommendsCorrectKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Retaining Recommends dependency in rebase comparison (INFO)
@@ -147,7 +145,6 @@ class RetainingRecommendsCompareRPMs(TestCompareRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RetainingRecommendsCompareKoji(TestCompareKoji):
@@ -160,7 +157,6 @@ class RetainingRecommendsCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Gaining a new Recommends in a rebase comparison (INFO)
@@ -276,7 +272,6 @@ class ChangingRecommendsExpectedCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ChangingRecommendsExpectedCompareRPMs(TestCompareRPMs):
@@ -377,7 +372,6 @@ class MissingEpochRecommendsSRPM(TestSRPM):
         # the result is OK here because the Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRecommendsRPMs(TestRPMs):
@@ -409,7 +403,6 @@ class MissingEpochRecommendsRPMs(TestRPMs):
         # doesn't fail
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRecommendsKoji(TestKoji):
@@ -438,7 +431,6 @@ class MissingEpochRecommendsKoji(TestKoji):
         # result is OK for Recommends weak dep; Epoch check is for Provides/Requires pairs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRecommendsCompareSRPM(TestCompareSRPM):
@@ -477,7 +469,6 @@ class MissingEpochRecommendsCompareSRPM(TestCompareSRPM):
         # this is 'OK' because the missing Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRecommendsCompareRPMs(TestCompareRPMs):
@@ -517,7 +508,6 @@ class MissingEpochRecommendsCompareRPMs(TestCompareRPMs):
         # entire collection of RPMs, it does it iteratively
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRecommendsCompareKoji(TestCompareKoji):
@@ -556,7 +546,6 @@ class MissingEpochRecommendsCompareKoji(TestCompareKoji):
         # result is OK for Recommends weak dep; Epoch check is for Provides/Requires pairs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Missing Epoch prefix on rebase compare (INFO)
@@ -596,7 +585,6 @@ class MissingEpochRecommendsRebaseCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRecommendsRebaseCompareRPMs(TestCompareRPMs):
@@ -686,7 +674,6 @@ class UnexpandedMacroRecommendsSRPM(TestSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroRecommendsRPMs(TestRPMs):
@@ -724,7 +711,6 @@ class UnexpandedMacroRecommendsCompareSRPM(TestCompareSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroRecommendsCompareRPMs(TestCompareRPMs):
@@ -789,7 +775,6 @@ class MissingExplicitRecommendsSRPM(TestSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitRecommendsRPMs(TestRPMs):
@@ -828,7 +813,6 @@ class MissingExplicitRecommendsRPMs(TestRPMs):
         # looking at a single RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitRecommendsKoji(TestKoji):
@@ -925,7 +909,6 @@ class MissingExplicitRecommendsCompareSRPM(TestCompareSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitRecommendsCompareRPMs(TestCompareRPMs):
@@ -985,7 +968,6 @@ class MissingExplicitRecommendsCompareRPMs(TestCompareRPMs):
         # RPM comparisons
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitRecommendsCompareKoji(TestCompareKoji):
@@ -1095,7 +1077,6 @@ class MultipleProvidersSRPM(TestSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersRPMs(TestRPMs):
@@ -1145,7 +1126,6 @@ class MultipleProvidersRPMs(TestRPMs):
         # result is OK because this check is a no-op for single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersKoji(TestKoji):
@@ -1194,7 +1174,6 @@ class MultipleProvidersKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareSRPM(TestCompareSRPM):
@@ -1272,7 +1251,6 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareRPMs(TestCompareRPMs):
@@ -1350,7 +1328,6 @@ class MultipleProvidersCompareRPMs(TestCompareRPMs):
         # result is OK because this check is a no-op when comparing single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):
@@ -1427,4 +1404,3 @@ class MultipleProvidersCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"

--- a/test/test_rpmdeps_requires.py
+++ b/test/test_rpmdeps_requires.py
@@ -80,7 +80,6 @@ class RequiresCorrectSRPM(TestSRPM):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RequiresCorrectRPMs(TestRPMs):
@@ -91,7 +90,6 @@ class RequiresCorrectRPMs(TestRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RequiresCorrectKoji(TestKoji):
@@ -102,7 +100,6 @@ class RequiresCorrectKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Retaining Requires dependency in rebase comparison (INFO)
@@ -152,7 +149,6 @@ class RetainingRequiresCompareSRPM(TestCompareSRPM):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RetainingRequiresCompareRPMs(TestCompareRPMs):
@@ -164,7 +160,6 @@ class RetainingRequiresCompareRPMs(TestCompareRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RetainingRequiresCompareKoji(TestCompareKoji):
@@ -176,7 +171,6 @@ class RetainingRequiresCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Gaining a new Requires in a rebase comparison (INFO)
@@ -330,7 +324,6 @@ class ChangingRequiresExpectedCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ChangingRequiresExpectedCompareRPMs(TestCompareRPMs):
@@ -446,7 +439,6 @@ class MissingEpochRequiresSRPM(TestSRPM):
         # the result is OK here because the Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRequiresRPMs(TestRPMs):
@@ -477,7 +469,6 @@ class MissingEpochRequiresRPMs(TestRPMs):
         # doesn't fail
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRequiresKoji(TestKoji):
@@ -506,7 +497,6 @@ class MissingEpochRequiresKoji(TestKoji):
 
         if on_alt_linux:
             self.result = "OK"
-            self.waiver_auth = "Not Waivable"
         else:
             self.result = "BAD"
             self.waiver_auth = "Anyone"
@@ -547,7 +537,6 @@ class MissingEpochRequiresCompareSRPM(TestCompareSRPM):
         # this is 'OK' because the missing Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRequiresCompareRPMs(TestCompareRPMs):
@@ -586,7 +575,6 @@ class MissingEpochRequiresCompareRPMs(TestCompareRPMs):
         # entire collection of RPMs, it does it iteratively
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRequiresCompareKoji(TestCompareKoji):
@@ -625,7 +613,6 @@ class MissingEpochRequiresCompareKoji(TestCompareKoji):
 
         if on_alt_linux:
             self.result = "OK"
-            self.waiver_auth = "Not Waivable"
         else:
             self.result = "BAD"
             self.waiver_auth = "Anyone"
@@ -667,7 +654,6 @@ class MissingEpochRequiresRebaseCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochRequiresRebaseCompareRPMs(TestCompareRPMs):
@@ -755,7 +741,6 @@ class UnexpandedMacroRequiresSRPM(TestSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroRequiresRPMs(TestRPMs):
@@ -793,7 +778,6 @@ class UnexpandedMacroRequiresCompareSRPM(TestCompareSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroRequiresCompareRPMs(TestCompareRPMs):
@@ -857,7 +841,6 @@ class MissingExplicitRequiresSRPM(TestSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitRequiresRPMs(TestRPMs):
@@ -895,7 +878,6 @@ class MissingExplicitRequiresRPMs(TestRPMs):
         # looking at a single RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitRequiresKoji(TestKoji):
@@ -990,7 +972,6 @@ class MissingExplicitRequiresCompareSRPM(TestCompareSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitRequiresCompareRPMs(TestCompareRPMs):
@@ -1049,7 +1030,6 @@ class MissingExplicitRequiresCompareRPMs(TestCompareRPMs):
         # RPM comparisons
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitRequiresCompareKoji(TestCompareKoji):
@@ -1157,7 +1137,6 @@ class MultipleProvidersSRPM(TestSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersRPMs(TestRPMs):
@@ -1206,7 +1185,6 @@ class MultipleProvidersRPMs(TestRPMs):
         # result is OK because this check is a no-op for single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersKoji(TestKoji):
@@ -1331,7 +1309,6 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareRPMs(TestCompareRPMs):
@@ -1408,7 +1385,6 @@ class MultipleProvidersCompareRPMs(TestCompareRPMs):
         # result is OK because this check is a no-op when comparing single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):

--- a/test/test_rpmdeps_suggests.py
+++ b/test/test_rpmdeps_suggests.py
@@ -94,7 +94,6 @@ class SuggestsCorrectRPMs(TestRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SuggestsCorrectKoji(TestKoji):
@@ -106,7 +105,6 @@ class SuggestsCorrectKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Retaining Suggests dependency in rebase comparison (INFO)
@@ -147,7 +145,6 @@ class RetainingSuggestsCompareRPMs(TestCompareRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RetainingSuggestsCompareKoji(TestCompareKoji):
@@ -160,7 +157,6 @@ class RetainingSuggestsCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Gaining a new Suggests in a rebase comparison (INFO)
@@ -276,7 +272,6 @@ class ChangingSuggestsExpectedCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ChangingSuggestsExpectedCompareRPMs(TestCompareRPMs):
@@ -377,7 +372,6 @@ class MissingEpochSuggestsSRPM(TestSRPM):
         # the result is OK here because the Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSuggestsRPMs(TestRPMs):
@@ -409,7 +403,6 @@ class MissingEpochSuggestsRPMs(TestRPMs):
         # doesn't fail
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSuggestsKoji(TestKoji):
@@ -438,7 +431,6 @@ class MissingEpochSuggestsKoji(TestKoji):
         # result is OK for Suggests weak dep; Epoch check is for Provides/Requires pairs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSuggestsCompareSRPM(TestCompareSRPM):
@@ -477,7 +469,6 @@ class MissingEpochSuggestsCompareSRPM(TestCompareSRPM):
         # this is 'OK' because the missing Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSuggestsCompareRPMs(TestCompareRPMs):
@@ -517,7 +508,6 @@ class MissingEpochSuggestsCompareRPMs(TestCompareRPMs):
         # entire collection of RPMs, it does it iteratively
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSuggestsCompareKoji(TestCompareKoji):
@@ -556,7 +546,6 @@ class MissingEpochSuggestsCompareKoji(TestCompareKoji):
         # result is OK for Suggests weak dep; Epoch check is for Provides/Requires pairs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Missing Epoch prefix on rebase compare (INFO)
@@ -596,7 +585,6 @@ class MissingEpochSuggestsRebaseCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSuggestsRebaseCompareRPMs(TestCompareRPMs):
@@ -687,7 +675,6 @@ class UnexpandedMacroSuggestsSRPM(TestSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroSuggestsRPMs(TestRPMs):
@@ -728,7 +715,6 @@ class UnexpandedMacroSuggestsCompareSRPM(TestCompareSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroSuggestsCompareRPMs(TestCompareRPMs):
@@ -795,7 +781,6 @@ class MissingExplicitSuggestsSRPM(TestSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitSuggestsRPMs(TestRPMs):
@@ -834,7 +819,6 @@ class MissingExplicitSuggestsRPMs(TestRPMs):
         # looking at a single RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitSuggestsKoji(TestKoji):
@@ -931,7 +915,6 @@ class MissingExplicitSuggestsCompareSRPM(TestCompareSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitSuggestsCompareRPMs(TestCompareRPMs):
@@ -991,7 +974,6 @@ class MissingExplicitSuggestsCompareRPMs(TestCompareRPMs):
         # RPM comparisons
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitSuggestsCompareKoji(TestCompareKoji):
@@ -1101,7 +1083,6 @@ class MultipleProvidersSRPM(TestSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersRPMs(TestRPMs):
@@ -1151,7 +1132,6 @@ class MultipleProvidersRPMs(TestRPMs):
         # result is OK because this check is a no-op for single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersKoji(TestKoji):
@@ -1200,7 +1180,6 @@ class MultipleProvidersKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareSRPM(TestCompareSRPM):
@@ -1278,7 +1257,6 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareRPMs(TestCompareRPMs):
@@ -1356,7 +1334,6 @@ class MultipleProvidersCompareRPMs(TestCompareRPMs):
         # result is OK because this check is a no-op when comparing single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):
@@ -1433,4 +1410,3 @@ class MultipleProvidersCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"

--- a/test/test_rpmdeps_supplements.py
+++ b/test/test_rpmdeps_supplements.py
@@ -94,7 +94,6 @@ class SupplementsCorrectRPMs(TestRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SupplementsCorrectKoji(TestKoji):
@@ -106,7 +105,6 @@ class SupplementsCorrectKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Retaining Supplements dependency in rebase comparison (INFO)
@@ -147,7 +145,6 @@ class RetainingSupplementsCompareRPMs(TestCompareRPMs):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RetainingSupplementsCompareKoji(TestCompareKoji):
@@ -160,7 +157,6 @@ class RetainingSupplementsCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Gaining a new Supplements in a rebase comparison (INFO)
@@ -276,7 +272,6 @@ class ChangingSupplementsExpectedCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ChangingSupplementsExpectedCompareRPMs(TestCompareRPMs):
@@ -377,7 +372,6 @@ class MissingEpochSupplementsSRPM(TestSRPM):
         # the result is OK here because the Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSupplementsRPMs(TestRPMs):
@@ -409,7 +403,6 @@ class MissingEpochSupplementsRPMs(TestRPMs):
         # doesn't fail
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSupplementsKoji(TestKoji):
@@ -438,7 +431,6 @@ class MissingEpochSupplementsKoji(TestKoji):
         # result is OK for Supplements weak dep; Epoch check is for Provides/Requires pairs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSupplementsCompareSRPM(TestCompareSRPM):
@@ -477,7 +469,6 @@ class MissingEpochSupplementsCompareSRPM(TestCompareSRPM):
         # this is 'OK' because the missing Epoch check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSupplementsCompareRPMs(TestCompareRPMs):
@@ -517,7 +508,6 @@ class MissingEpochSupplementsCompareRPMs(TestCompareRPMs):
         # entire collection of RPMs, it does it iteratively
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSupplementsCompareKoji(TestCompareKoji):
@@ -556,7 +546,6 @@ class MissingEpochSupplementsCompareKoji(TestCompareKoji):
         # result is OK for Supplements weak dep; Epoch check is for Provides/Requires pairs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Missing Epoch prefix on rebase compare (INFO)
@@ -596,7 +585,6 @@ class MissingEpochSupplementsRebaseCompareSRPM(TestCompareSRPM):
         # ok result because this is a source RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingEpochSupplementsRebaseCompareRPMs(TestCompareRPMs):
@@ -687,7 +675,6 @@ class UnexpandedMacroSupplementsSRPM(TestSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroSupplementsRPMs(TestRPMs):
@@ -728,7 +715,6 @@ class UnexpandedMacroSupplementsCompareSRPM(TestCompareSRPM):
         # this is OK because it's the SRPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class UnexpandedMacroSupplementsCompareRPMs(TestCompareRPMs):
@@ -795,7 +781,6 @@ class MissingExplicitSupplementsSRPM(TestSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitSupplementsRPMs(TestRPMs):
@@ -834,7 +819,6 @@ class MissingExplicitSupplementsRPMs(TestRPMs):
         # looking at a single RPM
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitSupplementsKoji(TestKoji):
@@ -931,7 +915,6 @@ class MissingExplicitSupplementsCompareSRPM(TestCompareSRPM):
         # result is OK because rpminspect can't report missing deps on SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitSupplementsCompareRPMs(TestCompareRPMs):
@@ -991,7 +974,6 @@ class MissingExplicitSupplementsCompareRPMs(TestCompareRPMs):
         # RPM comparisons
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MissingExplicitSupplementsCompareKoji(TestCompareKoji):
@@ -1101,7 +1083,6 @@ class MultipleProvidersSRPM(TestSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersRPMs(TestRPMs):
@@ -1151,7 +1132,6 @@ class MultipleProvidersRPMs(TestRPMs):
         # result is OK because this check is a no-op for single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersKoji(TestKoji):
@@ -1200,7 +1180,6 @@ class MultipleProvidersKoji(TestKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareSRPM(TestCompareSRPM):
@@ -1278,7 +1257,6 @@ class MultipleProvidersCompareSRPM(TestCompareSRPM):
         # result is OK because this check is a no-op for SRPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareRPMs(TestCompareRPMs):
@@ -1356,7 +1334,6 @@ class MultipleProvidersCompareRPMs(TestCompareRPMs):
         # result is OK because this check is a no-op when comparing single RPMs
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class MultipleProvidersCompareKoji(TestCompareKoji):
@@ -1433,4 +1410,3 @@ class MultipleProvidersCompareKoji(TestCompareKoji):
 
         self.inspection = "rpmdeps"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"

--- a/test/test_runpath.py
+++ b/test/test_runpath.py
@@ -35,7 +35,6 @@ class ValidRPATH1RPMs(TestRPMs):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH1Koji(TestKoji):
@@ -47,7 +46,6 @@ class ValidRPATH1Koji(TestKoji):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH1CompareRPMs(TestCompareRPMs):
@@ -59,7 +57,6 @@ class ValidRPATH1CompareRPMs(TestCompareRPMs):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH1CompareKoji(TestCompareKoji):
@@ -71,7 +68,6 @@ class ValidRPATH1CompareKoji(TestCompareKoji):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 ######################################################################
@@ -86,7 +82,6 @@ class ValidRPATH2RPMs(TestRPMs):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH2Koji(TestKoji):
@@ -98,7 +93,6 @@ class ValidRPATH2Koji(TestKoji):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH2CompareRPMs(TestCompareRPMs):
@@ -110,7 +104,6 @@ class ValidRPATH2CompareRPMs(TestCompareRPMs):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH2CompareKoji(TestCompareKoji):
@@ -122,7 +115,6 @@ class ValidRPATH2CompareKoji(TestCompareKoji):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 ###############################################################################################
@@ -192,7 +184,6 @@ class ValidRPATH4RPMs(TestRPMs):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH4Koji(TestKoji):
@@ -204,7 +195,6 @@ class ValidRPATH4Koji(TestKoji):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH4CompareRPMs(TestCompareRPMs):
@@ -218,7 +208,6 @@ class ValidRPATH4CompareRPMs(TestCompareRPMs):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH4CompareKoji(TestCompareKoji):
@@ -232,7 +221,6 @@ class ValidRPATH4CompareKoji(TestCompareKoji):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 ####################################################################################
@@ -249,7 +237,6 @@ class ValidRPATH5RPMs(TestRPMs):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH5Koji(TestKoji):
@@ -263,7 +250,6 @@ class ValidRPATH5Koji(TestKoji):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH5CompareRPMs(TestCompareRPMs):
@@ -277,7 +263,6 @@ class ValidRPATH5CompareRPMs(TestCompareRPMs):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class ValidRPATH5CompareKoji(TestCompareKoji):
@@ -291,7 +276,6 @@ class ValidRPATH5CompareKoji(TestCompareKoji):
 
         self.inspection = "runpath"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 ################################################################################################

--- a/test/test_securitypath.py
+++ b/test/test_securitypath.py
@@ -50,7 +50,6 @@ class SecuritySKIPFileAddedToSecurityPathCompareRPMs(TestCompareRPMs):
         )
         self.inspection = "addedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileAddedToSecurityPathCompareRPMs(TestCompareRPMs):
@@ -105,7 +104,6 @@ class SecuritySKIPFileAddedToSecurityPathCompareKoji(TestCompareKoji):
         )
         self.inspection = "addedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileAddedToSecurityPathCompareKoji(TestCompareKoji):
@@ -165,7 +163,6 @@ class SecuritySKIPFileRemovedFromSecurityPathCompareRPMs(TestCompareRPMs):
         )
         self.inspection = "addedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileRemovedFromSecurityPathCompareRPMs(TestCompareRPMs):
@@ -220,7 +217,6 @@ class SecuritySKIPFileRemovedFromSecurityPathCompareKoji(TestCompareKoji):
         )
         self.inspection = "addedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SecurityINFORMFileRemovedFromSecurityPathCompareKoji(TestCompareKoji):

--- a/test/test_shellsyntax.py
+++ b/test/test_shellsyntax.py
@@ -1535,6 +1535,7 @@ class BashExtglobWellFormedRPM(TestRPMs):
         )
         self.inspection = "shellsyntax"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class BashWellFormedKoji(TestKoji):
@@ -1584,6 +1585,7 @@ class BashExtglobWellFormedKoji(TestKoji):
         )
         self.inspection = "shellsyntax"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class BashWellFormedCompareRPMs(TestCompareRPMs):
@@ -1642,6 +1644,7 @@ class BashExtglobWellFormedCompareRPMs(TestCompareRPMs):
         )
         self.inspection = "shellsyntax"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class BashWellFormedCompareKoji(TestCompareKoji):
@@ -1700,6 +1703,7 @@ class BashExtglobWellFormedCompareKoji(TestCompareKoji):
         )
         self.inspection = "shellsyntax"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class BashWellMalformedCompareRPMs(TestCompareRPMs):

--- a/test/test_symlinks.py
+++ b/test/test_symlinks.py
@@ -61,7 +61,6 @@ class AbsoluteSymlinkExistsRPMs(TestRPMs):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class AbsoluteSymlinkExistsKoji(TestKoji):
@@ -78,7 +77,6 @@ class AbsoluteSymlinkExistsKoji(TestKoji):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class AbsoluteSymlinkExistsCompareRPMs(TestCompareRPMs):
@@ -97,7 +95,6 @@ class AbsoluteSymlinkExistsCompareRPMs(TestCompareRPMs):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class AbsoluteSymlinkExistsCompareKoji(TestCompareKoji):
@@ -116,7 +113,6 @@ class AbsoluteSymlinkExistsCompareKoji(TestCompareKoji):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Relative symlink with ../ exists (OK)
@@ -134,7 +130,6 @@ class RelativeSymlinkExistsParentDirRPMs(TestRPMs):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RelativeSymlinkExistsParentDirKoji(TestKoji):
@@ -151,7 +146,6 @@ class RelativeSymlinkExistsParentDirKoji(TestKoji):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RelativeSymlinkExistsParentDirCompareRPMs(TestCompareRPMs):
@@ -168,7 +162,6 @@ class RelativeSymlinkExistsParentDirCompareRPMs(TestCompareRPMs):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RelativeSymlinkExistsParentDirCompareKoji(TestCompareKoji):
@@ -185,7 +178,6 @@ class RelativeSymlinkExistsParentDirCompareKoji(TestCompareKoji):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Relative symlink in current directory exists (OK)
@@ -203,7 +195,6 @@ class RelativeSymlinkExistsCurrentDirRPMs(TestRPMs):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RelativeSymlinkExistsCurrentDirKoji(TestKoji):
@@ -220,7 +211,6 @@ class RelativeSymlinkExistsCurrentDirKoji(TestKoji):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RelativeSymlinkExistsCurrentDirCompareRPMs(TestCompareRPMs):
@@ -237,7 +227,6 @@ class RelativeSymlinkExistsCurrentDirCompareRPMs(TestCompareRPMs):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class RelativeSymlinkExistsCurrentDirCompareKoji(TestCompareKoji):
@@ -254,7 +243,6 @@ class RelativeSymlinkExistsCurrentDirCompareKoji(TestCompareKoji):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Symlink that exists spans subpackages (OK)
@@ -275,7 +263,6 @@ class SymlinkExistsMultiplePackagesRPMS(TestRPMs):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SymlinkExistsMultiplePackagesKoji(TestKoji):
@@ -295,7 +282,6 @@ class SymlinkExistsMultiplePackagesKoji(TestKoji):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SymlinkExistsMultiplePackagesCompareRPMs(TestCompareRPMs):
@@ -315,7 +301,6 @@ class SymlinkExistsMultiplePackagesCompareRPMs(TestCompareRPMs):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class SymlinkExistsMultiplePackagesCompareKoji(TestCompareKoji):
@@ -335,7 +320,6 @@ class SymlinkExistsMultiplePackagesCompareKoji(TestCompareKoji):
 
         self.inspection = "symlinks"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # Absolute symlink is dangling (VERIFY)

--- a/test/test_virus.py
+++ b/test/test_virus.py
@@ -34,7 +34,6 @@ class HasNoVirusSRPM(TestSRPM):
 
         self.inspection = "virus"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 @timeout_decorator.timeout(500)
@@ -48,7 +47,6 @@ class HasNoVirusRPMs(TestRPMs):
 
         self.inspection = "virus"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 @timeout_decorator.timeout(500)
@@ -62,7 +60,6 @@ class HasNoVirusKoji(TestKoji):
 
         self.inspection = "virus"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 @timeout_decorator.timeout(500)
@@ -79,7 +76,6 @@ class HasNoVirusCompareSRPM(TestCompareSRPM):
 
         self.inspection = "virus"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 @timeout_decorator.timeout(500)
@@ -96,7 +92,6 @@ class HasNoVirusCompareRPMs(TestCompareRPMs):
 
         self.inspection = "virus"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 @timeout_decorator.timeout(500)
@@ -113,7 +108,6 @@ class HasNoVirusCompareKoji(TestCompareKoji):
 
         self.inspection = "virus"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 # package that contains a virus (BAD)


### PR DESCRIPTION
Inspections that are disabled by the config file or by command line option are now reported in both verbose mode output as well as gaining a "SKIP" result entry.  This should make it more obvious that an inspection was disabled when looking at the results.

Fixes: #924