### PR TITLE
[lib] Drop ABI_HEADERS_DIR1 and ABI_HEADERS_DIR2

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -341,22 +341,6 @@
 #define ABI_DEBUG_INFO_DIR2 "--d2"
 
 /**
- * @def ABI_HEADERS_DIR1
- *
- * The command line option for abidiff(1) to specify the location of
- * public headers for the files in the before build.
- */
-#define ABI_HEADERS_DIR1 "--hd1"
-
-/**
- * @def ABI_HEADERS_DIR2
- *
- * The command line option for abidiff(1) to specify the location of
- * public headers for the files in the after build.
- */
-#define ABI_HEADERS_DIR2 "--hd2"
-
-/**
  * @def KMIDIFF_CMD
  *
  * Executable providing kmidiff(1), the Kernel Module Interface

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -157,12 +157,6 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     assert(cmd != NULL);
     free(tmp);
 
-    /* header dir args */
-/*
-    cmd = add_abidiff_arg(cmd, headers_dir1_table, arch, ABI_HEADERS_DIR1);
-    cmd = add_abidiff_arg(cmd, headers_dir2_table, arch, ABI_HEADERS_DIR2);
-*/
-
     /* the before and after builds */
     cmd = strappend(cmd, " ", file->peer_file->fullpath, " ", file->fullpath, NULL);
 


### PR DESCRIPTION
We do not need to pass --hd1 and --hd2 to abidiff as it can figure it out.

Signed-off-by: David Cantrell <dcantrell@redhat.com>