### PR TITLE
Fix unexpected removefiles findings reporting for security_path_prefix files

### DIFF
--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -107,7 +107,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 entry->data++;
             }
 
-            if (strprefix(entry->data, file->localpath)) {
+            if (strprefix(file->localpath, entry->data)) {
                 params.waiverauth = WAIVABLE_BY_SECURITY;
                 params.verb = VERB_FAILED;
                 break;
@@ -133,7 +133,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         } else {
             if (sentry) {
                 params.waiverauth = WAIVABLE_BY_SECURITY;
-            } else {
+            } else if ((sentry == NULL) && (params.waiverauth == NULL_WAIVERAUTH)) {
                 params.waiverauth = WAIVABLE_BY_ANYONE;
             }
 

--- a/test/test_removedfiles.py
+++ b/test/test_removedfiles.py
@@ -41,7 +41,6 @@ class FileNoRemovedRPMs(TestCompareRPMs):
 
         self.inspection = "removedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class FileNoRemovedKoji(TestCompareKoji):
@@ -62,7 +61,6 @@ class FileNoRemovedKoji(TestCompareKoji):
 
         self.inspection = "removedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"
 
 
 class FileRemovedRPMs(TestCompareRPMs):
@@ -96,8 +94,8 @@ class FileRemovedSecurityRPMs(TestCompareRPMs):
         )
 
         self.inspection = "removedfiles"
-        self.result = "OK"
-        self.waiver_auth = "WAIVABLE_BY_SECURITY"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
 
 
 class FileRemovedKoji(TestCompareKoji):
@@ -114,4 +112,3 @@ class FileRemovedKoji(TestCompareKoji):
 
         self.inspection = "removedfiles"
         self.result = "OK"
-        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
These should have been reported as RESULT_BAD with WAIVABLE_BY_SECURITY, but instead they were RESULT_BAD with WAIVABLE_BY_ANYONE.

Also enable and fix the test_removedfiles.py test cases.