### PR TITLE
[lib] Allow profile specification by full path or basename

### DIFF
--- a/src/rpminspect.1
+++ b/src/rpminspect.1
@@ -81,10 +81,13 @@ main configuration is loaded, then if you specify a profile name
 rpminspect will load that configuration file and any values specified
 will override what came from the default configuration file.  Think of
 the main configuration file as the common one and profile
-configuration files are optional overlays.  Profiles must be in
-the 'profiledir' directory and follow the naming scheme of
-PROFILE.yaml.  It is common for vendors to provide a set of profiles
-in addition to a main configuration file.
+configuration files are optional overlays.  In the data package,
+profiles should be of the form PROFILENAME.yaml and exist in
+the 'profiledir' subdirectory.  If you specify a PROFILENAME to this
+option, rpminspect will search for the profile in 'profiledir'.  You
+can also pass a PATH to this option and rpminspect will attempt to
+load the profile from that file.  It is common for vendors to provide
+a set of profiles in addition to a main configuration file.
 .RS
 .PP
 The format of a profile configuration file is the same as the


### PR DESCRIPTION
Some users specify a profile as a full path to the file rather than the basename (minus the .yaml extension) in profiledir.  This is understandable considering how the -c option works.  The origin of rpminspect profiles is from early in its creation where I thought it would make sense to have profiles that describe the rpminspect rules for large categories of software.  That really didn't take off as I thought it would, but the support is still there.

This patch allows the -p option to find a profile by basename in the profiledir as well as allowing the user to specify a full path to a profile.

I have also updated the man page to explain how the options work.  In all cases, the -c option is required and rpminspect will fail if you do not provide a configuration file with the -c option.

Fixes: #940

Signed-off-by: David Cantrell <dcantrell@redhat.com>