### PR TITLE
Add .mailmap to consolidate contributors and update AUTHORS.md

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Serhii Turivnyi <sturivny@redhat.com> sergturi <turivniy@gmail.com>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -31,6 +31,8 @@ Contributors
 
 - Jim Bair <jbair@redhat.com>
 
+- Martin Pitt <martin@piware.de>
+
 - Michal Srb <michal@redhat.com>
 
 - Miro Hrončok <miro@hroncok.cz>

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ authors:
 	echo "Contributors" >> AUTHORS.md
 	echo "============" >> AUTHORS.md
 	echo >> AUTHORS.md
-	git log --pretty="%an <%ae>" | sort -u | grep -vE "$(PRIMARY_AUTHORS)" | sed -e 's|^|- |g' | sed G >> AUTHORS.md
+	git log --pretty="%aN <%aE>" | sort -u | grep -vE "$(PRIMARY_AUTHORS)" | sed -e 's|^|- |g' | sed G >> AUTHORS.md
 	head -n $$(($$(wc -l < AUTHORS.md) - 1)) AUTHORS.md > AUTHORS.md.new
 	mv AUTHORS.md.new AUTHORS.md
 


### PR DESCRIPTION
This is something I've been meaning to do for a while.  Add a .mailmap file to consolidate committers who have used multiple addresses over time.  Then modify the 'make authors' target to respect that so that I can just type 'make authors' to update the AUTHORS.md file.