### PR TITLE
[lib] Check /data/static_context in modulemd.txt in 'modularity'

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -259,6 +259,27 @@ metadata:
         - .localdomain
         - .example.com
 
+modularity:
+    # This block only applies to RPM-based modules, something you will
+    # find in Fedora Linux and Fedora-derived Linux distributions.
+    # Roughly speaking they are collections of RPMs necessary for a
+    # specific purpose (e.g., a web application server) and contain
+    # additional metadata.  For more information, see:
+    #
+    # https://docs.fedoraproject.org/en-US/modularity/
+    #
+    # rpminspect can check RPMs that are part of a module since module
+    # builds can come from Koji.
+
+    # Should modules carry a "static_context: true" setting?  The
+    # possible options that rpminspect can check and report on are:
+    #
+    #     required     RPMs in modules must have setting
+    #     forbidden    RPMs in modules must not have the setting
+    #     recommend    RPMs do not need it, but if missing then rpminspect
+    #                  will recommend its addition.
+    #static_context: required
+
 elf:
     # File paths to include in or exclude from specific tests. Each
     # value is a POSIX extended regular expression (man 7

--- a/include/constants.h
+++ b/include/constants.h
@@ -876,6 +876,28 @@
 
 /** @} */
 
+/**
+ * @defgroup Modularity constants.
+ *
+ * @{
+ */
+
+/**
+ * @def MODULEMD_FILENAME
+ *
+ * The name of the module metadata file.
+ */
+#define MODULEMD_FILENAME "modulemd.txt"
+
+/**
+ * @def MODULEMD_ARCH_FILENAME
+ *
+ * The filename pattern for architecture-specific modulemd files.
+ */
+#define MODULEMD_ARCH_FILENAME "modulemd.%s.txt"
+
+/** @} */
+
 /** @} */
 
 #endif

--- a/include/init.h
+++ b/include/init.h
@@ -90,6 +90,7 @@
 #define SECTION_SECURITY_PATH_PREFIX     "security_path_prefix"
 #define SECTION_SHELLS                   "shells"
 #define SECTION_SIZE_THRESHOLD           "size_threshold"
+#define SECTION_STATIC_CONTEXT           "static_context"
 #define SECTION_SUGGESTS                 "suggests"
 #define SECTION_SUPPLEMENTS              "supplements"
 #define SECTION_SUPPRESSION_FILE         "suppression_file"
@@ -110,5 +111,8 @@
 #define TOKEN_INFO_ONLY2                 "info_only"
 #define TOKEN_ON                         "on"
 #define TOKEN_OFF                        "off"
+#define TOKEN_REQUIRED                   "required"
+#define TOKEN_FORBIDDEN                  "forbidden"
+#define TOKEN_RECOMMEND                  "recommend"
 
 #endif

--- a/include/results.h
+++ b/include/results.h
@@ -266,6 +266,13 @@
  */
 #define REMEDY_MODULARITY _("This package is part of a module but is missing the %{modularitylabel} header tag.  Add this as a %define in the spec file and rebuild.")
 
+/**
+ * @def REMEDY_MODULARITY_STATIC_CONTEXT
+ *
+ * How to address problems with /data/static_context in module metadata.
+ */
+#define REMEDY_MODULARITY_STATIC_CONTEXT _("This build either contains a valid or invalid /data/static_context setting.  Refer to the module rules for the product you are building to determine what the setting should be.  The rpminspect configuration settings also set the rules determining if the /data/static_context setting is required, forbidden, or recommend.")
+
 /** @} */
 
 /**

--- a/include/types.h
+++ b/include/types.h
@@ -333,6 +333,14 @@ typedef struct _caps_entry_t {
 
 typedef TAILQ_HEAD(caps_entry_s, _caps_entry_t) caps_t;
 
+/* Modularity static context types */
+typedef enum _static_context_t {
+    STATIC_CONTEXT_NULL = 0,
+    STATIC_CONTEXT_REQUIRED = 1,
+    STATIC_CONTEXT_FORBIDDEN = 2,
+    STATIC_CONTEXT_RECOMMEND = 3
+} static_context_t;
+
 /* Spec filename matching types */
 typedef enum _specname_match_t {
     MATCH_NULL = 0,
@@ -498,6 +506,9 @@ struct rpminspect {
                                 * from certain package strings.
                                 */
     char *vendor;              /* Required vendor string */
+
+    /* Modularity values */
+    static_context_t modularity_static_context;
 
     /* Required subdomain for buildhosts -- multiple subdomains allowed */
     string_list_t *buildhost_subdomain;
@@ -703,6 +714,10 @@ struct rpminspect {
     char *before_rel;               /* before Release w/o %{?dist} */
     char *after_rel;                /* after Release w/o ${?dist} */
     int rebase_build;               /* indicates if this is a rebased build */
+
+    /* specific to module builds */
+    bool before_static_context;
+    bool after_static_context;
 
     /* local disk space requirements */
     unsigned long int download_size;

--- a/lib/init.c
+++ b/lib/init.c
@@ -151,7 +151,8 @@ enum {
     BLOCK_ENVIRONMENT = 72,
     BLOCK_LICENSEDB = 73,
     BLOCK_DEBUGINFO = 74,
-    BLOCK_PATCH_AUTOMACROS = 75
+    BLOCK_PATCH_AUTOMACROS = 75,
+    BLOCK_MODULARITY = 76
 };
 
 static int add_regex(const char *pattern, regex_t **regex_out)
@@ -762,6 +763,9 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     } else if (!strcmp(key, NAME_METADATA)) {
                         block = BLOCK_NULL;
                         group = BLOCK_METADATA;
+                    } else if (!strcmp(key, NAME_MODULARITY)) {
+                        block = BLOCK_MODULARITY;
+                        group = BLOCK_NULL;
                     } else if (!strcmp(key, NAME_ELF)) {
                         block = BLOCK_NULL;
                         group = BLOCK_ELF;
@@ -1172,6 +1176,19 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             } else {
                                 ri->specprimary = PRIMARY_NAME;
                                 warnx(_("*** unknown specname primary setting '%s', defaulting to 'name'"), t);
+                            }
+                        }
+                    } else if (block == BLOCK_MODULARITY) {
+                        if (!strcmp(key, SECTION_STATIC_CONTEXT)) {
+                            if (!strcasecmp(t, TOKEN_REQUIRED)) {
+                                ri->modularity_static_context = STATIC_CONTEXT_REQUIRED;
+                            } else if (!strcasecmp(t, TOKEN_FORBIDDEN)) {
+                                ri->modularity_static_context = STATIC_CONTEXT_FORBIDDEN;
+                            } else if (!strcasecmp(t, TOKEN_RECOMMEND)) {
+                                ri->modularity_static_context = STATIC_CONTEXT_RECOMMEND;
+                            } else {
+                                ri->modularity_static_context = STATIC_CONTEXT_NULL;
+                                warnx(_("*** unknown modularity static context settings '%s'"), t);
                             }
                         }
                     } else if (group == BLOCK_ELF) {

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -21,10 +21,218 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <ftw.h>
 #include <errno.h>
+#include <err.h>
 #include <assert.h>
+#include <yaml.h>
 
 #include "rpminspect.h"
+
+/* Globals */
+static bool static_context = false;
+
+/*
+ * Called by nftw() to find and read /data/static_context from modulemd.txt
+ */
+static int read_modulemd(const char *fpath, __attribute__((unused)) const struct stat *sb, int tflag, __attribute__((unused)) struct FTW *ftwbuf)
+{
+    int r = 0;
+    char *bn = NULL;
+    yaml_parser_t parser;
+    yaml_token_t token;
+    char *value = NULL;
+    int in_data = 0;
+    FILE *fp = NULL;
+
+    if (tflag != FTW_F) {
+        return 0;
+    }
+
+    bn = basename(fpath);
+    static_context = false;
+
+    /* try to read this file */
+    if (!strcmp(bn, MODULEMD_FILENAME)) {
+        /* prepare a YAML parser */
+        if (!yaml_parser_initialize(&parser)) {
+            warn("yaml_parser_initializer");
+        }
+
+        /* open the modulemd file */
+        if ((fp = fopen(fpath, "r")) == NULL) {
+            err(RI_PROGRAM_ERROR, "fopen");
+        }
+
+        /* tell the YAML parser to read the modulemd file */
+        yaml_parser_set_input_file(&parser, fp);
+
+        /* Loop over the YAML file looking for /data/static_context */
+        do {
+            if (yaml_parser_scan(&parser, &token) == 0) {
+                warnx(_("ignoring malformed module metadata file: %s"), fpath);
+                return -1;
+            }
+
+            value = (char *) token.data.scalar.value;
+
+            switch (token.type) {
+                case YAML_SCALAR_TOKEN:
+                    if ((in_data == 0) && !strcmp(value, "data")) {
+                        in_data++;
+                    } else if ((in_data == 1) && !strcmp(value, "static_context")) {
+                        in_data++;
+                    } else if (in_data == 2) {
+                        if (!strcasecmp(value, "true")) {
+                            static_context = true;
+                        }
+                    }
+
+                    break;
+                case YAML_BLOCK_END_TOKEN:
+                    in_data = 0;
+                    break;
+                default:
+                    break;
+            }
+
+            if (token.type != YAML_STREAM_END_TOKEN) {
+                yaml_token_delete(&token);
+            }
+
+            if (static_context) {
+                r = 1;
+                break;
+            }
+        } while (token.type != YAML_STREAM_END_TOKEN);
+
+        /* destroy the YAML parser, close the input file */
+        yaml_parser_delete(&parser);
+
+        if (fclose(fp) != 0) {
+            err(RI_PROGRAM_ERROR, "fclose");
+        }
+    }
+
+    return r;
+}
+
+/*
+ * Given a directory and a build subdirectory, construct a new full
+ * path and walk that tree looking for the modulemd.txt file and then
+ * reading /data/static_context from it.
+ */
+static bool get_static_context(const char *subdir, const char *build)
+{
+    char *path = NULL;
+
+    assert(subdir != NULL);
+    assert(build != NULL);
+
+    /* create the build path */
+    path = joinpath(subdir, build, NULL);
+    assert(path != NULL);
+
+    /* find the modulemd.txt file and read /data/static_context */
+    static_context = false;
+
+    if (nftw(path, read_modulemd, FOPEN_MAX, FTW_PHYS) == -1) {
+        warn("nftw");
+        free(path);
+        return false;
+    }
+
+    /* cleanup */
+    free(path);
+
+    return static_context;
+}
+
+/*
+ * Read the /data/static_context value from the modulemd.txt files and
+ * validate them against the rules.
+ */
+static bool check_static_context(struct rpminspect *ri)
+{
+    bool r = true;
+    bool bsc = false;
+    bool asc = false;
+    struct result_params params;
+
+    assert(ri != NULL);
+
+    /* Set up the result parameters */
+    init_result_params(&params);
+    params.header = NAME_MODULARITY;
+    params.severity = RESULT_INFO;
+    params.waiverauth = NOT_WAIVABLE;
+
+    /* get the after build static_context first */
+    asc = get_static_context(ri->worksubdir, AFTER_SUBDIR);
+
+    if (ri->before) {
+        /* comparing builds, verify after build is correct, but report changes */
+        bsc = get_static_context(ri->worksubdir, BEFORE_SUBDIR);
+
+        if (bsc == asc) {
+            if (ri->modularity_static_context == STATIC_CONTEXT_FORBIDDEN) {
+                xasprintf(&params.msg, _("The /data/static_context value in %s matches the value in %s, but the product release rules forbid the presence of /data/static_context in the module metadata."), ri->before, ri->after);
+                params.severity = RESULT_VERIFY;
+                params.waiverauth = WAIVABLE_BY_ANYONE;
+                params.remedy = REMEDY_MODULARITY_STATIC_CONTEXT;
+                r = false;
+            } else if (ri->modularity_static_context == STATIC_CONTEXT_REQUIRED) {
+                xasprintf(&params.msg, _("The /data/static_context value in %s matches the value in %s, and the product release rules require the presence of /data/static_context in the module metadata."), ri->before, ri->after);
+            } else if (ri->modularity_static_context == STATIC_CONTEXT_RECOMMEND) {
+                xasprintf(&params.msg, _("The /data/static_context value in %s matches the value in %s, and the product release rules recommend the presence of /data/static_context in the module metadata."), ri->before, ri->after);
+            } else {
+                xasprintf(&params.msg, _("The /data/static_context value in %s matches the value in %s, and the product release rules do not have a setting for /data/static_context in the module metadata."), ri->before, ri->after);
+            }
+        } else if (bsc != asc) {
+            if (asc && ri->modularity_static_context == STATIC_CONTEXT_FORBIDDEN) {
+                xasprintf(&params.msg, _("The /data/static_context value in %s was %s and became %s in %s, but the product release rules forbid the presence of /data/static_context in the module metadata."), ri->before, bsc ? _("true") : _("false"), asc ? _("true") : _("false"), ri->after);
+                params.severity = RESULT_VERIFY;
+                params.waiverauth = WAIVABLE_BY_ANYONE;
+                params.remedy = REMEDY_MODULARITY_STATIC_CONTEXT;
+                r = false;
+            } else if (!asc && ri->modularity_static_context == STATIC_CONTEXT_REQUIRED) {
+                xasprintf(&params.msg, _("The /data/static_context value in %s was %s and became %s in %s, but the product release rules require the presence of /data/static_context in the module metadata."), ri->before, bsc ? _("true") : _("false"), asc ? _("true") : _("false"), ri->after);
+                params.severity = RESULT_VERIFY;
+                params.waiverauth = WAIVABLE_BY_ANYONE;
+                params.remedy = REMEDY_MODULARITY_STATIC_CONTEXT;
+                r = false;
+            } else if (!asc && ri->modularity_static_context == STATIC_CONTEXT_RECOMMEND) {
+                xasprintf(&params.msg, _("The /data/static_context value in %s was %s and became %s in %s, and the product release rules recommend the presence of /data/static_context in the module metadata."), ri->before, bsc ? _("true") : _("false"), asc ? _("true") : _("false"), ri->after);
+            } else {
+                xasprintf(&params.msg, _("The /data/static_context value in %s was %s and became %s in %s, and the product release rules do not have a setting for /data/static_context in the module metadata."), ri->before, bsc ? _("true") : _("false"), asc ? _("true") : _("false"), ri->after);
+            }
+        }
+    } else {
+        if (asc && ri->modularity_static_context == STATIC_CONTEXT_FORBIDDEN) {
+            xasprintf(&params.msg, _("The /data/static_context value in %s is %s, but the product release rules forbid the presence of /data/static_context in the module metadata."), ri->after, asc ? _("true") : _("false"));
+            params.severity = RESULT_VERIFY;
+            params.waiverauth = WAIVABLE_BY_ANYONE;
+            params.remedy = REMEDY_MODULARITY_STATIC_CONTEXT;
+            r = false;
+        } else if (!asc && ri->modularity_static_context == STATIC_CONTEXT_REQUIRED) {
+            xasprintf(&params.msg, _("The /data/static_context value in %s is %s, but the product release rules require the presence of /data/static_context in the module metadata."), ri->after, asc ? _("true") : _("false"));
+            params.severity = RESULT_VERIFY;
+            params.waiverauth = WAIVABLE_BY_ANYONE;
+            params.remedy = REMEDY_MODULARITY_STATIC_CONTEXT;
+            r = false;
+        } else if (!asc && ri->modularity_static_context == STATIC_CONTEXT_RECOMMEND) {
+            xasprintf(&params.msg, _("The /data/static_context value in %s is %s, and the product release rules recommend the presence of /data/static_context in the module metadata."), ri->after, asc ? _("true") : _("false"));
+        } else {
+            xasprintf(&params.msg, _("The /data/static_context value in %s is %s, and the product release rules do not have a setting for /data/static_context in the module metadata."), ri->after, asc ? _("true") : _("false"));
+        }
+    }
+
+    /* report */
+    add_result(ri, &params);
+    free(params.msg);
+
+    return r;
+}
 
 static bool modularity_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
@@ -80,6 +288,8 @@ static bool modularity_driver(struct rpminspect *ri, rpmfile_entry_t *file)
  */
 bool inspect_modularity(struct rpminspect *ri)
 {
+    bool tag_result = false;
+    bool static_context_result = false;
     bool result = false;
     struct result_params params;
 
@@ -96,7 +306,14 @@ bool inspect_modularity(struct rpminspect *ri)
         return true;
     }
 
-    result = foreach_peer_file(ri, NAME_MODULARITY, modularity_driver);
+    /* check each RPM for the modularitylabel tag */
+    tag_result = foreach_peer_file(ri, NAME_MODULARITY, modularity_driver);
+
+    /* check static context against static context rule */
+    static_context_result = check_static_context(ri);
+
+    /* final check of all results */
+    result = tag_result && static_context_result;
 
     if (result) {
         init_result_params(&params);


### PR DESCRIPTION
Expand the modularity inspection to check the /data/static_context setting from the module metadata.  The value is collected and then checked against the configuration file setting.  Reporting is based on what is found vs. the configuration file setting.  For instance, if it is found set in modulemd.txt and the config file says static_context is forbidden, that is a VERIFY result.

Fixes: #803

Signed-off-by: David Cantrell <dcantrell@redhat.com>