### PR TITLE
Allow TestKoji and TestCompareKoji to be base classes; use super().setUp() and super.tearDown()

### DIFF
--- a/test/test_badfuncs.py
+++ b/test/test_badfuncs.py
@@ -28,7 +28,7 @@ forbidden_ipv6_src = open(datadir + "/forbidden-ipv6.c").read()
 # Program uses forbidden IPv6 function
 class ForbiddenIPv6FunctionRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.inspection = "badfuncs"
         self.waiver_auth = "Anyone"
@@ -37,7 +37,7 @@ class ForbiddenIPv6FunctionRPM(TestRPMs):
 
 class ForbiddenIPv6FunctionKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.inspection = "badfuncs"
         self.waiver_auth = "Anyone"
@@ -46,7 +46,7 @@ class ForbiddenIPv6FunctionKoji(TestKoji):
 
 class ForbiddenIPv6FunctionCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.after_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.inspection = "badfuncs"
@@ -56,7 +56,7 @@ class ForbiddenIPv6FunctionCompareRPMs(TestCompareRPMs):
 
 class ForbiddenIPv6FunctionCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.after_rpm.add_simple_compilation(sourceContent=forbidden_ipv6_src)
         self.inspection = "badfuncs"
@@ -67,7 +67,7 @@ class ForbiddenIPv6FunctionCompareKoji(TestCompareKoji):
 # Program uses forbidden IPv6 function, but is explicitly allowed
 class AllowedForbiddenIPv6FunctionRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.extra_cfg = {}
         self.extra_cfg["badfuncs"] = {}
@@ -82,7 +82,7 @@ class AllowedForbiddenIPv6FunctionRPM(TestRPMs):
 
 class AllowedForbiddenIPv6FunctionKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.extra_cfg = {}
         self.extra_cfg["badfuncs"] = {}
@@ -97,7 +97,7 @@ class AllowedForbiddenIPv6FunctionKoji(TestKoji):
 
 class AllowedForbiddenIPv6FunctionCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.extra_cfg = {}
         self.extra_cfg["badfuncs"] = {}
@@ -113,7 +113,7 @@ class AllowedForbiddenIPv6FunctionCompareRPMs(TestCompareRPMs):
 
 class AllowedForbiddenIPv6FunctionCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.extra_cfg = {}
         self.extra_cfg["badfuncs"] = {}

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -29,7 +29,7 @@ from baseclass import TestCompareSRPM, TestCompareRPMs, TestCompareKoji
 #    report that as VERIFY.
 class LostChangeLogCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
 
         # create a simple changelog
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -49,7 +49,7 @@ class LostChangeLogCompareSRPM(TestCompareSRPM):
 
 class LostChangeLogCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # create a simple changelog
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -71,7 +71,7 @@ class LostChangeLogCompareRPMs(TestCompareRPMs):
 
 class LostChangeLogCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # create a simple changelog
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -93,7 +93,7 @@ class LostChangeLogCompareKoji(TestCompareKoji):
 #    build.  The test should report that as INFO.
 class GainedChangeLogCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
 
         # create a simple changelog
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -113,7 +113,7 @@ class GainedChangeLogCompareSRPM(TestCompareSRPM):
 
 class GainedChangeLogCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # create a simple changelog
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -133,7 +133,7 @@ class GainedChangeLogCompareRPMs(TestCompareRPMs):
 
 class GainedChangeLogCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # create a simple changelog
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -155,7 +155,7 @@ class GainedChangeLogCompareKoji(TestCompareKoji):
 #    after build, the test should report it as BAD.
 class SameChangeLogCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
 
         # create a simple changelog and duplicate it
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -175,7 +175,7 @@ class SameChangeLogCompareSRPM(TestCompareSRPM):
 
 class SameChangeLogCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # create a simple changelog and duplicate it
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -198,7 +198,7 @@ class SameChangeLogCompareKoji(TestCompareKoji):
 #    report that as INFO.
 class BalancedChangeLogEditCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # create a simple prefix that will result in a one line edit script
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -226,7 +226,7 @@ class BalancedChangeLogEditCompareKoji(TestCompareKoji):
 
 class UnbalancedChangeLogEditCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # create a simple prefix that will result in a multiline removal
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -256,7 +256,7 @@ class UnbalancedChangeLogEditCompareKoji(TestCompareKoji):
 #    should report as INFO.
 class AddChangeLogEntryCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
 
         # create a simple prefix that will result in a new entry
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -285,7 +285,7 @@ class AddChangeLogEntryCompareSRPM(TestCompareSRPM):
 
 class AddChangeLogEntryCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # create a simple prefix that will result in a new entry
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -309,7 +309,7 @@ class AddChangeLogEntryCompareRPMs(TestCompareRPMs):
 
 class AddChangeLogEntryCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # create a simple prefix that will result in a new entry
         today = datetime.date.today().strftime("%a %b %d %Y")
@@ -335,7 +335,7 @@ class AddChangeLogEntryCompareKoji(TestCompareKoji):
 #    sure that is reported as BAD.
 class UnprofessinalChangeLogEntryCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # create a change with a bad word
         today = datetime.date.today().strftime("%a %b %d %Y")

--- a/test/test_default.py
+++ b/test/test_default.py
@@ -30,7 +30,7 @@ class DefaultSRPM(TestSRPM):
     """
 
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.result = "OK"
 
 
@@ -40,7 +40,7 @@ class DefaultRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.result = "OK"
 
 
@@ -50,7 +50,7 @@ class DefaultKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.result = "OK"
 
 
@@ -60,7 +60,7 @@ class DefaultCompareSRPM(TestCompareSRPM):
     """
 
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.result = "OK"
 
 
@@ -70,7 +70,7 @@ class DefaultCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.result = "OK"
 
 
@@ -80,5 +80,5 @@ class DefaultCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.result = "OK"

--- a/test/test_desktop.py
+++ b/test/test_desktop.py
@@ -98,7 +98,7 @@ MimeType=application/x-extension-fcstd;
 # Valid desktop file passes in RPM (OK)
 class ValidDesktopFileRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -122,7 +122,7 @@ class ValidDesktopFileRPM(TestRPMs):
 # Valid desktop file passes in Koji build (OK)
 class ValidDesktopFileKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -146,7 +146,7 @@ class ValidDesktopFileKoji(TestKoji):
 # Valid desktop file passes in RPM compare (OK)
 class ValidDesktopFileCompareRPM(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -179,7 +179,7 @@ class ValidDesktopFileCompareRPM(TestCompareRPMs):
 # Valid desktop file passes in Koji build compare (OK)
 class ValidDesktopFileCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -212,7 +212,7 @@ class ValidDesktopFileCompareKoji(TestCompareKoji):
 # Desktop file with missing icon in RPM (VERIFY)
 class DesktopFileMissingIconRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -231,7 +231,7 @@ class DesktopFileMissingIconRPM(TestRPMs):
 # Desktop file with missing icon in RPM compare (VERIFY)
 class DesktopFileMissingIconCompareRPM(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -255,7 +255,7 @@ class DesktopFileMissingIconCompareRPM(TestCompareRPMs):
 # Desktop file with missing icon in Koji build (VERIFY)
 class DesktopFileMissingIconKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -274,7 +274,7 @@ class DesktopFileMissingIconKoji(TestKoji):
 # Desktop file with missing icon in Koji build compare (VERIFY)
 class DesktopFileMissingIconCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -298,7 +298,7 @@ class DesktopFileMissingIconCompareKoji(TestCompareKoji):
 # Invalid desktop file fails desktop-file-validate in RPM (BAD)
 class DesktopFileValidateFailsRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -323,7 +323,7 @@ class DesktopFileValidateFailsRPM(TestRPMs):
 # Invalid desktop file fails desktop-file-validate in Koji build (BAD)
 class DesktopFileValidateFailsKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -348,7 +348,7 @@ class DesktopFileValidateFailsKoji(TestKoji):
 # Invalid desktop file fails desktop-file-validate in RPM compare (BAD)
 class DesktopFileValidateFailsCompareRPM(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -382,7 +382,7 @@ class DesktopFileValidateFailsCompareRPM(TestCompareRPMs):
 # Invalid desktop file fails desktop-file-validate in Koji build compare (BAD)
 class DesktopFileValidateFailsCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -416,7 +416,7 @@ class DesktopFileValidateFailsCompareKoji(TestCompareKoji):
 # Desktop file with Exec with arguments in RPM (OK)
 class DesktopFileExecArgsRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -440,7 +440,7 @@ class DesktopFileExecArgsRPM(TestRPMs):
 # Desktop file with Exec with arguments in Koji build (OK)
 class DesktopFileExecArgsKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -464,7 +464,7 @@ class DesktopFileExecArgsKoji(TestKoji):
 # Desktop file with Exec with arguments in RPM compare (OK)
 class DesktopFileExecArgsCompareRPM(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -497,7 +497,7 @@ class DesktopFileExecArgsCompareRPM(TestCompareRPMs):
 # Desktop file with Exec with arguments in Koji build compare (OK)
 class DesktopFileExecArgsCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -530,7 +530,7 @@ class DesktopFileExecArgsCompareKoji(TestCompareKoji):
 # Desktop file without world readable Icon in RPM (VERIFY)
 class DesktopFileNotWorldReadableIconRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -556,7 +556,7 @@ class DesktopFileNotWorldReadableIconRPM(TestRPMs):
 # Desktop file without world readable Icon in Koji build (VERIFY)
 class DesktopFileNotWorldReadableIconKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -582,7 +582,7 @@ class DesktopFileNotWorldReadableIconKoji(TestKoji):
 # Desktop file without world readable Icon in RPM compare (VERIFY)
 class DesktopFileNotWorldReadableIconCompareRPM(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -618,7 +618,7 @@ class DesktopFileNotWorldReadableIconCompareRPM(TestCompareRPMs):
 # Desktop file without world readable Icon in Koji build compare (VERIFY)
 class DesktopFileNotWorldReadableIconCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -654,7 +654,7 @@ class DesktopFileNotWorldReadableIconCompareKoji(TestCompareKoji):
 # Desktop file with invalid Exec file in RPM (VERIFY)
 class DesktopFileInvalidExecRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/share/icons/hello-world.png
         self.rpm.add_installed_file(
@@ -676,7 +676,7 @@ class DesktopFileInvalidExecRPM(TestRPMs):
 # Desktop file with invalid Exec file in Koji build (VERIFY)
 class DesktopFileInvalidExecRPMs(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/share/icons/hello-world.png
         self.rpm.add_installed_file(
@@ -698,7 +698,7 @@ class DesktopFileInvalidExecRPMs(TestKoji):
 # Desktop file with invalid Exec file in RPM compare (VERIFY)
 class DesktopFileInvalidExecCompareRPM(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/share/icons/hello-world.png
         self.before_rpm.add_installed_file(
@@ -728,7 +728,7 @@ class DesktopFileInvalidExecCompareRPM(TestCompareRPMs):
 # Desktop file with invalid Exec file in Koji compare (VERIFY)
 class DesktopFileInvalidExecCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/share/icons/hello-world.png
         self.before_rpm.add_installed_file(
@@ -758,7 +758,7 @@ class DesktopFileInvalidExecCompareKoji(TestCompareKoji):
 # Desktop file without world executable Exec file in RPM (VERIFY)
 class DesktopFileWithoutWorldExecutableExecRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -784,7 +784,7 @@ class DesktopFileWithoutWorldExecutableExecRPM(TestRPMs):
 # Desktop file without world executable Exec file in Koji build (VERIFY)
 class DesktopFileWithoutWorldExecutableExecKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -810,7 +810,7 @@ class DesktopFileWithoutWorldExecutableExecKoji(TestKoji):
 # Desktop file without world executable Exec file in RPM compare (VERIFY)
 class DesktopFileWithoutWorldExecutableExecCompareRPM(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -846,7 +846,7 @@ class DesktopFileWithoutWorldExecutableExecCompareRPM(TestCompareRPMs):
 # Desktop file without world executable Exec file in Koji build compare (VERIFY)
 class DesktopFileWithoutWorldExecutableExecCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()
@@ -882,7 +882,7 @@ class DesktopFileWithoutWorldExecutableExecCompareKoji(TestCompareKoji):
 # Desktop file with invalid Exec file in RPM (VERIFY)
 class DesktopFileMissingExecWithTryExecRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/share/icons/hello-world.png
         self.rpm.add_installed_file(
@@ -905,7 +905,7 @@ class DesktopFileMissingExecWithTryExecRPM(TestRPMs):
 # Desktop file with invalid Exec file in Koji build (VERIFY)
 class DesktopFileMissingExecWithTryExecRPMs(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/share/icons/hello-world.png
         self.rpm.add_installed_file(
@@ -928,7 +928,7 @@ class DesktopFileMissingExecWithTryExecRPMs(TestKoji):
 # Desktop file with invalid Exec file in RPM compare (VERIFY)
 class DesktopFileMissingExecWithTryExecCompareRPM(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /usr/share/icons/hello-world.png
         self.before_rpm.add_installed_file(
@@ -959,7 +959,7 @@ class DesktopFileMissingExecWithTryExecCompareRPM(TestCompareRPMs):
 # Desktop file with invalid Exec file in Koji compare (VERIFY)
 class DesktopFileMissingExecWithTryExecCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/share/icons/hello-world.png
         self.before_rpm.add_installed_file(
@@ -990,7 +990,7 @@ class DesktopFileMissingExecWithTryExecCompareKoji(TestCompareKoji):
 # Valid desktop file passes in Koji build using subpackage (OK)
 class ValidDesktopFileIconInSubpackageKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.rpm.add_simple_compilation()
@@ -1015,7 +1015,7 @@ class ValidDesktopFileIconInSubpackageKoji(TestKoji):
 
 class ValidDesktopFileIconInSubpackageCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /usr/bin/hello-world
         self.before_rpm.add_simple_compilation()

--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -66,7 +66,7 @@ if os.path.isfile("/usr/lib/rpm/macros.d/macros.rpmautospec"):
 # Verify missing %{?dist} in Release fails on SRPM (BAD)
 class MissingDistTagSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.inspection = "disttag"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
@@ -75,7 +75,7 @@ class MissingDistTagSRPM(TestSRPM):
 # Verify missing %{?dist} in Release fails on Koji build (BAD)
 class MissingDistTagKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.inspection = "disttag"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
@@ -84,7 +84,7 @@ class MissingDistTagKojiBuild(TestKoji):
 # Verify running on not an SRPM fails
 class DistTagOnNonSRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.release = "1%{?dist}"
         self.inspection = "disttag"
         self.result = "INFO"
@@ -94,7 +94,7 @@ class DistTagOnNonSRPM(TestRPMs):
 # Verify malformed %{?dist} tag in Release fails on SRPM (BAD)
 class MalformedDistTagSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.release = "1dist"
         self.inspection = "disttag"
         self.result = "BAD"
@@ -104,7 +104,7 @@ class MalformedDistTagSRPM(TestSRPM):
 # Verify malformed %{?dist} tag in Release fails on Koji build (BAD)
 class MalformedDistTagKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.release = "1dist"
         self.inspection = "disttag"
         self.result = "BAD"
@@ -114,7 +114,7 @@ class MalformedDistTagKojiBuild(TestKoji):
 # Verify correct %{?dist} usage passes on SRPM (OK)
 class DistTagSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.release = "1%{?dist}"
         self.inspection = "disttag"
 
@@ -122,7 +122,7 @@ class DistTagSRPM(TestSRPM):
 # Verify correct %{?dist} usage passes on Koji build (OK)
 class DistTagKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.release = "1%{?dist}"
         self.inspection = "disttag"
 
@@ -131,7 +131,7 @@ class DistTagKojiBuild(TestKoji):
 class AutoReleaseDistTagSRPM(TestSRPM):
     @unittest.skipIf(missing_rpmautospec, "test requires the rpmautospec macros")
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.release = "%autorelease"
         self.inspection = "disttag"
 
@@ -140,7 +140,7 @@ class AutoReleaseDistTagSRPM(TestSRPM):
 class AutoReleaseDistTagKoji(TestKoji):
     @unittest.skipIf(missing_rpmautospec, "test requires the rpmautospec macros")
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.release = "%autorelease"
         self.inspection = "disttag"
 
@@ -158,7 +158,7 @@ class AutoReleaseDistTagKoji(TestKoji):
 # Macros in the Release value with macros expanding to %{?dist} (OK)
 class DistTagInMacroSRPM(RequiresRpminspect):
     def setUp(self):
-        RequiresRpminspect.setUp(self)
+        super().setUp()
 
         # create a temporary directory to build an SRPM
         self.tmpdir = tempfile.TemporaryDirectory()
@@ -250,13 +250,13 @@ class DistTagInMacroSRPM(RequiresRpminspect):
 
     def tearDown(self):
         self.tmpdir.cleanup()
-        RequiresRpminspect.tearDown(self)
+        super().tearDown()
 
 
 # Macros in the Release value with macros expanding to %{?dist}, tab field separator (OK)
 class TabbedDistTagInMacroSRPM(RequiresRpminspect):
     def setUp(self):
-        RequiresRpminspect.setUp(self)
+        super().setUp()
 
         # create a temporary directory to build an SRPM
         self.tmpdir = tempfile.TemporaryDirectory()
@@ -348,4 +348,4 @@ class TabbedDistTagInMacroSRPM(RequiresRpminspect):
 
     def tearDown(self):
         self.tmpdir.cleanup()
-        RequiresRpminspect.tearDown(self)
+        super().tearDown()

--- a/test/test_elf.py
+++ b/test/test_elf.py
@@ -71,7 +71,7 @@ if proc.returncode == 0 and str(out).find("ld-musl") != -1:
 # Program built with noexecstack
 class WithoutExecStackRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
         self.result = "OK"
@@ -79,7 +79,7 @@ class WithoutExecStackRPM(TestRPMs):
 
 class WithoutExecStackKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
         self.result = "OK"
@@ -87,7 +87,7 @@ class WithoutExecStackKoji(TestKoji):
 
 class WithoutExecStackCompareRPM(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
@@ -96,7 +96,7 @@ class WithoutExecStackCompareRPM(TestCompareRPMs):
 
 class WithoutExecStackCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,noexecstack")
         self.inspection = "elf"
@@ -106,7 +106,7 @@ class WithoutExecStackCompareKoji(TestCompareKoji):
 # Program built with execstack
 class WithExecStackRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/bin/execstack", compileFlags="-Wl,-z,execstack"
         )
@@ -117,7 +117,7 @@ class WithExecStackRPM(TestRPMs):
 
 class SecuritySKIPWithExecStackRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,execstack"
         )
@@ -127,7 +127,7 @@ class SecuritySKIPWithExecStackRPM(TestRPMs):
 
 class SecurityINFORMWithExecStackRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/sbin/inform", compileFlags="-Wl,-z,execstack"
         )
@@ -138,7 +138,7 @@ class SecurityINFORMWithExecStackRPM(TestRPMs):
 
 class SecurityVERIFYWithExecStackRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/sbin/verify", compileFlags="-Wl,-z,execstack"
         )
@@ -149,7 +149,7 @@ class SecurityVERIFYWithExecStackRPM(TestRPMs):
 
 class SecurityFAILWithExecStackRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/sbin/fail", compileFlags="-Wl,-z,execstack"
         )
@@ -160,7 +160,7 @@ class SecurityFAILWithExecStackRPM(TestRPMs):
 
 class WithExecStackKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/bin/execstack", compileFlags="-Wl,-z,execstack"
         )
@@ -171,7 +171,7 @@ class WithExecStackKoji(TestKoji):
 
 class SecuritySKIPWithExecStackKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,execstack"
         )
@@ -181,7 +181,7 @@ class SecuritySKIPWithExecStackKoji(TestKoji):
 
 class SecurityINFORMWithExecStackKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/sbin/inform", compileFlags="-Wl,-z,execstack"
         )
@@ -192,7 +192,7 @@ class SecurityINFORMWithExecStackKoji(TestKoji):
 
 class SecurityVERIFYWithExecStackKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/sbin/verify", compileFlags="-Wl,-z,execstack"
         )
@@ -203,7 +203,7 @@ class SecurityVERIFYWithExecStackKoji(TestKoji):
 
 class SecurityFAILWithExecStackKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             installPath="usr/sbin/fail", compileFlags="-Wl,-z,execstack"
         )
@@ -214,7 +214,7 @@ class SecurityFAILWithExecStackKoji(TestKoji):
 
 class WithExecStackCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/bin/execstack", compileFlags="-Wl,-z,execstack"
         )
@@ -228,7 +228,7 @@ class WithExecStackCompareRPMs(TestCompareRPMs):
 
 class SecuritySKIPWithExecStackCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,execstack"
         )
@@ -241,7 +241,7 @@ class SecuritySKIPWithExecStackCompareRPMs(TestCompareRPMs):
 
 class SecurityINFORMWithExecStackCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/inform", compileFlags="-Wl,-z,execstack"
         )
@@ -255,7 +255,7 @@ class SecurityINFORMWithExecStackCompareRPMs(TestCompareRPMs):
 
 class SecurityVERIFYWithExecStackCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/verify", compileFlags="-Wl,-z,execstack"
         )
@@ -269,7 +269,7 @@ class SecurityVERIFYWithExecStackCompareRPMs(TestCompareRPMs):
 
 class SecurityFAILWithExecStackCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/fail", compileFlags="-Wl,-z,execstack"
         )
@@ -283,7 +283,7 @@ class SecurityFAILWithExecStackCompareRPMs(TestCompareRPMs):
 
 class WithExecStackCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/bin/execstack", compileFlags="-Wl,-z,execstack"
         )
@@ -297,7 +297,7 @@ class WithExecStackCompareKoji(TestCompareKoji):
 
 class SecuritySKIPWithExecStackCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,execstack"
         )
@@ -310,7 +310,7 @@ class SecuritySKIPWithExecStackCompareKoji(TestCompareKoji):
 
 class SecurityINFORMWithExecStackCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/inform", compileFlags="-Wl,-z,execstack"
         )
@@ -324,7 +324,7 @@ class SecurityINFORMWithExecStackCompareKoji(TestCompareKoji):
 
 class SecurityVERIFYWithExecStackCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/verify", compileFlags="-Wl,-z,execstack"
         )
@@ -338,7 +338,7 @@ class SecurityVERIFYWithExecStackCompareKoji(TestCompareKoji):
 
 class SecurityFAILWithExecStackCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/fail", compileFlags="-Wl,-z,execstack"
         )
@@ -353,7 +353,7 @@ class SecurityFAILWithExecStackCompareKoji(TestCompareKoji):
 # Program lost full RELRO
 class LostFullRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,now")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,norelro")
         self.inspection = "elf"
@@ -363,7 +363,7 @@ class LostFullRELROCompareRPMs(TestCompareRPMs):
 
 class SecuritySKIPLostFullRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -376,7 +376,7 @@ class SecuritySKIPLostFullRELROCompareRPMs(TestCompareRPMs):
 
 class SecurityINFORMLostFullRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/inform", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -390,7 +390,7 @@ class SecurityINFORMLostFullRELROCompareRPMs(TestCompareRPMs):
 
 class SecurityVERIFYLostFullRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/verify", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -404,7 +404,7 @@ class SecurityVERIFYLostFullRELROCompareRPMs(TestCompareRPMs):
 
 class SecurityFAILLostFullRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/fail", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -418,7 +418,7 @@ class SecurityFAILLostFullRELROCompareRPMs(TestCompareRPMs):
 
 class LostFullRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,now")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,norelro")
         self.inspection = "elf"
@@ -428,7 +428,7 @@ class LostFullRELROCompareKoji(TestCompareKoji):
 
 class SecuritySKIPLostFullRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -441,7 +441,7 @@ class SecuritySKIPLostFullRELROCompareKoji(TestCompareKoji):
 
 class SecurityINFORMLostFullRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/inform", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -455,7 +455,7 @@ class SecurityINFORMLostFullRELROCompareKoji(TestCompareKoji):
 
 class SecurityVERIFYLostFullRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/verify", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -469,7 +469,7 @@ class SecurityVERIFYLostFullRELROCompareKoji(TestCompareKoji):
 
 class SecurityFAILLostFullRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/fail", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -484,7 +484,7 @@ class SecurityFAILLostFullRELROCompareKoji(TestCompareKoji):
 # Program lost full RELRO but retained partial RELRO
 class FulltoPartialRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,now")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,lazy")
         self.inspection = "elf"
@@ -494,7 +494,7 @@ class FulltoPartialRELROCompareRPMs(TestCompareRPMs):
 
 class SecuritySKIPFulltoPartialRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -507,7 +507,7 @@ class SecuritySKIPFulltoPartialRELROCompareRPMs(TestCompareRPMs):
 
 class SecurityINFORMFulltoPartialRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/inform", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -521,7 +521,7 @@ class SecurityINFORMFulltoPartialRELROCompareRPMs(TestCompareRPMs):
 
 class SecurityVERIFYFulltoPartialRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/verify", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -535,7 +535,7 @@ class SecurityVERIFYFulltoPartialRELROCompareRPMs(TestCompareRPMs):
 
 class SecurityFAILFulltoPartialRELROCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/fail", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -549,7 +549,7 @@ class SecurityFAILFulltoPartialRELROCompareRPMs(TestCompareRPMs):
 
 class FulltoPartialRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,now")
         self.after_rpm.add_simple_compilation(compileFlags="-Wl,-z,relro,-z,lazy")
         self.inspection = "elf"
@@ -559,7 +559,7 @@ class FulltoPartialRELROCompareKoji(TestCompareKoji):
 
 class SecuritySKIPFulltoPartialRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/skip", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -572,7 +572,7 @@ class SecuritySKIPFulltoPartialRELROCompareKoji(TestCompareKoji):
 
 class SecurityINFORMFulltoPartialRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/inform", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -586,7 +586,7 @@ class SecurityINFORMFulltoPartialRELROCompareKoji(TestCompareKoji):
 
 class SecurityVERIFYFulltoPartialRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/verify", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -600,7 +600,7 @@ class SecurityVERIFYFulltoPartialRELROCompareKoji(TestCompareKoji):
 
 class SecurityFAILFulltoPartialRELROCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_compilation(
             installPath="usr/sbin/fail", compileFlags="-Wl,-z,relro,-z,now"
         )
@@ -616,7 +616,7 @@ class SecurityFAILFulltoPartialRELROCompareKoji(TestCompareKoji):
 class LostPICCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libsimple.a"
 
@@ -653,7 +653,7 @@ class LostPICCompareRPMs(TestCompareRPMs):
 class SecuritySKIPLostPICCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libskip.a"
 
@@ -689,7 +689,7 @@ class SecuritySKIPLostPICCompareRPMs(TestCompareRPMs):
 class SecurityINFORMLostPICCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libinform.a"
 
@@ -726,7 +726,7 @@ class SecurityINFORMLostPICCompareRPMs(TestCompareRPMs):
 class SecurityVERIFYLostPICCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libverify.a"
 
@@ -763,7 +763,7 @@ class SecurityVERIFYLostPICCompareRPMs(TestCompareRPMs):
 class SecurityFAILLostPICCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libfail.a"
 
@@ -800,7 +800,7 @@ class SecurityFAILLostPICCompareRPMs(TestCompareRPMs):
 class LostPICCompareKoji(TestCompareKoji):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libsimple.a"
 
@@ -838,7 +838,7 @@ class LostPICCompareKoji(TestCompareKoji):
 class HasTEXTRELRPMs(TestRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libfoo.so"
 
@@ -861,7 +861,7 @@ class HasTEXTRELRPMs(TestRPMs):
 class SecuritySKIPHasTEXTRELRPMs(TestRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libskip.so"
 
@@ -883,7 +883,7 @@ class SecuritySKIPHasTEXTRELRPMs(TestRPMs):
 class SecurityINFORMHasTEXTRELRPMs(TestRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libinform.so"
 
@@ -906,7 +906,7 @@ class SecurityINFORMHasTEXTRELRPMs(TestRPMs):
 class SecurityVERIFYHasTEXTRELRPMs(TestRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libverify.so"
 
@@ -929,7 +929,7 @@ class SecurityVERIFYHasTEXTRELRPMs(TestRPMs):
 class SecurityFAILHasTEXTRELRPMs(TestRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libfail.so"
 
@@ -952,7 +952,7 @@ class SecurityFAILHasTEXTRELRPMs(TestRPMs):
 class HasTEXTRELCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libfoo.so"
 
@@ -993,7 +993,7 @@ class HasTEXTRELCompareRPMs(TestCompareRPMs):
 class SecuritySKIPHasTEXTRELCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libskip.so"
 
@@ -1033,7 +1033,7 @@ class SecuritySKIPHasTEXTRELCompareRPMs(TestCompareRPMs):
 class SecurityINFORMHasTEXTRELCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libinform.so"
 
@@ -1074,7 +1074,7 @@ class SecurityINFORMHasTEXTRELCompareRPMs(TestCompareRPMs):
 class SecurityVERIFYHasTEXTRELCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libverify.so"
 
@@ -1115,7 +1115,7 @@ class SecurityVERIFYHasTEXTRELCompareRPMs(TestCompareRPMs):
 class SecurityFAILHasTEXTRELCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libfail.so"
 
@@ -1156,7 +1156,7 @@ class SecurityFAILHasTEXTRELCompareRPMs(TestCompareRPMs):
 class HasTEXTRELCompareKoji(TestCompareKoji):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libfoo.so"
 
@@ -1197,7 +1197,7 @@ class HasTEXTRELCompareKoji(TestCompareKoji):
 class SecuritySKIPHasTEXTRELCompareKoji(TestCompareKoji):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libskip.so"
 
@@ -1237,7 +1237,7 @@ class SecuritySKIPHasTEXTRELCompareKoji(TestCompareKoji):
 class SecurityINFORMHasTEXTRELCompareKoji(TestCompareKoji):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libinform.so"
 
@@ -1278,7 +1278,7 @@ class SecurityINFORMHasTEXTRELCompareKoji(TestCompareKoji):
 class SecurityVERIFYHasTEXTRELCompareKoji(TestCompareKoji):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libverify.so"
 
@@ -1319,7 +1319,7 @@ class SecurityVERIFYHasTEXTRELCompareKoji(TestCompareKoji):
 class SecurityFAILHasTEXTRELCompareKoji(TestCompareKoji):
     @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         installPath = "usr/lib/libfail.so"
 

--- a/test/test_emptyrpm.py
+++ b/test/test_emptyrpm.py
@@ -22,7 +22,7 @@ from baseclass import TestKoji, TestRPMs, TestSRPM
 # Regular SRPM has payload (OK)
 class HasPayloadSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.add_simple_payload_file()
         self.inspection = "emptyrpm"
         self.result = "OK"
@@ -31,7 +31,7 @@ class HasPayloadSRPM(TestSRPM):
 # Regular RPMs have payload (OK)
 class HasPayloadRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_payload_file()
         self.inspection = "emptyrpm"
         self.result = "OK"
@@ -40,7 +40,7 @@ class HasPayloadRPMs(TestRPMs):
 # Regular Koji build has payload (OK)
 class HasPayloadKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_payload_file()
         self.inspection = "emptyrpm"
         self.result = "OK"
@@ -49,7 +49,7 @@ class HasPayloadKojiBuild(TestKoji):
 # Regular package has empty payload (VERIFY)
 class PkgHasEmptyPayload(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.inspection = "emptyrpm"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
@@ -58,7 +58,7 @@ class PkgHasEmptyPayload(TestRPMs):
 # Packages in Koji build have empty payloads (VERIFY)
 class KojiBuildHaveEmptyPayloads(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.inspection = "emptyrpm"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -28,7 +28,7 @@ from baseclass import TestSRPM, TestKoji, TestCompareSRPM, TestCompareKoji
 
 class ValidFilesSectionSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
 
         # add a library and proper %files reference
         libraryName = "libfoo.so"
@@ -53,7 +53,7 @@ class ValidFilesSectionSRPM(TestSRPM):
 
 class ValidFilesSectionKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add a library and proper %files reference
         libraryName = "libfoo.so"
@@ -78,7 +78,7 @@ class ValidFilesSectionKoji(TestKoji):
 
 class ValidFilesSectionCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
 
         # add a library and proper %files reference
         libraryName = "libfoo.so"
@@ -105,7 +105,7 @@ class ValidFilesSectionCompareSRPM(TestCompareSRPM):
 
 class ValidFilesSectionCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add a library and proper %files reference
         libraryName = "libfoo.so"
@@ -132,7 +132,7 @@ class ValidFilesSectionCompareKoji(TestCompareKoji):
 
 class InvalidFilesSectionSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.add_simple_library()
 
         self.inspection = "files"
@@ -142,7 +142,7 @@ class InvalidFilesSectionSRPM(TestSRPM):
 
 class InvalidFilesSectionKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_library()
 
         self.inspection = "files"
@@ -152,7 +152,7 @@ class InvalidFilesSectionKoji(TestKoji):
 
 class InvalidFilesSectionCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.after_rpm.add_simple_library()
 
         self.inspection = "files"
@@ -162,7 +162,7 @@ class InvalidFilesSectionCompareSRPM(TestCompareSRPM):
 
 class InvalidFilesSectionCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.after_rpm.add_simple_library()
 
         self.inspection = "files"

--- a/test/test_kmod.py
+++ b/test/test_kmod.py
@@ -140,7 +140,7 @@ def get_derp_kmod_aliases(rpminspect):
 class GoodKmodParamsRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -160,7 +160,7 @@ class GoodKmodParamsRPMs(TestCompareRPMs):
 class LostKmodParmsRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -180,7 +180,7 @@ class LostKmodParmsRPMs(TestCompareRPMs):
 class GoodKmodParamsKoji(TestCompareKoji):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -200,7 +200,7 @@ class GoodKmodParamsKoji(TestCompareKoji):
 class LostKmodParamsKoji(TestCompareKoji):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -224,7 +224,7 @@ class LostKmodParamsKoji(TestCompareKoji):
 class GoodKmodDependsRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -244,7 +244,7 @@ class GoodKmodDependsRPMs(TestCompareRPMs):
 class LostKmodDependsRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -264,7 +264,7 @@ class LostKmodDependsRPMs(TestCompareRPMs):
 class GoodKmodDependsKoji(TestCompareKoji):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -284,7 +284,7 @@ class GoodKmodDependsKoji(TestCompareKoji):
 class LostKmodDependsKoji(TestCompareKoji):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -308,7 +308,7 @@ class LostKmodDependsKoji(TestCompareKoji):
 class GoodKmodAliasesRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -328,7 +328,7 @@ class GoodKmodAliasesRPMs(TestCompareRPMs):
 class LostKmodAliasesRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -348,7 +348,7 @@ class LostKmodAliasesRPMs(TestCompareRPMs):
 class GoodKmodAliasesKoji(TestCompareKoji):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -368,7 +368,7 @@ class GoodKmodAliasesKoji(TestCompareKoji):
 class LostKmodAliasesKoji(TestCompareKoji):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -388,7 +388,7 @@ class LostKmodAliasesKoji(TestCompareKoji):
 class KmodChangingPathCompareRPMs(TestCompareRPMs):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",
@@ -407,7 +407,7 @@ class KmodChangingPathCompareRPMs(TestCompareRPMs):
 class KmodChangingPathCompareKoji(TestCompareKoji):
     @unittest.skipUnless(have_kernel_devel, "Need kernel devel files")
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.before_rpm.add_installed_file(
             "/usr/lib/modules/" + kver + "/extra/drivers/derp.ko",

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -27,7 +27,7 @@ class EmptyLicenseTagSRPM(TestSRPM):
         "rpmbuild actually prevents this, but leave the test in case we need it in the future"
     )
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.license = ""
         self.inspection = "license"
         self.result = "BAD"
@@ -40,7 +40,7 @@ class EmptyLicenseTagRPMs(TestRPMs):
         "rpmbuild actually prevents this, but leave the test in case we need it in the future"
     )
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.license = ""
         self.inspection = "license"
         self.result = "BAD"
@@ -53,7 +53,7 @@ class EmptyLicenseTagKoji(TestKoji):
         "rpmbuild actually prevents this, but leave the test in case we need it in the future"
     )
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.license = ""
         self.inspection = "license"
         self.result = "BAD"
@@ -63,7 +63,7 @@ class EmptyLicenseTagKoji(TestKoji):
 # Forbidden License tag fails on SRPM (BAD)
 class ForbiddenLicenseTagSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addLicense("APSL-1.2")
         self.inspection = "license"
         self.result = "BAD"
@@ -73,7 +73,7 @@ class ForbiddenLicenseTagSRPM(TestSRPM):
 # Forbidden License tag fails on RPMs (BAD)
 class ForbiddenLicenseTagRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addLicense("APSL-1.2")
         self.inspection = "license"
         self.result = "BAD"
@@ -83,7 +83,7 @@ class ForbiddenLicenseTagRPMs(TestRPMs):
 # Forbidden License tag fails on Koji build (BAD)
 class ForbiddenLicenseTagKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense("APSL-1.2")
         self.inspection = "license"
         self.result = "BAD"
@@ -93,7 +93,7 @@ class ForbiddenLicenseTagKoji(TestKoji):
 # License tag with unprofessional language fails on SRPM (BAD)
 class BadWordLicenseTagSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
         self.inspection = "license"
         self.result = "BAD"
@@ -103,7 +103,7 @@ class BadWordLicenseTagSRPM(TestSRPM):
 # License tag with unprofessional language fails on RPMs (BAD)
 class BadWordLicenseTagRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
         self.inspection = "license"
         self.result = "BAD"
@@ -113,7 +113,7 @@ class BadWordLicenseTagRPMs(TestRPMs):
 # License tag with unprofessional language fails on Koji build (BAD)
 class BadWordLicenseTagKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
         self.inspection = "license"
         self.result = "BAD"
@@ -123,7 +123,7 @@ class BadWordLicenseTagKoji(TestKoji):
 # Valid License tag passes on SRPM (OK)
 class ValidLicenseTagSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addLicense("GPLv3+")
         self.inspection = "license"
         self.result = "INFO"
@@ -133,7 +133,7 @@ class ValidLicenseTagSRPM(TestSRPM):
 # Valid License tag passes on RPMs (OK)
 class ValidLicenseTagRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addLicense("GPLv3+")
         self.inspection = "license"
         self.result = "INFO"
@@ -143,7 +143,7 @@ class ValidLicenseTagRPMs(TestRPMs):
 # Valid License tag passes on Koji build (OK)
 class ValidLicenseTagKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense("GPLv3+")
         self.inspection = "license"
         self.result = "INFO"
@@ -153,7 +153,7 @@ class ValidLicenseTagKoji(TestKoji):
 # Valid License tag with spaces passes on SRPM (OK)
 class ValidLicenseTagWithSpacesSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addLicense("ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
@@ -163,7 +163,7 @@ class ValidLicenseTagWithSpacesSRPM(TestSRPM):
 # Valid License tag with spaces passes on RPMs (OK)
 class ValidLicenseTagWithSpacesRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addLicense("ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
@@ -173,7 +173,7 @@ class ValidLicenseTagWithSpacesRPMs(TestRPMs):
 # Valid License tag with spaces passes on Koji build (OK)
 class ValidLicenseTagWithSpacesKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense("ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
@@ -183,7 +183,7 @@ class ValidLicenseTagWithSpacesKoji(TestKoji):
 # Valid License tag with spaces passes on SRPM (OK)
 class ValidLicenseTagWithBooleanSpacesSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addLicense("GPLv3+ and ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
@@ -193,7 +193,7 @@ class ValidLicenseTagWithBooleanSpacesSRPM(TestSRPM):
 # Valid License tag with spaces passes on RPMs (OK)
 class ValidLicenseTagWithBooleanSpacesRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addLicense("ASL 2.0 and GPLv3+")
         self.inspection = "license"
         self.result = "INFO"
@@ -203,7 +203,7 @@ class ValidLicenseTagWithBooleanSpacesRPMs(TestRPMs):
 # Valid License tag with spaces passes on Koji build (OK)
 class ValidLicenseTagWithBooleanSpacesKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense("GPLv3+ or ASL 2.0")
         self.inspection = "license"
         self.result = "INFO"
@@ -213,7 +213,7 @@ class ValidLicenseTagWithBooleanSpacesKoji(TestKoji):
 # Valid License tag with spaces and parens passes on SRPM (OK)
 class ValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addLicense("Artistic 2.0 and (GPL+ or Artistic)")
         self.inspection = "license"
         self.result = "INFO"
@@ -223,7 +223,7 @@ class ValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
 # Valid License tag with spaces and parens passes on RPMs (OK)
 class ValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addLicense("Artistic 2.0 and (GPL+ or Artistic)")
         self.inspection = "license"
         self.result = "INFO"
@@ -233,7 +233,7 @@ class ValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
 # Valid License tag with spaces and parens passes on Koji build (OK)
 class ValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense("Artistic 2.0 and (GPL+ or Artistic)")
         self.inspection = "license"
         self.result = "INFO"
@@ -243,7 +243,7 @@ class ValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
 # Valid License tag with spaces and parens passes on SRPM (OK)
 class AnotherValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
         self.inspection = "license"
         self.result = "INFO"
@@ -253,7 +253,7 @@ class AnotherValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
 # Valid License tag with spaces and parens passes on RPMs (OK)
 class AnotherValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
         self.inspection = "license"
         self.result = "INFO"
@@ -263,7 +263,7 @@ class AnotherValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
 # Valid License tag with spaces and parens passes on Koji build (OK)
 class AnotherValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
         self.inspection = "license"
         self.result = "INFO"
@@ -273,7 +273,7 @@ class AnotherValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
 # Valid glibc License tag on Koji build (OK)
 class ValidGlibcLicenseTagKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense(
             "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions "
             "and BSD and Inner-Net and ISC and Public Domain and GFDL"
@@ -286,7 +286,7 @@ class ValidGlibcLicenseTagKoji(TestKoji):
 # Valid perl-HTTP-Message License tag on Koji build (OK)
 class ValidPerlHTTPMessageLicenseTagKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense("(GPL+ or Artistic) and CC0")
         self.inspection = "license"
         self.result = "INFO"
@@ -296,7 +296,7 @@ class ValidPerlHTTPMessageLicenseTagKoji(TestKoji):
 # Valid License string without any official abbreviations (OK)
 class ValidLoremIpsonLicenseTagSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addLicense(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"  # noqa: E501
         )
@@ -307,7 +307,7 @@ class ValidLoremIpsonLicenseTagSRPM(TestSRPM):
 
 class ValidLoremIpsonLicenseTagRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addLicense(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"  # noqa: E501
         )
@@ -318,7 +318,7 @@ class ValidLoremIpsonLicenseTagRPMs(TestRPMs):
 
 class ValidLoremIpsonLicenseTagKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"  # noqa: E501
         )
@@ -330,7 +330,7 @@ class ValidLoremIpsonLicenseTagKoji(TestKoji):
 # Invalid use of fedora_name string when an abbreviation is available (BAD)
 class InvalidUseOfLicenseStringSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addLicense("Apache Software License 2.0")
         self.inspection = "license"
         self.result = "BAD"
@@ -339,7 +339,7 @@ class InvalidUseOfLicenseStringSRPM(TestSRPM):
 
 class InvalidUseOfLicenseStringRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addLicense("Apache Software License 2.0")
         self.inspection = "license"
         self.result = "BAD"
@@ -348,7 +348,7 @@ class InvalidUseOfLicenseStringRPMs(TestRPMs):
 
 class InvalidUseOfLicenseStringKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addLicense("Apache Software License 2.0")
         self.inspection = "license"
         self.result = "BAD"

--- a/test/test_lostpayload.py
+++ b/test/test_lostpayload.py
@@ -22,7 +22,7 @@ from baseclass import TestCompareKoji
 # New package has empty payload across Koji builds (VERIFY)
 class NewPkgHasEmptyPayload(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_payload_file()
         self.after_rpm.add_subpackage(self.after_rpm.name + "-newthing")
         self.inspection = "lostpayload"
@@ -33,7 +33,7 @@ class NewPkgHasEmptyPayload(TestCompareKoji):
 # Packages continue to be empty (INFO)
 class PkgStillHasEmptyPayload(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.inspection = "lostpayload"
         self.result = "INFO"
 
@@ -41,7 +41,7 @@ class PkgStillHasEmptyPayload(TestCompareKoji):
 # Package lost payload across Koji builds (VERIFY)
 class PkgLostPayload(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_payload_file()
         self.inspection = "lostpayload"
         self.result = "VERIFY"
@@ -51,7 +51,7 @@ class PkgLostPayload(TestCompareKoji):
 # Existing package is now missing across Koji builds (VERIFY)
 class ExistingPkgMissing(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_simple_payload_file()
         self.before_rpm.add_subpackage(self.before_rpm.name + "-newthing")
         self.inspection = "lostpayload"

--- a/test/test_lto.py
+++ b/test/test_lto.py
@@ -36,7 +36,7 @@ lto_src = open(datadir + "/mathlib.c").read()
 # No LTO symbols in .o files (OK)
 class NoLTOSymbolsRelocRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             sourceContent=lto_src,
             compileFlags="-c -fno-lto -o a.out",
@@ -48,7 +48,7 @@ class NoLTOSymbolsRelocRPMs(TestRPMs):
 
 class NoLTOSymbolsRelocKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             sourceContent=lto_src,
             compileFlags="-c -fno-lto -o a.out",
@@ -60,7 +60,7 @@ class NoLTOSymbolsRelocKoji(TestKoji):
 
 class NoLTOSymbolsRelocCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.after_rpm.add_simple_compilation(
             sourceContent=lto_src,
             compileFlags="-c -fno-lto -o a.out",
@@ -72,7 +72,7 @@ class NoLTOSymbolsRelocCompareRPMs(TestCompareRPMs):
 
 class NoLTOSymbolsRelocCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.after_rpm.add_simple_compilation(
             sourceContent=lto_src,
             compileFlags="-c -fno-lto -o a.out",
@@ -85,7 +85,7 @@ class NoLTOSymbolsRelocCompareKoji(TestCompareKoji):
 # No LTO symbols in .a files (OK)
 class NoLTOSymbolsStaticLibRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # first create an object file
         self.rpm.add_simple_compilation(
@@ -107,7 +107,7 @@ class NoLTOSymbolsStaticLibRPMs(TestRPMs):
 
 class NoLTOSymbolsStaticLibKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # first create an object file
         self.rpm.add_simple_compilation(
@@ -129,7 +129,7 @@ class NoLTOSymbolsStaticLibKoji(TestKoji):
 
 class NoLTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # first create an object file
         self.after_rpm.add_simple_compilation(
@@ -151,7 +151,7 @@ class NoLTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
 
 class NoLTOSymbolsStaticLibCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # first create an object file
         self.after_rpm.add_simple_compilation(
@@ -174,7 +174,7 @@ class NoLTOSymbolsStaticLibCompareKoji(TestCompareKoji):
 # LTO symbols present in .o files (BAD)
 class LTOSymbolsRelocRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             sourceContent=lto_src,
             compileFlags="-c -flto -o a.out",
@@ -187,7 +187,7 @@ class LTOSymbolsRelocRPMs(TestRPMs):
 
 class LTOSymbolsRelocKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_simple_compilation(
             sourceContent=lto_src,
             compileFlags="-c -flto -o a.out",
@@ -200,7 +200,7 @@ class LTOSymbolsRelocKoji(TestKoji):
 
 class LTOSymbolsRelocCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.after_rpm.add_simple_compilation(
             sourceContent=lto_src,
             compileFlags="-c -flto -o a.out",
@@ -213,7 +213,7 @@ class LTOSymbolsRelocCompareRPMs(TestCompareRPMs):
 
 class LTOSymbolsRelocCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.after_rpm.add_simple_compilation(
             sourceContent=lto_src,
             compileFlags="-c -flto -o a.out",
@@ -227,7 +227,7 @@ class LTOSymbolsRelocCompareKoji(TestCompareKoji):
 # LTO symbols present in .a files (BAD)
 class LTOSymbolsStaticLibRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # first create an object file
         self.rpm.add_simple_compilation(
@@ -250,7 +250,7 @@ class LTOSymbolsStaticLibRPMs(TestRPMs):
 
 class LTOSymbolsStaticLibKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # first create an object file
         self.rpm.add_simple_compilation(
@@ -273,7 +273,7 @@ class LTOSymbolsStaticLibKoji(TestKoji):
 
 class LTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # first create an object file
         self.after_rpm.add_simple_compilation(
@@ -296,7 +296,7 @@ class LTOSymbolsStaticLibCompareRPMs(TestCompareRPMs):
 
 class LTOSymbolsStaticLibCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # first create an object file
         self.after_rpm.add_simple_compilation(

--- a/test/test_manpage.py
+++ b/test/test_manpage.py
@@ -29,7 +29,7 @@ from baseclass import TestRPMs, TestKoji, TestCompareRPMs, TestCompareKoji
 # Man page in the correct section subdirectory in RPM (OK)
 class ManPageCorrectSectionRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.rpm.header += "%global __brp_compress /bin/true\n"
@@ -48,7 +48,7 @@ class ManPageCorrectSectionRPM(TestRPMs):
 # Man page in the correct section subdirectory in Koji build (OK)
 class ManPageCorrectSectionKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.rpm.header += "%global __brp_compress /bin/true\n"
@@ -67,7 +67,7 @@ class ManPageCorrectSectionKoji(TestKoji):
 # Man page in the correct section subdirectory in compare RPMs (OK)
 class ManPageCorrectSectionCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.before_rpm.header += "%global __brp_compress /bin/true\n"
@@ -91,7 +91,7 @@ class ManPageCorrectSectionCompareRPMs(TestCompareRPMs):
 # Man page in the correct section subdirectory in compare Koji (OK)
 class ManPageCorrectSectionCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.before_rpm.header += "%global __brp_compress /bin/true\n"
@@ -117,7 +117,7 @@ class ManPageNotGzippedRPM(TestRPMs):
     # Don't use add_manpage() here so we can disable automatic compression
     # of man pages and construct the correct %files section.
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.rpm.header += "%global __brp_compress /bin/true\n"
@@ -139,7 +139,7 @@ class ManPageNotGzippedKoji(TestKoji):
     # Don't use add_manpage() here so we can disable automatic compression
     # of man pages and construct the correct %files section.
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.rpm.header += "%global __brp_compress /bin/true\n"
@@ -161,7 +161,7 @@ class ManPageNotGzippedCompareRPMs(TestCompareRPMs):
     # Don't use add_manpage() here so we can disable automatic compression
     # of man pages and construct the correct %files section.
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.before_rpm.header += "%global __brp_compress /bin/true\n"
@@ -188,7 +188,7 @@ class ManPageNotGzippedCompareKoji(TestCompareKoji):
     # Don't use add_manpage() here so we can disable automatic compression
     # of man pages and construct the correct %files section.
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.before_rpm.header += "%global __brp_compress /bin/true\n"
@@ -213,7 +213,7 @@ class ManPageNotGzippedCompareKoji(TestCompareKoji):
 # Man page in wrong section subdirectory in RPM (VERIFY)
 class ManPageWrongSectionRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_manpage(
             sourceFileName="foo.8", installPath="usr/share/man/man1/foo.8.gz"
         )
@@ -225,7 +225,7 @@ class ManPageWrongSectionRPM(TestRPMs):
 # Man page in wrong section subdirectory in Koji build (VERIFY)
 class ManPageWrongSectionKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_manpage(
             sourceFileName="foo.8", installPath="usr/share/man/man1/foo.8.gz"
         )
@@ -237,7 +237,7 @@ class ManPageWrongSectionKoji(TestKoji):
 # Man page in wrong section subdirectory in compare RPMs (VERIFY)
 class ManPageWrongSectionCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_manpage(
             sourceFileName="foo.8", installPath="usr/share/man/man1/foo.8.gz"
         )
@@ -252,7 +252,7 @@ class ManPageWrongSectionCompareRPMs(TestCompareRPMs):
 # Man page in wrong section subdirectory in compare Koji (VERIFY)
 class ManPageWrongSectionCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_manpage(
             sourceFileName="foo.8", installPath="usr/share/man/man1/foo.8.gz"
         )
@@ -267,7 +267,7 @@ class ManPageWrongSectionCompareKoji(TestCompareKoji):
 # Invalid man page syntax in RPM (VERIFY)
 class InvalidManPageRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.rpm.header += "%global __brp_compress /bin/true\n"
@@ -287,7 +287,7 @@ class InvalidManPageRPM(TestRPMs):
 # Invalid man page syntax in Koji build (VERIFY)
 class InvalidManPageKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.rpm.header += "%global __brp_compress /bin/true\n"
@@ -307,7 +307,7 @@ class InvalidManPageKoji(TestKoji):
 # Invalid man page syntax in compare RPMs (VERIFY)
 class InvalidManPageCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.before_rpm.header += "%global __brp_compress /bin/true\n"
@@ -332,7 +332,7 @@ class InvalidManPageCompareRPMs(TestCompareRPMs):
 # Invalid man page syntax in compare Koji (VERIFY)
 class InvalidManPageCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.before_rpm.header += "%global __brp_compress /bin/true\n"
@@ -357,7 +357,7 @@ class InvalidManPageCompareKoji(TestCompareKoji):
 # Empty but compressed man page RPM build (VERIFY)
 class EmptyManPageRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.rpm.header += "%global __brp_compress /bin/true\n"
@@ -380,7 +380,7 @@ class EmptyManPageRPM(TestRPMs):
 # Empty but compressed man page Koji build (VERIFY)
 class EmptyManPageKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.rpm.header += "%global __brp_compress /bin/true\n"
@@ -403,7 +403,7 @@ class EmptyManPageKoji(TestKoji):
 # Empty but compressed man page compare RPM builds (VERIFY)
 class EmptyManPageCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.after_rpm.header += "%global __brp_compress /bin/true\n"
@@ -426,7 +426,7 @@ class EmptyManPageCompareRPMs(TestCompareRPMs):
 # Empty but compressed man page compare Koji builds (VERIFY)
 class EmptyManPageCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # disable automatic man page compression in rpmbuild
         self.after_rpm.header += "%global __brp_compress /bin/true\n"

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -30,7 +30,7 @@ from baseclass import (
 # Verify valid Vendor passes on an SRPM (OK)
 class ValidVendorSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.result = "OK"
@@ -39,7 +39,7 @@ class ValidVendorSRPM(TestSRPM):
 # Verify valid Vendor passes on binary RPMs (OK)
 class ValidVendorRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.result = "OK"
@@ -48,7 +48,7 @@ class ValidVendorRPMs(TestRPMs):
 # Verify valid Vendor passes on Koji build (OK)
 class ValidVendorKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.result = "OK"
@@ -57,7 +57,7 @@ class ValidVendorKojiBuild(TestKoji):
 # Verify invalid Vendor fails on an SRPM (BAD)
 class InvalidVendorSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addVendor("Amalgamated Amalgamations LLC")
         self.inspection = "metadata"
         self.result = "BAD"
@@ -67,7 +67,7 @@ class InvalidVendorSRPM(TestSRPM):
 # Verify invalid Vendor fails on binary RPMs (BAD)
 class InvalidVendorRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.addVendor("Amalgamated Amalgamations LLC")
         self.inspection = "metadata"
         self.result = "BAD"
@@ -77,7 +77,7 @@ class InvalidVendorRPMs(TestRPMs):
 # Verify invalid Vendor fails on Koji build (BAD)
 class InvalidVendorKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addVendor("Amalgamated Amalgamations LLC")
         self.inspection = "metadata"
         self.result = "BAD"
@@ -87,7 +87,7 @@ class InvalidVendorKojiBuild(TestKoji):
 # Verify gaining Vendor reports verify on SRPM (VERIFY)
 class GainingVendorCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.after_rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.result = "VERIFY"
@@ -97,7 +97,7 @@ class GainingVendorCompareSRPM(TestCompareSRPM):
 # Verify gaining Vendor reports verify on built RPMS (VERIFY)
 class GainingVendorCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.after_rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.result = "VERIFY"
@@ -107,7 +107,7 @@ class GainingVendorCompareRPMs(TestCompareRPMs):
 # Verify gaining Vendor reports verify on Koji build (VERIFY)
 class GainingVendorCompareKojiBuild(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.after_rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.result = "VERIFY"
@@ -117,7 +117,7 @@ class GainingVendorCompareKojiBuild(TestCompareKoji):
 # Verify losing Vendor reports verify on SRPM (VERIFY)
 class LosingVendorCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.waiver_auth = "Anyone"
@@ -128,7 +128,7 @@ class LosingVendorCompareSRPM(TestCompareSRPM):
 # Verify losing Vendor reports verify on built RPMs (VERIFY)
 class LosingVendorCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.waiver_auth = "Anyone"
@@ -139,7 +139,7 @@ class LosingVendorCompareRPMs(TestCompareRPMs):
 # Verify losing Vendor reports verify on Koji build (VERIFY)
 class LosingVendorCompareKojiBuild(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.addVendor(VENDOR)
         self.inspection = "metadata"
         self.waiver_auth = "Anyone"
@@ -149,7 +149,7 @@ class LosingVendorCompareKojiBuild(TestCompareKoji):
 # Verify changing Vendor reports verify on SRPM (VERIFY)
 class ChangingVendorCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.addVendor("Amalgamated Amalgamations LLC")
         self.after_rpm.addVendor(VENDOR)
         self.inspection = "metadata"
@@ -161,7 +161,7 @@ class ChangingVendorCompareSRPM(TestCompareSRPM):
 # Verify changing Vendor reports verify on built RPMs (VERIFY)
 class ChangingVendorCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.addVendor("Amalgamated Amalgamations LLC")
         self.after_rpm.addVendor(VENDOR)
         self.inspection = "metadata"
@@ -172,7 +172,7 @@ class ChangingVendorCompareRPMs(TestCompareRPMs):
 # Verify changing Vendor reports verify on Koji build (VERIFY)
 class LosingVendorCompareKojiBeforeAfterBuild(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.addVendor("Amalgamated Amalgamations LLC")
         self.after_rpm.addVendor(VENDOR)
         self.inspection = "metadata"
@@ -183,7 +183,7 @@ class LosingVendorCompareKojiBeforeAfterBuild(TestCompareKoji):
 # Verify invalid Buildhost subdomain fails on an SRPM (BAD)
 class InvalidBuildhostSubdomainSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.buildhost_subdomain = ".totallylegitbuilder.com"
         self.rpm.addVendor(VENDOR)
         self.inspection = "metadata"
@@ -194,7 +194,7 @@ class InvalidBuildhostSubdomainSRPM(TestSRPM):
 # Verify invalid Buildhost subdomain fails on binary RPMs (BAD)
 class InvalidBuildhostSubdomainRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.buildhost_subdomain = ".totallylegitbuilder.com"
         self.rpm.addVendor(VENDOR)
         self.inspection = "metadata"
@@ -205,7 +205,7 @@ class InvalidBuildhostSubdomainRPMs(TestRPMs):
 # Verify invalid Buildhost subdomain fails on Koji build (BAD)
 class InvalidBuildhostSubdomainKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.buildhost_subdomain = ".totallylegitbuilder.com"
         self.rpm.addVendor(VENDOR)
         self.inspection = "metadata"
@@ -216,7 +216,7 @@ class InvalidBuildhostSubdomainKojiBuild(TestKoji):
 # Verify Summary without bad words passes on an SRPM (OK)
 class CleanSummarySRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.add_summary("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
         self.result = "OK"
@@ -225,7 +225,7 @@ class CleanSummarySRPM(TestSRPM):
 # Verify Summary without bad words passes on binary RPMs (OK)
 class CleanSummaryRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_summary("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
         self.result = "OK"
@@ -234,7 +234,7 @@ class CleanSummaryRPMs(TestRPMs):
 # Verify Summary without bad words passes on Koji build (OK)
 class CleanSummaryKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_summary("Lorem ipsum dolor sit amet")
         self.inspection = "metadata"
         self.result = "OK"
@@ -243,7 +243,7 @@ class CleanSummaryKojiBuild(TestKoji):
 # Verify Summary with bad words fails on an SRPM (BAD)
 class DirtySummarySRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.add_summary("Lorem ipsum reallybadword dolor sit amet")
         self.inspection = "metadata"
         self.result = "BAD"
@@ -253,7 +253,7 @@ class DirtySummarySRPM(TestSRPM):
 # Verify Summary with bad words fails on binary RPMs (BAD)
 class DirtySummaryRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_summary("Lorem ipsum reallybadword dolor sit amet")
         self.inspection = "metadata"
         self.result = "BAD"
@@ -263,7 +263,7 @@ class DirtySummaryRPMs(TestRPMs):
 # Verify Summary with bad words fails on Koji build (BAD)
 class DirtySummaryKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_summary("Lorem ipsum reallybadword dolor sit amet")
         self.inspection = "metadata"
         self.result = "BAD"
@@ -273,7 +273,7 @@ class DirtySummaryKojiBuild(TestKoji):
 # Verify changing Summary reports verify on SRPM (INFO)
 class ChangingSummaryCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.add_summary("Lorem ipsum dolor sit amet")
         self.after_rpm.add_summary("Lorem ipsum")
         self.inspection = "metadata"
@@ -284,7 +284,7 @@ class ChangingSummaryCompareSRPM(TestCompareSRPM):
 # Verify changing Summary reports verify on built RPMs (INFO)
 class ChangingSummaryCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_summary("Lorem ipsum dolor sit amet")
         self.after_rpm.add_summary("Lorem ipsum")
         self.inspection = "metadata"
@@ -295,7 +295,7 @@ class ChangingSummaryCompareRPMs(TestCompareRPMs):
 # Verify changing Summary reports verify on Koji build (INFO)
 class ChangingSummaryCompareKojiBuild(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_summary("Lorem ipsum dolor sit amet")
         self.after_rpm.add_summary("Lorem ipsum")
         self.inspection = "metadata"
@@ -306,7 +306,7 @@ class ChangingSummaryCompareKojiBuild(TestCompareKoji):
 # Verify Description without bad words passes on an SRPM (OK)
 class CleanDescriptionSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.add_description(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor "
             "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "
@@ -322,7 +322,7 @@ class CleanDescriptionSRPM(TestSRPM):
 # Verify Description without bad words passes on binary RPMs (OK)
 class CleanDescriptionRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_description(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor "
             "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "
@@ -338,7 +338,7 @@ class CleanDescriptionRPMs(TestRPMs):
 # Verify Description without bad words passes on Koji build (OK)
 class CleanDescriptionKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_description(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor "
             "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "
@@ -354,7 +354,7 @@ class CleanDescriptionKojiBuild(TestKoji):
 # Verify Description with bad words fails on an SRPM (BAD)
 class DirtyDescriptionSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.add_description(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod reallybadword "
             "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "
@@ -371,7 +371,7 @@ class DirtyDescriptionSRPM(TestSRPM):
 # Verify Description with bad words fails on binary RPMs (BAD)
 class DirtyDescriptionRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_description(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod reallybadword "
             "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "
@@ -388,7 +388,7 @@ class DirtyDescriptionRPMs(TestRPMs):
 # Verify Description with bad words fails on Koji build (BAD)
 class DirtyDescriptionKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_description(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod reallybadword "
             "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "
@@ -405,7 +405,7 @@ class DirtyDescriptionKojiBuild(TestKoji):
 # Verify changing Description reports verify on SRPM (INFO)
 class ChangingDescriptionCompareSRPM(TestCompareSRPM):
     def setUp(self):
-        TestCompareSRPM.setUp(self)
+        super().setUp()
         self.before_rpm.add_description(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod reallybadword "
             "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "
@@ -423,7 +423,7 @@ class ChangingDescriptionCompareSRPM(TestCompareSRPM):
 # Verify changing Description reports verify on built RPMs (INFO)
 class ChangingDescriptionCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_description(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod reallybadword "
             "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "
@@ -441,7 +441,7 @@ class ChangingDescriptionCompareRPMs(TestCompareRPMs):
 # Verify changing Description reports verify on Koji build (INFO)
 class ChangingDescriptionCompareKojiBuild(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_description(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod reallybadword "
             "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "

--- a/test/test_ownership.py
+++ b/test/test_ownership.py
@@ -56,7 +56,7 @@ class SlashBinOwnedByRootRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -77,7 +77,7 @@ class SlashSbinOwnedByRootRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -98,7 +98,7 @@ class SlashUsrSlashBinOwnedByRootRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -119,7 +119,7 @@ class SlashUsrSlashSbinOwnedByRootRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -140,7 +140,7 @@ class SlashBinOwnedByBinRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -162,7 +162,7 @@ class SlashSbinOwnedByBinRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -184,7 +184,7 @@ class SlashUsrSlashBinOwnedByBinRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -206,7 +206,7 @@ class SlashUsrSlashSbinOwnedByBinRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -228,7 +228,7 @@ class SlashBinOwnedByRootKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -249,7 +249,7 @@ class SlashSbinOwnedByRootKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -270,7 +270,7 @@ class SlashUsrSlashBinOwnedByRootKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -291,7 +291,7 @@ class SlashUsrSlashSbinOwnedByRootKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -312,7 +312,7 @@ class SlashBinOwnedByBinKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by bin
         self.rpm.add_installed_file(
@@ -334,7 +334,7 @@ class SlashSbinOwnedByBinKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by bin
         self.rpm.add_installed_file(
@@ -356,7 +356,7 @@ class SlashUsrSlashBinOwnedByBinKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by bin
         self.rpm.add_installed_file(
@@ -378,7 +378,7 @@ class SlashUsrSlashSbinOwnedByBinKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by bin
         self.rpm.add_installed_file(
@@ -400,7 +400,7 @@ class SlashBinOwnedByRootCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -421,7 +421,7 @@ class SlashSbinOwnedByRootCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -442,7 +442,7 @@ class SlashUsrSlashBinOwnedByRootCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -463,7 +463,7 @@ class SlashUsrSlashSbinOwnedByRootCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -484,7 +484,7 @@ class SlashBinOwnedByBinCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -506,7 +506,7 @@ class SlashSbinOwnedByBinCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -528,7 +528,7 @@ class SlashUsrSlashBinOwnedByBinCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -550,7 +550,7 @@ class SlashUsrSlashSbinOwnedByBinCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -572,7 +572,7 @@ class SlashBinOwnedByRootCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -593,7 +593,7 @@ class SlashSbinOwnedByRootCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -614,7 +614,7 @@ class SlashUsrSlashBinOwnedByRootCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -635,7 +635,7 @@ class SlashUsrSlashSbinOwnedByRootCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -656,7 +656,7 @@ class SlashBinOwnedByBinCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -678,7 +678,7 @@ class SlashSbinOwnedByBinCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -700,7 +700,7 @@ class SlashUsrSlashBinOwnedByBinCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -722,7 +722,7 @@ class SlashUsrSlashSbinOwnedByBinCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -749,7 +749,7 @@ class SlashBinOwnedByGroupRootRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -770,7 +770,7 @@ class SlashSbinOwnedByGroupRootRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -791,7 +791,7 @@ class SlashUsrSlashBinOwnedByGroupRootRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -812,7 +812,7 @@ class SlashUsrSlashSbinOwnedByGroupRootRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -833,7 +833,7 @@ class SlashBinOwnedByGroupBinRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -855,7 +855,7 @@ class SlashSbinOwnedByGroupBinRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -877,7 +877,7 @@ class SlashiUsrSlashBinOwnedByGroupBinRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -899,7 +899,7 @@ class SlashUsrSlashSbinOwnedByGroupBinRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -921,7 +921,7 @@ class SlashBinOwnedByGroupRootKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -942,7 +942,7 @@ class SlashSbinOwnedByGroupRootKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -963,7 +963,7 @@ class SlashUsrSlashBinOwnedByGroupRootKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -984,7 +984,7 @@ class SlashUsrSlashSbinOwnedByGroupRootKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -1005,7 +1005,7 @@ class SlashBinOwnedByGroupBinKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -1027,7 +1027,7 @@ class SlashSbinOwnedByGroupBinKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -1049,7 +1049,7 @@ class SlashUsrSlashBinOwnedByGroupBinKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -1071,7 +1071,7 @@ class SlashUsrSlashSbinOwnedByGroupBinKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -1093,7 +1093,7 @@ class SlashBinOwnedByGroupRootCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1114,7 +1114,7 @@ class SlashSbinOwnedByGroupRootCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1135,7 +1135,7 @@ class SlashUsrSlashBinOwnedByGroupRootCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1156,7 +1156,7 @@ class SlashUsrSlashSbinOwnedByGroupRootCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1177,7 +1177,7 @@ class SlashBinOwnedByGroupBinCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1199,7 +1199,7 @@ class SlashSbinOwnedByGroupBinCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1221,7 +1221,7 @@ class SlashUsrSlashBinOwnedByGroupBinCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1243,7 +1243,7 @@ class SlashUsrSlashSbinOwnedByGroupBinCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1265,7 +1265,7 @@ class SlashBinOwnedByGroupRootCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1286,7 +1286,7 @@ class SlashSbinOwnedByGroupRootCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1307,7 +1307,7 @@ class SlashUsrSlashBinOwnedByGroupRootCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1328,7 +1328,7 @@ class SlashUsrSlashSbinOwnedByGroupRootCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1349,7 +1349,7 @@ class SlashBinOwnedByGroupBinCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1371,7 +1371,7 @@ class SlashSbinOwnedByGroupBinCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1393,7 +1393,7 @@ class SlashUsrSlashBinOwnedByGroupBinCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1415,7 +1415,7 @@ class SlashUsrSlashSbinOwnedByGroupBinCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1441,7 +1441,7 @@ class SlashBinOwnedByMockRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -1462,7 +1462,7 @@ class SlashBinOwnedByMockKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -1484,7 +1484,7 @@ class SlashBinOwnedByMockCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1506,7 +1506,7 @@ class SlashBinOwnedByMockCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1533,7 +1533,7 @@ class SlashBinOwnedByGroupMockRPMs(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -1555,7 +1555,7 @@ class SlashBinOwnedByGroupMockKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.rpm.add_installed_file(
@@ -1577,7 +1577,7 @@ class SlashBinOwnedByGroupMockCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1599,7 +1599,7 @@ class SlashBinOwnedByGroupMockCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root
         self.after_rpm.add_installed_file(
@@ -1627,7 +1627,7 @@ class CapSETUIDWithOtherExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1657,7 +1657,7 @@ class SecuritySKIPCapSETUIDWithOtherExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1686,7 +1686,7 @@ class SecurityINFORMCapSETUIDWithOtherExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1716,7 +1716,7 @@ class SecurityVERIFYCapSETUIDWithOtherExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1746,7 +1746,7 @@ class SecurityFAILCapSETUIDWithOtherExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1776,7 +1776,7 @@ class CapSETUIDWithOtherExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1806,7 +1806,7 @@ class SecuritySKIPCapSETUIDWithOtherExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1835,7 +1835,7 @@ class SecurityINFORMCapSETUIDWithOtherExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1865,7 +1865,7 @@ class SecurityVERIFYCapSETUIDWithOtherExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1895,7 +1895,7 @@ class SecurityFAILCapSETUIDWithOtherExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1925,7 +1925,7 @@ class CapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1957,7 +1957,7 @@ class SecuritySKIPCapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -1988,7 +1988,7 @@ class SecurityINFORMCapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2020,7 +2020,7 @@ class SecurityVERIFYCapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2052,7 +2052,7 @@ class SecurityFAILCapSETUIDWithOtherExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2084,7 +2084,7 @@ class CapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2116,7 +2116,7 @@ class SecuritySKIPCapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2147,7 +2147,7 @@ class SecurityINFORMCapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2179,7 +2179,7 @@ class SecurityVERIFYCapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2211,7 +2211,7 @@ class SecurityFAILCapSETUIDWithOtherExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and o+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2248,7 +2248,7 @@ class CapSETUIDWithGroupExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2278,7 +2278,7 @@ class SecuritySKIPCapSETUIDWithGroupExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2307,7 +2307,7 @@ class SecurityINFORMCapSETUIDWithGroupExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2337,7 +2337,7 @@ class SecurityVERIFYCapSETUIDWithGroupExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2367,7 +2367,7 @@ class SecurityFAILCapSETUIDWithGroupExecRPMs(TestRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2397,7 +2397,7 @@ class CapSETUIDWithGroupExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2427,7 +2427,7 @@ class SecuritySKIPCapSETUIDWithGroupExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2456,7 +2456,7 @@ class SecurityINFORMCapSETUIDWithGroupExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2486,7 +2486,7 @@ class SecurityVERIFYCapSETUIDWithGroupExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2516,7 +2516,7 @@ class SecurityFAILCapSETUIDWithGroupExecKoji(TestKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2546,7 +2546,7 @@ class CapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2578,7 +2578,7 @@ class SecuritySKIPCapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2609,7 +2609,7 @@ class SecurityINFORMCapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2641,7 +2641,7 @@ class SecurityVERIFYCapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2673,7 +2673,7 @@ class SecurityFAILCapSETUIDWithGroupExecCompareRPMs(TestCompareRPMs):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2705,7 +2705,7 @@ class CapSETUIDWithGroupExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2737,7 +2737,7 @@ class SecuritySKIPCapSETUIDWithGroupExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2768,7 +2768,7 @@ class SecurityINFORMCapSETUIDWithGroupExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2800,7 +2800,7 @@ class SecurityVERIFYCapSETUIDWithGroupExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2832,7 +2832,7 @@ class SecurityFAILCapSETUIDWithGroupExecCompareKoji(TestCompareKoji):
 
     @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file owned by root w/ setuid capability and g+x mode
         # (basically duplicate add_installed_file() here because we
@@ -2867,7 +2867,7 @@ class FileOwnerChangedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Start with root opwner
         self.before_rpm.add_installed_file(
@@ -2899,7 +2899,7 @@ class FileOwnerChangedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Start with root opwner
         self.before_rpm.add_installed_file(
@@ -2935,7 +2935,7 @@ class FileGroupChangedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Start with root group
         self.before_rpm.add_installed_file(
@@ -2967,7 +2967,7 @@ class FileGroupChangedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Start with root group
         self.before_rpm.add_installed_file(

--- a/test/test_pathmigration.py
+++ b/test/test_pathmigration.py
@@ -29,7 +29,7 @@ from baseclass import TestRPMs, TestCompareRPMs, TestKoji, TestCompareKoji
 # File in /bin in RPM (VERIFY)
 class SlashBinFileRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /bin/hello-world
         self.rpm.add_simple_compilation(installPath="bin/hello-world")
@@ -42,7 +42,7 @@ class SlashBinFileRPM(TestRPMs):
 # File in /bin in compare RPM (VERIFY)
 class SlashBinFileCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /bin/hello-world
         self.before_rpm.add_simple_compilation(installPath="bin/hello-world")
@@ -56,7 +56,7 @@ class SlashBinFileCompareRPMs(TestCompareRPMs):
 # File in /bin in Koji build (VERIFY)
 class SlashBinFileKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /bin/hello-world
         self.rpm.add_simple_compilation(installPath="bin/hello-world")
@@ -69,7 +69,7 @@ class SlashBinFileKoji(TestKoji):
 # File in /bin in compare Koji build (VERIFY)
 class SlashBinFileCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /bin/hello-world
         self.before_rpm.add_simple_compilation(installPath="bin/hello-world")
@@ -87,7 +87,7 @@ class SlashBinFileCompareKoji(TestCompareKoji):
 # File in /sbin in RPM (VERIFY)
 class SlashSbinFileRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /sbin/hello-world
         self.rpm.add_simple_compilation(installPath="sbin/hello-world")
@@ -100,7 +100,7 @@ class SlashSbinFileRPM(TestRPMs):
 # File in /sbin in compare RPM (VERIFY)
 class SlashSbinFileCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /sbin/hello-world
         self.before_rpm.add_simple_compilation(installPath="sbin/hello-world")
@@ -114,7 +114,7 @@ class SlashSbinFileCompareRPMs(TestCompareRPMs):
 # File in /sbin in Koji build (VERIFY)
 class SlashSbinFileKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /sbin/hello-world
         self.rpm.add_simple_compilation(installPath="sbin/hello-world")
@@ -127,7 +127,7 @@ class SlashSbinFileKoji(TestKoji):
 # File in /sbin in compare Koji build (VERIFY)
 class SlashSbinFileCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /sbin/hello-world
         self.before_rpm.add_simple_compilation(installPath="sbin/hello-world")
@@ -145,7 +145,7 @@ class SlashSbinFileCompareKoji(TestCompareKoji):
 # File in /lib in RPM (VERIFY)
 class SlashLibFileRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /lib/libfoo.so
         self.rpm.add_simple_compilation(installPath="lib/libfoo.so")
@@ -158,7 +158,7 @@ class SlashLibFileRPM(TestRPMs):
 # File in /lib in compare RPM (VERIFY)
 class SlashLibFileCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /lib/libfoo.so
         self.before_rpm.add_simple_compilation(installPath="lib/libfoo.so")
@@ -172,7 +172,7 @@ class SlashLibFileCompareRPMs(TestCompareRPMs):
 # File in /lib in Koji build (VERIFY)
 class SlashLibFileKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /lib/libfoo.so
         self.rpm.add_simple_compilation(installPath="lib/libfoo.so")
@@ -185,7 +185,7 @@ class SlashLibFileKoji(TestKoji):
 # File in /lib in compare Koji build (VERIFY)
 class SlashLibFileCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /lib/libfoo.so
         self.before_rpm.add_simple_compilation(installPath="lib/libfoo.so")
@@ -203,7 +203,7 @@ class SlashLibFileCompareKoji(TestCompareKoji):
 # File in /lib64 in RPM (VERIFY)
 class SlashLib64FileRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # Adds /lib64/libfoo.so
         self.rpm.add_simple_compilation(installPath="lib64/libfoo.so")
@@ -216,7 +216,7 @@ class SlashLib64FileRPM(TestRPMs):
 # File in /lib64 in compare RPM (VERIFY)
 class SlashLib64FileCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # Adds /lib64/libfoo.so
         self.before_rpm.add_simple_compilation(installPath="lib64/libfoo.so")
@@ -230,7 +230,7 @@ class SlashLib64FileCompareRPMs(TestCompareRPMs):
 # File in /lib64 in Koji build (VERIFY)
 class SlashLib64FileKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # Adds /lib64/libfoo.so
         self.rpm.add_simple_compilation(installPath="lib64/libfoo.so")
@@ -243,7 +243,7 @@ class SlashLib64FileKoji(TestKoji):
 # File in /lib64 in compare Koji build (VERIFY)
 class SlashLib64FileCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # Adds /lib64/libfoo.so
         self.before_rpm.add_simple_compilation(installPath="lib64/libfoo.so")

--- a/test/test_runpath.py
+++ b/test/test_runpath.py
@@ -28,7 +28,7 @@ datadir = os.environ["RPMINSPECT_TEST_DATA_PATH"]
 #####################################################################
 class ValidRPATH1RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN' a.out\n"
@@ -39,7 +39,7 @@ class ValidRPATH1RPMs(TestRPMs):
 
 class ValidRPATH1Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN' a.out\n"
@@ -50,7 +50,7 @@ class ValidRPATH1Koji(TestKoji):
 
 class ValidRPATH1CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN' a.out\n"
@@ -61,7 +61,7 @@ class ValidRPATH1CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH1CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN' a.out\n"
@@ -75,7 +75,7 @@ class ValidRPATH1CompareKoji(TestCompareKoji):
 ######################################################################
 class ValidRPATH2RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN/' a.out\n"
@@ -86,7 +86,7 @@ class ValidRPATH2RPMs(TestRPMs):
 
 class ValidRPATH2Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN/' a.out\n"
@@ -97,7 +97,7 @@ class ValidRPATH2Koji(TestKoji):
 
 class ValidRPATH2CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN/' a.out\n"
@@ -108,7 +108,7 @@ class ValidRPATH2CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH2CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN/' a.out\n"
@@ -122,7 +122,7 @@ class ValidRPATH2CompareKoji(TestCompareKoji):
 ###############################################################################################
 class ValidRPATH3RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += (
@@ -136,7 +136,7 @@ class ValidRPATH3RPMs(TestRPMs):
 
 class ValidRPATH3Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += (
@@ -150,7 +150,7 @@ class ValidRPATH3Koji(TestKoji):
 
 class ValidRPATH3CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN/../lib/jli:$ORIGIN/../lib' a.out\n"  # noqa: E501
@@ -162,7 +162,7 @@ class ValidRPATH3CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH3CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '$ORIGIN/../lib/jli:$ORIGIN/../lib' a.out\n"  # noqa: E501
@@ -177,7 +177,7 @@ class ValidRPATH3CompareKoji(TestCompareKoji):
 ##############################################################################
 class ValidRPATH4RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN/../lib64' a.out\n"
@@ -188,7 +188,7 @@ class ValidRPATH4RPMs(TestRPMs):
 
 class ValidRPATH4Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '$ORIGIN/../lib64' a.out\n"
@@ -199,7 +199,7 @@ class ValidRPATH4Koji(TestKoji):
 
 class ValidRPATH4CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (
@@ -212,7 +212,7 @@ class ValidRPATH4CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH4CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (
@@ -228,7 +228,7 @@ class ValidRPATH4CompareKoji(TestCompareKoji):
 ####################################################################################
 class ValidRPATH5RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += (
@@ -241,7 +241,7 @@ class ValidRPATH5RPMs(TestRPMs):
 
 class ValidRPATH5Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += (
@@ -254,7 +254,7 @@ class ValidRPATH5Koji(TestKoji):
 
 class ValidRPATH5CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (
@@ -267,7 +267,7 @@ class ValidRPATH5CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH5CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (
@@ -283,7 +283,7 @@ class ValidRPATH5CompareKoji(TestCompareKoji):
 ################################################################################################
 class InvalidRPATH1RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/jq-1.6/.libs' a.out\n"  # noqa: E501
@@ -295,7 +295,7 @@ class InvalidRPATH1RPMs(TestRPMs):
 
 class InvalidRPATH1Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/jq-1.6/.libs' a.out\n"  # noqa: E501
@@ -307,7 +307,7 @@ class InvalidRPATH1Koji(TestKoji):
 
 class InvalidRPATH1CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/jq-1.6/.libs' a.out\n"  # noqa: E501
@@ -319,7 +319,7 @@ class InvalidRPATH1CompareRPMs(TestCompareRPMs):
 
 class InvalidRPATH1CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/jq-1.6/.libs' a.out\n"  # noqa: E501
@@ -334,7 +334,7 @@ class InvalidRPATH1CompareKoji(TestCompareKoji):
 #########################################################################################################################  # noqa: E266,E501
 class InvalidRPATH2RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/texlive-base-20200327/source/inst/lib' a.out\n"  # noqa: E501
@@ -346,7 +346,7 @@ class InvalidRPATH2RPMs(TestRPMs):
 
 class InvalidRPATH2Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/texlive-base-20200327/source/inst/lib' a.out\n"  # noqa: E501
@@ -358,7 +358,7 @@ class InvalidRPATH2Koji(TestKoji):
 
 class InvalidRPATH2CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/texlive-base-20200327/source/inst/lib' a.out\n"  # noqa: E501
@@ -370,7 +370,7 @@ class InvalidRPATH2CompareRPMs(TestCompareRPMs):
 
 class InvalidRPATH2CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/builddir/build/BUILD/texlive-base-20200327/source/inst/lib' a.out\n"  # noqa: E501
@@ -385,7 +385,7 @@ class InvalidRPATH2CompareKoji(TestCompareKoji):
 ##############################################################################
 class ValidRPATH6RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib/systemd' a.out\n"
@@ -397,7 +397,7 @@ class ValidRPATH6RPMs(TestRPMs):
 
 class ValidRPATH6Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib/systemd' a.out\n"
@@ -409,7 +409,7 @@ class ValidRPATH6Koji(TestKoji):
 
 class ValidRPATH6CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (
@@ -423,7 +423,7 @@ class ValidRPATH6CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH6CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (
@@ -440,7 +440,7 @@ class ValidRPATH6CompareKoji(TestCompareKoji):
 ########################################################################
 class ValidRPATH7RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64' a.out\n"
@@ -452,7 +452,7 @@ class ValidRPATH7RPMs(TestRPMs):
 
 class ValidRPATH7Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64' a.out\n"
@@ -464,7 +464,7 @@ class ValidRPATH7Koji(TestKoji):
 
 class ValidRPATH7CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64' a.out\n"
@@ -476,7 +476,7 @@ class ValidRPATH7CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH7CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64' a.out\n"
@@ -491,7 +491,7 @@ class ValidRPATH7CompareKoji(TestCompareKoji):
 #############################################################################
 class ValidRPATH8RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64/sssd' a.out\n"
@@ -503,7 +503,7 @@ class ValidRPATH8RPMs(TestRPMs):
 
 class ValidRPATH8Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64/sssd' a.out\n"
@@ -515,7 +515,7 @@ class ValidRPATH8Koji(TestKoji):
 
 class ValidRPATH8CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64/sssd' a.out\n"
@@ -527,7 +527,7 @@ class ValidRPATH8CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH8CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64/sssd' a.out\n"
@@ -542,7 +542,7 @@ class ValidRPATH8CompareKoji(TestCompareKoji):
 #################################################################################################
 class ValidRPATH9RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64:/usr/lib64/firebird/intl' a.out\n"  # noqa: E501
@@ -554,7 +554,7 @@ class ValidRPATH9RPMs(TestRPMs):
 
 class ValidRPATH9Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/lib64:/usr/lib64/firebird/intl' a.out\n"  # noqa: E501
@@ -566,7 +566,7 @@ class ValidRPATH9Koji(TestKoji):
 
 class ValidRPATH9CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64:/usr/lib64/firebird/intl' a.out\n"  # noqa: E501
@@ -578,7 +578,7 @@ class ValidRPATH9CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH9CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/usr/lib64:/usr/lib64/firebird/intl' a.out\n"  # noqa: E501
@@ -593,7 +593,7 @@ class ValidRPATH9CompareKoji(TestCompareKoji):
 ###############################################################################
 class ValidRPATH10RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/libexec/sudo' a.out\n"
@@ -605,7 +605,7 @@ class ValidRPATH10RPMs(TestRPMs):
 
 class ValidRPATH10Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/libexec/sudo' a.out\n"
@@ -617,7 +617,7 @@ class ValidRPATH10Koji(TestKoji):
 
 class ValidRPATH10CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (
@@ -631,7 +631,7 @@ class ValidRPATH10CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH10CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (
@@ -648,7 +648,7 @@ class ValidRPATH10CompareKoji(TestCompareKoji):
 ##################################################################################################################################  # noqa: E266, E501
 class InvalidRPATH3RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/lib64:$ORIGIN/../etc:$ORIGIN/usr/lib64/:/builddir/build/BUILD/lib64' a.out\n"  # noqa: E501
@@ -660,7 +660,7 @@ class InvalidRPATH3RPMs(TestRPMs):
 
 class InvalidRPATH3Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/lib64:$ORIGIN/../etc:$ORIGIN/usr/lib64/:/builddir/build/BUILD/lib64' a.out\n"  # noqa: E501
@@ -672,7 +672,7 @@ class InvalidRPATH3Koji(TestKoji):
 
 class InvalidRPATH3CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/lib64:$ORIGIN/../etc:$ORIGIN/usr/lib64/:/builddir/build/BUILD/lib64' a.out\n"  # noqa: E501
@@ -684,7 +684,7 @@ class InvalidRPATH3CompareRPMs(TestCompareRPMs):
 
 class InvalidRPATH3CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += "patchelf --set-rpath '/lib64:$ORIGIN/../etc:$ORIGIN/usr/lib64/:/builddir/build/BUILD/lib64' a.out\n"  # noqa: E501
@@ -699,7 +699,7 @@ class InvalidRPATH3CompareKoji(TestCompareKoji):
 ##############################################################################
 class ValidRPATH11RPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/src/kernels/' a.out\n"
@@ -711,7 +711,7 @@ class ValidRPATH11RPMs(TestRPMs):
 
 class ValidRPATH11Koji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_simple_compilation()
         self.rpm.section_build += "patchelf --set-rpath '/usr/src/kernels/' a.out\n"
@@ -723,7 +723,7 @@ class ValidRPATH11Koji(TestKoji):
 
 class ValidRPATH11CompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (
@@ -737,7 +737,7 @@ class ValidRPATH11CompareRPMs(TestCompareRPMs):
 
 class ValidRPATH11CompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         self.after_rpm.add_simple_compilation()
         self.after_rpm.section_build += (

--- a/test/test_shellsyntax.py
+++ b/test/test_shellsyntax.py
@@ -71,7 +71,7 @@ class ShWellFormedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
@@ -86,7 +86,7 @@ class ShMalformedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_sh.sh",
@@ -103,7 +103,7 @@ class ShWellFormedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
@@ -118,7 +118,7 @@ class ShMalformedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_sh.sh",
@@ -135,7 +135,7 @@ class ShWellFormedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
         )
@@ -152,7 +152,7 @@ class ShMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_sh.sh",
             rpmfluff.SourceFile("invalid_sh.sh", invalid_sh),
@@ -172,7 +172,7 @@ class ShWellFormedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
         )
@@ -189,7 +189,7 @@ class ShMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_sh.sh",
             rpmfluff.SourceFile("invalid_sh.sh", invalid_sh),
@@ -209,7 +209,7 @@ class ShWellMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
         )
@@ -228,7 +228,7 @@ class ShWellMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_sh.sh", rpmfluff.SourceFile("valid_sh.sh", valid_sh)
         )
@@ -301,7 +301,7 @@ class KshWellFormedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_ksh.sh",
@@ -317,7 +317,7 @@ class KshMalformedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_ksh.sh",
@@ -334,7 +334,7 @@ class KshWellFormedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_ksh.sh",
@@ -350,7 +350,7 @@ class KshMalformedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_ksh.sh",
@@ -367,7 +367,7 @@ class KshWellFormedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_ksh.sh",
             rpmfluff.SourceFile("valid_ksh.sh", valid_ksh),
@@ -386,7 +386,7 @@ class KshMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_ksh.sh",
             rpmfluff.SourceFile("invalid_ksh.sh", invalid_ksh),
@@ -406,7 +406,7 @@ class KshWellFormedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_ksh.sh",
             rpmfluff.SourceFile("valid_ksh.sh", valid_ksh),
@@ -425,7 +425,7 @@ class KshMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_ksh.sh",
             rpmfluff.SourceFile("invalid_ksh.sh", invalid_ksh),
@@ -445,7 +445,7 @@ class KshWellMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_ksh.sh",
             rpmfluff.SourceFile("valid_ksh.sh", valid_ksh),
@@ -465,7 +465,7 @@ class KshWellMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_ksh.sh",
             rpmfluff.SourceFile("valid_ksh.sh", valid_ksh),
@@ -535,7 +535,7 @@ class ZshWellFormedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_zsh.sh",
@@ -551,7 +551,7 @@ class ZshMalformedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_zsh.sh",
@@ -568,7 +568,7 @@ class ZshWellFormedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_zsh.sh",
@@ -584,7 +584,7 @@ class ZshMalformedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_zsh.sh",
@@ -601,7 +601,7 @@ class ZshWellFormedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_zsh.sh",
             rpmfluff.SourceFile("valid_zsh.sh", valid_zsh),
@@ -620,7 +620,7 @@ class ZshMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_zsh.sh",
             rpmfluff.SourceFile("invalid_zsh.sh", invalid_zsh),
@@ -640,7 +640,7 @@ class ZshWellFormedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_zsh.sh",
             rpmfluff.SourceFile("valid_zsh.sh", valid_zsh),
@@ -659,7 +659,7 @@ class ZshMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_zsh.sh",
             rpmfluff.SourceFile("invalid_zsh.sh", invalid_zsh),
@@ -679,7 +679,7 @@ class ZshWellMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_zsh.sh",
             rpmfluff.SourceFile("valid_zsh.sh", valid_zsh),
@@ -699,7 +699,7 @@ class ZshWellMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_zsh.sh",
             rpmfluff.SourceFile("valid_zsh.sh", valid_zsh),
@@ -786,7 +786,7 @@ class CshWellFormedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_csh.sh",
@@ -802,7 +802,7 @@ class CshMalformedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_csh.sh",
@@ -819,7 +819,7 @@ class CshWellFormedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_csh.sh",
@@ -835,7 +835,7 @@ class CshMalformedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_csh.sh",
@@ -852,7 +852,7 @@ class CshWellFormedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_csh.sh",
             rpmfluff.SourceFile("valid_csh.sh", valid_csh),
@@ -871,7 +871,7 @@ class CshMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_csh.sh",
             rpmfluff.SourceFile("invalid_csh.sh", invalid_csh),
@@ -891,7 +891,7 @@ class CshWellFormedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_csh.sh",
             rpmfluff.SourceFile("valid_csh.sh", valid_csh),
@@ -910,7 +910,7 @@ class CshMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_csh.sh",
             rpmfluff.SourceFile("invalid_csh.sh", invalid_csh),
@@ -930,7 +930,7 @@ class CshWellMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_csh.sh",
             rpmfluff.SourceFile("valid_csh.sh", valid_csh),
@@ -950,7 +950,7 @@ class CshWellMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_csh.sh",
             rpmfluff.SourceFile("valid_csh.sh", valid_csh),
@@ -1009,7 +1009,7 @@ class TcshWellFormedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_tcsh.sh",
@@ -1025,7 +1025,7 @@ class TcshMalformedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_tcsh.sh",
@@ -1042,7 +1042,7 @@ class TcshWellFormedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_tcsh.sh",
@@ -1058,7 +1058,7 @@ class TcshMalformedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_tcsh.sh",
@@ -1075,7 +1075,7 @@ class TcshWellFormedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_tcsh.sh",
             rpmfluff.SourceFile("valid_tcsh.sh", valid_tcsh),
@@ -1094,7 +1094,7 @@ class TcshMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_tcsh.sh",
             rpmfluff.SourceFile("invalid_tcsh.sh", invalid_tcsh),
@@ -1114,7 +1114,7 @@ class TcshWellFormedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_tcsh.sh",
             rpmfluff.SourceFile("valid_tcsh.sh", valid_tcsh),
@@ -1133,7 +1133,7 @@ class TcshMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_tcsh.sh",
             rpmfluff.SourceFile("invalid_tcsh.sh", invalid_tcsh),
@@ -1153,7 +1153,7 @@ class TcshWellMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_tcsh.sh",
             rpmfluff.SourceFile("valid_tcsh.sh", valid_tcsh),
@@ -1173,7 +1173,7 @@ class TcshWellMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_tcsh.sh",
             rpmfluff.SourceFile("valid_tcsh.sh", valid_tcsh),
@@ -1254,7 +1254,7 @@ class RcWellFormedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
@@ -1269,7 +1269,7 @@ class RcMalformedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_rc.sh",
@@ -1286,7 +1286,7 @@ class RcWellFormedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
@@ -1301,7 +1301,7 @@ class RcMalformedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_rc.sh",
@@ -1318,7 +1318,7 @@ class RcWellFormedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
         )
@@ -1335,7 +1335,7 @@ class RcMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_rc.sh",
             rpmfluff.SourceFile("invalid_rc.sh", invalid_rc),
@@ -1355,7 +1355,7 @@ class RcWellFormedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
         )
@@ -1372,7 +1372,7 @@ class RcMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_rc.sh",
             rpmfluff.SourceFile("invalid_rc.sh", invalid_rc),
@@ -1392,7 +1392,7 @@ class RcWellMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
         )
@@ -1411,7 +1411,7 @@ class RcWellMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_rc.sh", rpmfluff.SourceFile("valid_rc.sh", valid_rc)
         )
@@ -1494,7 +1494,7 @@ class BashWellFormedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_bash.sh",
@@ -1510,7 +1510,7 @@ class BashMalformedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_bash.sh",
@@ -1527,7 +1527,7 @@ class BashExtglobWellFormedRPM(TestRPMs):
     """
 
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_bash_extglob.sh",
@@ -1544,7 +1544,7 @@ class BashWellFormedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_bash.sh",
@@ -1560,7 +1560,7 @@ class BashMalformedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/invalid_bash.sh",
@@ -1577,7 +1577,7 @@ class BashExtglobWellFormedKoji(TestKoji):
     """
 
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         self.rpm.add_installed_file(
             "/usr/share/data/valid_bash_extglob.sh",
@@ -1594,7 +1594,7 @@ class BashWellFormedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_bash.sh",
             rpmfluff.SourceFile("valid_bash.sh", valid_bash),
@@ -1613,7 +1613,7 @@ class BashMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_bash.sh",
             rpmfluff.SourceFile("invalid_bash.sh", invalid_bash),
@@ -1633,7 +1633,7 @@ class BashExtglobWellFormedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_bash_extglob.sh",
             rpmfluff.SourceFile("valid_bash_extglob.sh", valid_bash_extglob),
@@ -1653,7 +1653,7 @@ class BashWellFormedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_bash.sh",
             rpmfluff.SourceFile("valid_bash.sh", valid_bash),
@@ -1672,7 +1672,7 @@ class BashMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid_bash.sh",
             rpmfluff.SourceFile("invalid_bash.sh", invalid_bash),
@@ -1692,7 +1692,7 @@ class BashExtglobWellFormedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_bash_extglob.sh",
             rpmfluff.SourceFile("valid_bash_extglob.sh", valid_bash_extglob),
@@ -1712,7 +1712,7 @@ class BashWellMalformedCompareRPMs(TestCompareRPMs):
     """
 
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_bash.sh",
             rpmfluff.SourceFile("valid_bash.sh", valid_bash),
@@ -1732,7 +1732,7 @@ class BashWellMalformedCompareKoji(TestCompareKoji):
     """
 
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid_bash.sh",
             rpmfluff.SourceFile("valid_bash.sh", valid_bash),

--- a/test/test_specname.py
+++ b/test/test_specname.py
@@ -24,7 +24,7 @@ from baseclass import TestSRPM, TestRPMs, TestKoji
 # Verify spec filename matches package name on SRPM (OK)
 class SpecNameSRPM(TestSRPM):
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.inspection = "specname"
         self.result = "OK"
 
@@ -32,7 +32,7 @@ class SpecNameSRPM(TestSRPM):
 # Verify spec filename matches package name on Koji build (OK)
 class SpecNameKojiBuild(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.inspection = "specname"
         self.result = "OK"
 
@@ -40,7 +40,7 @@ class SpecNameKojiBuild(TestKoji):
 # Verify spec filename test on binary RPMs fails (BAD)
 class SpecNameRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.inspection = "specname"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
@@ -50,7 +50,7 @@ class SpecNameRPMs(TestRPMs):
 class BadSpecNameSRPM(TestSRPM):
     @unittest.skip("requires addSpecBasename() support in rpmfluff")
     def setUp(self):
-        TestSRPM.setUp(self)
+        super().setUp()
         self.rpm.addSpecBasename("badspecname")
         self.inspection = "specname"
         self.result = "BAD"
@@ -61,7 +61,7 @@ class BadSpecNameSRPM(TestSRPM):
 class BadSpecNameKojiBuild(TestKoji):
     @unittest.skip("requires addSpecBasename() support in rpmfluff")
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.addSpecBasename("badspecname")
         self.inspection = "specname"
         self.result = "BAD"

--- a/test/test_symlinks.py
+++ b/test/test_symlinks.py
@@ -49,7 +49,7 @@ with open(os.environ["RPMINSPECT"], mode="rb") as f:
 # Absolute symlink exists (OK)
 class AbsoluteSymlinkExistsRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -65,7 +65,7 @@ class AbsoluteSymlinkExistsRPMs(TestRPMs):
 
 class AbsoluteSymlinkExistsKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -81,7 +81,7 @@ class AbsoluteSymlinkExistsKoji(TestKoji):
 
 class AbsoluteSymlinkExistsCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -99,7 +99,7 @@ class AbsoluteSymlinkExistsCompareRPMs(TestCompareRPMs):
 
 class AbsoluteSymlinkExistsCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -118,7 +118,7 @@ class AbsoluteSymlinkExistsCompareKoji(TestCompareKoji):
 # Relative symlink with ../ exists (OK)
 class RelativeSymlinkExistsParentDirRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -134,7 +134,7 @@ class RelativeSymlinkExistsParentDirRPMs(TestRPMs):
 
 class RelativeSymlinkExistsParentDirKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -150,7 +150,7 @@ class RelativeSymlinkExistsParentDirKoji(TestKoji):
 
 class RelativeSymlinkExistsParentDirCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -166,7 +166,7 @@ class RelativeSymlinkExistsParentDirCompareRPMs(TestCompareRPMs):
 
 class RelativeSymlinkExistsParentDirCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -183,7 +183,7 @@ class RelativeSymlinkExistsParentDirCompareKoji(TestCompareKoji):
 # Relative symlink in current directory exists (OK)
 class RelativeSymlinkExistsCurrentDirRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -199,7 +199,7 @@ class RelativeSymlinkExistsCurrentDirRPMs(TestRPMs):
 
 class RelativeSymlinkExistsCurrentDirKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -215,7 +215,7 @@ class RelativeSymlinkExistsCurrentDirKoji(TestKoji):
 
 class RelativeSymlinkExistsCurrentDirCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -231,7 +231,7 @@ class RelativeSymlinkExistsCurrentDirCompareRPMs(TestCompareRPMs):
 
 class RelativeSymlinkExistsCurrentDirCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -248,7 +248,7 @@ class RelativeSymlinkExistsCurrentDirCompareKoji(TestCompareKoji):
 # Symlink that exists spans subpackages (OK)
 class SymlinkExistsMultiplePackagesRPMS(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -267,7 +267,7 @@ class SymlinkExistsMultiplePackagesRPMS(TestRPMs):
 
 class SymlinkExistsMultiplePackagesKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -286,7 +286,7 @@ class SymlinkExistsMultiplePackagesKoji(TestKoji):
 
 class SymlinkExistsMultiplePackagesCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -305,7 +305,7 @@ class SymlinkExistsMultiplePackagesCompareRPMs(TestCompareRPMs):
 
 class SymlinkExistsMultiplePackagesCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -325,7 +325,7 @@ class SymlinkExistsMultiplePackagesCompareKoji(TestCompareKoji):
 # Absolute symlink is dangling (VERIFY)
 class AbsoluteSymlinkDanglingRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -344,7 +344,7 @@ class AbsoluteSymlinkDanglingRPMs(TestRPMs):
 
 class AbsoluteSymlinkDanglingKoji(TestKoji):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -363,7 +363,7 @@ class AbsoluteSymlinkDanglingKoji(TestKoji):
 
 class AbsoluteSymlinkDanglingCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -382,7 +382,7 @@ class AbsoluteSymlinkDanglingCompareRPMs(TestCompareRPMs):
 
 class AbsoluteSymlinkDanglingCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -402,7 +402,7 @@ class AbsoluteSymlinkDanglingCompareKoji(TestCompareKoji):
 # Relative symlink with ../ is dangling (VERIFY)
 class RelativeSymlinkDanglingParentDirRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -421,7 +421,7 @@ class RelativeSymlinkDanglingParentDirRPMs(TestRPMs):
 
 class RelativeSymlinkDanglingParentDirKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -440,7 +440,7 @@ class RelativeSymlinkDanglingParentDirKoji(TestKoji):
 
 class RelativeSymlinkDanglingParentDirAfterRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -459,7 +459,7 @@ class RelativeSymlinkDanglingParentDirAfterRPMs(TestCompareRPMs):
 
 class RelativeSymlinkDanglingParentDirAfterKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -479,7 +479,7 @@ class RelativeSymlinkDanglingParentDirAfterKoji(TestCompareKoji):
 # Relative symlink in current directory is dangling (VERIFY)
 class RelativeSymlinkDanglingCurrentDirRPMs(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -498,7 +498,7 @@ class RelativeSymlinkDanglingCurrentDirRPMs(TestRPMs):
 
 class RelativeSymlinkDanglingCurrentDirKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -517,7 +517,7 @@ class RelativeSymlinkDanglingCurrentDirKoji(TestKoji):
 
 class RelativeSymlinkDanglingCurrentDirCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -536,7 +536,7 @@ class RelativeSymlinkDanglingCurrentDirCompareRPMs(TestCompareRPMs):
 
 class RelativeSymlinkDanglingCurrentDirCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -564,7 +564,7 @@ class TooManySymlinkLevelsRPMs(TestRPMs):
         % (rpm_major, rpm_minor, rpm_update),
     )
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -592,7 +592,7 @@ class TooManySymlinkLevelsKoji(TestKoji):
         % (rpm_major, rpm_minor, rpm_update),
     )
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.rpm.add_installed_file(
@@ -620,7 +620,7 @@ class TooManySymlinkLevelsCompareRPMs(TestCompareRPMs):
         % (rpm_major, rpm_minor, rpm_update),
     )
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -652,7 +652,7 @@ class TooManySymlinkLevelsCompareKoji(TestCompareKoji):
         % (rpm_major, rpm_minor, rpm_update),
     )
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add file and symlink
         self.after_rpm.add_installed_file(
@@ -680,7 +680,7 @@ class TooManySymlinkLevelsCompareKoji(TestCompareKoji):
 # Directory becomes a symlink (VERIFY)
 class DirectoryBecomesSymlinkCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add directories and symlinks
         self.before_rpm.add_installed_directory("usr/share/testdirectory")
@@ -697,7 +697,7 @@ class DirectoryBecomesSymlinkCompareRPMs(TestCompareRPMs):
 
 class DirectoryBecomesSymlinkCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add directories and symlinks
         self.before_rpm.add_installed_directory("usr/share/testdirectory")
@@ -715,7 +715,7 @@ class DirectoryBecomesSymlinkCompareKoji(TestCompareKoji):
 # Non-directory becomes a symlink (VERIFY)
 class NonDirectoryBecomesSymlinkCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
 
         # add files and symlinks
         self.before_rpm.add_installed_file(
@@ -742,7 +742,7 @@ class NonDirectoryBecomesSymlinkCompareRPMs(TestCompareRPMs):
 
 class NonDirectoryBecomesSymlinkCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
 
         # add files and symlinks
         self.before_rpm.add_installed_file(

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -39,7 +39,7 @@ invalid_xml = """<?xml version='1.0'?>
 # XML file is well formed in RPM (OK)
 class XMLWellFormedRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_installed_file(
             "/usr/share/data/valid.xml", rpmfluff.SourceFile("valid.xml", valid_xml)
         )
@@ -50,7 +50,7 @@ class XMLWellFormedRPM(TestRPMs):
 # XML file is well formed in Koji build (OK)
 class XMLWellFormedKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_installed_file(
             "/usr/share/data/valid.xml", rpmfluff.SourceFile("valid.xml", valid_xml)
         )
@@ -61,7 +61,7 @@ class XMLWellFormedKoji(TestKoji):
 # XML file is well formed in compare RPMs (OK)
 class XMLWellFormedCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid.xml", rpmfluff.SourceFile("valid.xml", valid_xml)
         )
@@ -75,7 +75,7 @@ class XMLWellFormedCompareRPMs(TestCompareRPMs):
 # XML file is well formed in compare Koji builds (OK)
 class XMLWellFormedCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/valid.xml", rpmfluff.SourceFile("valid.xml", valid_xml)
         )
@@ -89,7 +89,7 @@ class XMLWellFormedCompareKoji(TestCompareKoji):
 # XML file is malformed in RPM (VERIFY)
 class XMLMalformedRPM(TestRPMs):
     def setUp(self):
-        TestRPMs.setUp(self)
+        super().setUp()
         self.rpm.add_installed_file(
             "/usr/share/data/invalid.xml",
             rpmfluff.SourceFile("invalid.xml", invalid_xml),
@@ -102,7 +102,7 @@ class XMLMalformedRPM(TestRPMs):
 # XML file is malformed in Koji build (VERIFY)
 class XMLMalformedKoji(TestKoji):
     def setUp(self):
-        TestKoji.setUp(self)
+        super().setUp()
         self.rpm.add_installed_file(
             "/usr/share/data/invalid.xml",
             rpmfluff.SourceFile("invalid.xml", invalid_xml),
@@ -115,7 +115,7 @@ class XMLMalformedKoji(TestKoji):
 # XML file is malformed in compare RPMs (VERIFY)
 class XMLMalformedCompareRPMs(TestCompareRPMs):
     def setUp(self):
-        TestCompareRPMs.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid.xml",
             rpmfluff.SourceFile("invalid.xml", invalid_xml),
@@ -132,7 +132,7 @@ class XMLMalformedCompareRPMs(TestCompareRPMs):
 # XML file is malformed in compare Koji builds (VERIFY)
 class XMLMalformedCompareKoji(TestCompareKoji):
     def setUp(self):
-        TestCompareKoji.setUp(self)
+        super().setUp()
         self.before_rpm.add_installed_file(
             "/usr/share/data/invalid.xml",
             rpmfluff.SourceFile("invalid.xml", invalid_xml),


### PR DESCRIPTION
This is a refactoring of TestKoji and TestCompareKoji so I can inherit from them to make module base classes.  Also, change all test cases to consistently use super().setUp() and super().tearDown().