### PR TITLE
module base classes for the test suite and modularity test cases

### DIFF
--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -185,8 +185,8 @@ static bool check_static_context(struct rpminspect *ri)
                 xasprintf(&params.msg, _("The /data/static_context value in %s matches the value in %s, and the product release rules require the presence of /data/static_context in the module metadata."), ri->before, ri->after);
             } else if (ri->modularity_static_context == STATIC_CONTEXT_RECOMMEND) {
                 xasprintf(&params.msg, _("The /data/static_context value in %s matches the value in %s, and the product release rules recommend the presence of /data/static_context in the module metadata."), ri->before, ri->after);
-            } else {
-                xasprintf(&params.msg, _("The /data/static_context value in %s matches the value in %s, and the product release rules do not have a setting for /data/static_context in the module metadata."), ri->before, ri->after);
+            } else if (ri->modularity_static_context == STATIC_CONTEXT_NULL) {
+                xasprintf(&params.msg, _("The /data/static_context value in %s matches the value in %s, but the product release rules do not have a setting for /data/static_context in the module metadata."), ri->before, ri->after);
             }
         } else if (bsc != asc) {
             if (asc && ri->modularity_static_context == STATIC_CONTEXT_FORBIDDEN) {
@@ -203,8 +203,8 @@ static bool check_static_context(struct rpminspect *ri)
                 r = false;
             } else if (!asc && ri->modularity_static_context == STATIC_CONTEXT_RECOMMEND) {
                 xasprintf(&params.msg, _("The /data/static_context value in %s was %s and became %s in %s, and the product release rules recommend the presence of /data/static_context in the module metadata."), ri->before, bsc ? _("true") : _("false"), asc ? _("true") : _("false"), ri->after);
-            } else {
-                xasprintf(&params.msg, _("The /data/static_context value in %s was %s and became %s in %s, and the product release rules do not have a setting for /data/static_context in the module metadata."), ri->before, bsc ? _("true") : _("false"), asc ? _("true") : _("false"), ri->after);
+            } else if (ri->modularity_static_context == STATIC_CONTEXT_NULL) {
+                xasprintf(&params.msg, _("The /data/static_context value in %s was %s and became %s in %s, but the product release rules do not have a setting for /data/static_context in the module metadata."), ri->before, bsc ? _("true") : _("false"), asc ? _("true") : _("false"), ri->after);
             }
         }
     } else {
@@ -222,14 +222,16 @@ static bool check_static_context(struct rpminspect *ri)
             r = false;
         } else if (!asc && ri->modularity_static_context == STATIC_CONTEXT_RECOMMEND) {
             xasprintf(&params.msg, _("The /data/static_context value in %s is %s, and the product release rules recommend the presence of /data/static_context in the module metadata."), ri->after, asc ? _("true") : _("false"));
-        } else {
-            xasprintf(&params.msg, _("The /data/static_context value in %s is %s, and the product release rules do not have a setting for /data/static_context in the module metadata."), ri->after, asc ? _("true") : _("false"));
+        } else if (ri->modularity_static_context == STATIC_CONTEXT_NULL) {
+            xasprintf(&params.msg, _("The /data/static_context value in %s is %s, but the product release rules do not have a setting for /data/static_context in the module metadata."), ri->after, asc ? _("true") : _("false"));
         }
     }
 
     /* report */
-    add_result(ri, &params);
-    free(params.msg);
+    if (params.msg != NULL) {
+        add_result(ri, &params);
+        free(params.msg);
+    }
 
     return r;
 }

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -228,7 +228,7 @@ static bool check_static_context(struct rpminspect *ri)
     }
 
     /* report */
-    if (params.msg != NULL) {
+    if (params.msg) {
         add_result(ri, &params);
         free(params.msg);
     }

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -386,10 +386,7 @@ class TestSRPM(RequiresRpminspect):
     def tearDown(self):
         super().tearDown()
 
-        if KEEP_RESULTS and self.kojidir:
-            print(">>> Test builds: %s" % self.kojidir)
-            self.kojidir = None
-        elif self.kojidir:
+        if not KEEP_RESULTS:
             self.rpm.clean()
 
 
@@ -491,10 +488,7 @@ class TestCompareSRPM(RequiresRpminspect):
     def tearDown(self):
         super().tearDown()
 
-        if KEEP_RESULTS and self.kojidir:
-            print(">>> Test builds: %s" % self.kojidir)
-            self.kojidir = None
-        elif self.kojidir:
+        if not KEEP_RESULTS:
             self.before_rpm.clean()
             self.after_rpm.clean()
 
@@ -585,10 +579,7 @@ class TestRPMs(RequiresRpminspect):
     def tearDown(self):
         super().tearDown()
 
-        if KEEP_RESULTS and self.kojidir:
-            print(">>> Test builds: %s" % self.kojidir)
-            self.kojidir = None
-        elif self.kojidir:
+        if not KEEP_RESULTS:
             self.rpm.clean()
 
 
@@ -693,10 +684,7 @@ class TestCompareRPMs(RequiresRpminspect):
     def tearDown(self):
         super().tearDown()
 
-        if KEEP_RESULTS and self.kojidir:
-            print(">>> Test builds: %s" % self.kojidir)
-            self.kojidir = None
-        elif self.kojidir:
+        if not KEEP_RESULTS:
             self.before_rpm.clean()
             self.after_rpm.clean()
 

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -872,3 +872,56 @@ class TestCompareKoji(TestCompareRPMs):
         if not KEEP_RESULTS:
             super().tearDown()
             shutil.rmtree(self.kojidir, ignore_errors=True)
+
+
+# Base test case class that tests a fake module build
+class TestModule(TestKoji):
+    def setUp(self, modularitylabel=True, static_context=True):
+        super().setUp()
+
+        # add the modularitylabel to the built RPMs
+        if modularitylabel:
+            self.rpm.header += "\n%define modularitylabel TEST_LABEL\n"
+
+        # create the modulemd.txt file
+        filesdir = os.path.join(self.kojidir, "files")
+        os.makedirs(filesdir, exist_ok=True)
+        modulemd = os.path.join(filesdir, "modulemd.txt")
+
+        f = open(modulemd, "w")
+        f.write("---\n")
+        f.write("document: modulemd\n")
+        f.write("version: 2\n")
+        f.write("data:\n")
+        if static_context:
+            f.write("   static_context: true\n")
+        f.close()
+
+
+# Base test case class that compares before and after module builds
+class TestCompareModules(TestCompareKoji):
+    def setUp(self, rebase=False, same=False, modularitylabel=True, static_context=True):
+        super().setUp(rebase=rebase, same=same)
+
+        # add the modularitylabel to the built RPMs
+        if modularitylabel:
+            self.before_rpm.header += "\n%define modularitylabel TEST_LABEL\n"
+            self.after_rpm.header += "\n%define modularitylabel TEST_LABEL\n"
+
+        # create the modulemd.txt file
+        beforefilesdir = os.path.join(self.kojidir, "before", "files")
+        afterfilesdir = os.path.join(self.kojidir, "after", "files")
+        os.makedirs(beforefilesdir, exist_ok=True)
+        os.makedirs(afterfilesdir, exist_ok=True)
+        modulemd = os.path.join(beforefilesdir, "modulemd.txt")
+
+        f = open(modulemd, "w")
+        f.write("---\n")
+        f.write("document: modulemd\n")
+        f.write("version: 2\n")
+        f.write("data:\n")
+        if static_context:
+            f.write("   static_context: true\n")
+        f.close()
+
+        shutil.copy(modulemd, afterfilesdir)

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -198,6 +198,9 @@ class RequiresRpminspect(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
+        # did we show kept files and dirs?
+        self.keep_shown = False
+
         # make sure we have the program
         self.rpminspect = os.environ["RPMINSPECT"]
 
@@ -298,7 +301,11 @@ class RequiresRpminspect(unittest.TestCase):
         outstream.close()
 
     def tearDown(self):
-        if not KEEP_RESULTS:
+        if KEEP_RESULTS and not self.keep_shown:
+            print("\n>>> Configuration file: %s" % self.conffile)
+            print(">>> Output file: %s" % self.outputfile)
+            self.keep_shown = True
+        else:
             os.unlink(self.conffile)
             os.unlink(self.outputfile)
 
@@ -377,8 +384,12 @@ class TestSRPM(RequiresRpminspect):
         )
 
     def tearDown(self):
-        if not KEEP_RESULTS:
-            super().tearDown()
+        super().tearDown()
+
+        if KEEP_RESULTS and self.kojidir:
+            print(">>> Test builds: %s" % self.kojidir)
+            self.kojidir = None
+        elif self.kojidir:
             self.rpm.clean()
 
 
@@ -478,8 +489,12 @@ class TestCompareSRPM(RequiresRpminspect):
         )
 
     def tearDown(self):
-        if not KEEP_RESULTS:
-            super().tearDown()
+        super().tearDown()
+
+        if KEEP_RESULTS and self.kojidir:
+            print(">>> Test builds: %s" % self.kojidir)
+            self.kojidir = None
+        elif self.kojidir:
             self.before_rpm.clean()
             self.after_rpm.clean()
 
@@ -568,8 +583,12 @@ class TestRPMs(RequiresRpminspect):
                 )
 
     def tearDown(self):
-        if not KEEP_RESULTS:
-            super().tearDown()
+        super().tearDown()
+
+        if KEEP_RESULTS and self.kojidir:
+            print(">>> Test builds: %s" % self.kojidir)
+            self.kojidir = None
+        elif self.kojidir:
             self.rpm.clean()
 
 
@@ -672,8 +691,12 @@ class TestCompareRPMs(RequiresRpminspect):
             )
 
     def tearDown(self):
-        if not KEEP_RESULTS:
-            super().tearDown()
+        super().tearDown()
+
+        if KEEP_RESULTS and self.kojidir:
+            print(">>> Test builds: %s" % self.kojidir)
+            self.kojidir = None
+        elif self.kojidir:
             self.before_rpm.clean()
             self.after_rpm.clean()
 
@@ -759,12 +782,13 @@ class TestKoji(TestRPMs):
             message=self.message,
         )
 
-        if KEEP_RESULTS:
-            print("Test builds: %s" % self.kojidir)
-
     def tearDown(self):
-        if not KEEP_RESULTS:
-            super().tearDown()
+        super().tearDown()
+
+        if KEEP_RESULTS and self.kojidir:
+            print(">>> Test builds: %s" % self.kojidir)
+            self.kojidir = None
+        elif self.kojidir:
             shutil.rmtree(self.kojidir, ignore_errors=True)
 
 
@@ -864,13 +888,13 @@ class TestCompareKoji(TestCompareRPMs):
         except AssertionError:
             self.dumpResults()
 
-        # show where results are
-        if KEEP_RESULTS:
-            print("Test builds: %s" % self.kojidir)
-
     def tearDown(self):
-        if not KEEP_RESULTS:
-            super().tearDown()
+        super().tearDown()
+
+        if KEEP_RESULTS and self.kojidir:
+            print(">>> Test builds: %s" % self.kojidir)
+            self.kojidir = None
+        elif self.kojidir:
             shutil.rmtree(self.kojidir, ignore_errors=True)
 
 
@@ -878,6 +902,7 @@ class TestCompareKoji(TestCompareRPMs):
 class TestModule(TestKoji):
     def setUp(self, modularitylabel=True, static_context=True):
         super().setUp()
+        self.buildtype = "module"
 
         # add the modularitylabel to the built RPMs
         if modularitylabel:
@@ -900,8 +925,11 @@ class TestModule(TestKoji):
 
 # Base test case class that compares before and after module builds
 class TestCompareModules(TestCompareKoji):
-    def setUp(self, rebase=False, same=False, modularitylabel=True, static_context=True):
+    def setUp(
+        self, rebase=False, same=False, modularitylabel=True, static_context=True
+    ):
         super().setUp(rebase=rebase, same=same)
+        self.buildtype = "module"
 
         # add the modularitylabel to the built RPMs
         if modularitylabel:

--- a/test/meson.build
+++ b/test/meson.build
@@ -139,6 +139,7 @@ if python.found()
         'test_lto.py',
         'test_manpage.py',
         'test_metadata.py',
+        'test_modularity.py',
         'test_ownership.py',
         'test_patches.py',
         'test_pathmigration.py',

--- a/test/test_modularity.py
+++ b/test/test_modularity.py
@@ -1,0 +1,157 @@
+#
+# Copyright 2022 Red Hat, Inc.
+# Author(s): David Cantrell <dcantrell@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from baseclass import TestModule, TestCompareModules
+
+
+# Module has %{modularitylabel} defined (OK)
+class ModuleHasModularityLabel(TestModule):
+    def setUp(self):
+        super().setUp(modularitylabel=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["static_context"] = "required"
+
+        self.inspection = "modularity"
+        self.result = "OK"
+
+
+class ModulesHaveModularityLabel(TestCompareModules):
+    def setUp(self):
+        super().setUp(modularitylabel=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["static_context"] = "required"
+
+        self.inspection = "modularity"
+        self.result = "OK"
+
+
+# Module does not have %{modularitylabel} defined (BAD)
+class ModuleLacksModularityLabel(TestModule):
+    def setUp(self):
+        super().setUp(modularitylabel=False)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["static_context"] = "required"
+
+        self.inspection = "modularity"
+        self.result = "BAD"
+        self.waiverauth = "Anyone"
+
+
+class ModulesLacksModularityLabel(TestCompareModules):
+    def setUp(self):
+        super().setUp(modularitylabel=False)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["static_context"] = "required"
+
+        self.inspection = "modularity"
+        self.result = "BAD"
+        self.waiverauth = "Anyone"
+
+
+# Module has static_context and rules require it (OK)
+class ModuleHasStaticContext(TestModule):
+    def setUp(self):
+        super().setUp(static_context=True)
+
+        self.inspection = "modularity"
+        self.result = "OK"
+
+
+class ModulesHaveStaticContext(TestCompareModules):
+    def setUp(self):
+        super().setUp(static_context=True)
+
+        self.inspection = "modularity"
+        self.result = "OK"
+
+
+# Module has static_context and rules recommend it (OK)
+class ModuleHasStaticContextAndRecommended(TestModule):
+    def setUp(self):
+        super().setUp(static_context=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["static_context"] = "recommend"
+
+        self.inspection = "modularity"
+        self.result = "OK"
+
+
+class ModulesHaveStaticContextAndRecommended(TestCompareModules):
+    def setUp(self):
+        super().setUp(static_context=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["static_context"] = "recommend"
+
+        self.inspection = "modularity"
+        self.result = "OK"
+
+
+# Module has static_context and rules forbid it (VERIFY)
+class ModuleHasStaticContextAndForbidden(TestModule):
+    def setUp(self):
+        super().setUp(static_context=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["static_context"] = "forbidden"
+
+        self.inspection = "modularity"
+        self.result = "VERIFY"
+        self.waiverauth = "Anyone"
+
+
+class ModulesHaveStaticContextAndForbidden(TestCompareModules):
+    def setUp(self):
+        super().setUp(static_context=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["static_context"] = "forbidden"
+
+        self.inspection = "modularity"
+        self.result = "VERIFY"
+        self.waiverauth = "Anyone"
+
+
+# Module has static_context and rules do not exist (INFO)
+class ModuleHasStaticContextWithNoRule(TestModule):
+    def setUp(self):
+        super().setUp(static_context=True)
+
+        self.inspection = "modularity"
+        self.result = "OK"
+
+
+class ModulesHaveStaticContextWithNoRule(TestCompareModules):
+    def setUp(self):
+        super().setUp(static_context=True)
+
+        self.inspection = "modularity"
+        self.result = "OK"


### PR DESCRIPTION
A number of patches here.  It starts with adding base classes for module test cases, then adds test cases, then some fixes for baseclass.py debugging and some actual fixes for the modularity inspection.