### PR TITLE
Modernize and simplify the license boilerplates in the code

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -1,21 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/include/init.h
+++ b/include/init.h
@@ -1,21 +1,5 @@
 /*
- * Copyright 2022 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/include/output.h
+++ b/include/output.h
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/include/queue.h
+++ b/include/queue.h
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/include/readelf.h
+++ b/include/readelf.h
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/include/results.h
+++ b/include/results.h
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/include/secrules.h
+++ b/include/secrules.h
@@ -1,21 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/include/types.h
+++ b/include/types.h
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/abi.c
+++ b/lib/abi.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/abspath.c
+++ b/lib/abspath.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/arches.c
+++ b/lib/arches.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/badwords.c
+++ b/lib/badwords.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/bytes.c
+++ b/lib/bytes.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/curl.c
+++ b/lib/curl.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2022 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
 #include <stdlib.h>

--- a/lib/filecmp.c
+++ b/lib/filecmp.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/flags.c
+++ b/lib/flags.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/free.c
+++ b/lib/free.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/fs.c
+++ b/lib/fs.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2022 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/humansize.c
+++ b/lib/humansize.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2022 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_debuginfo.c
+++ b/lib/inspect_debuginfo.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2022 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_files.c
+++ b/lib/inspect_files.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_metadata.c
+++ b/lib/inspect_metadata.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_specname.c
+++ b/lib/inspect_specname.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/local.c
+++ b/lib/local.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/magic.c
+++ b/lib/magic.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/output.c
+++ b/lib/output.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/output_json.c
+++ b/lib/output_json.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/output_summary.c
+++ b/lib/output_summary.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/output_text.c
+++ b/lib/output_text.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/output_xunit.c
+++ b/lib/output_xunit.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/pairfuncs.c
+++ b/lib/pairfuncs.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/pic_bits.sh
+++ b/lib/pic_bits.sh
@@ -1,22 +1,5 @@
 #!/bin/sh
-# Copyright © 2019 Red Hat, Inc.
-# Author(s): David Shea <dshea@redhat.com>
-#            David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public License
-# as published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program.  If not, see
-# <https://www.gnu.org/licenses/>.
-#
+# Copyright The rpminspect Project Authors
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # shellcheck disable=SC2129

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *            David Shea <dshea@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/readfile.c
+++ b/lib/readfile.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/rebase.c
+++ b/lib/rebase.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/release.c
+++ b/lib/release.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/results.c
+++ b/lib/results.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -1,22 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/secrule.c
+++ b/lib/secrule.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/tty.c
+++ b/lib/tty.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/lib/uncompress.c
+++ b/lib/uncompress.c
@@ -1,21 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
- *
+ * Copyright The rpminspect Project Authors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/rpminspect.1
+++ b/src/rpminspect.1
@@ -1,18 +1,5 @@
-.\" Copyright 2018 Red Hat, Inc.
-.\" Author(s): David Cantrell <dcantrell@redhat.com>
-.\"
-.\" This program is free software: you can redistribute it and/or modify
-.\" it under the terms of the GNU General Public License as published by
-.\" the Free Software Foundation, either version 3 of the License, or
-.\" (at your option) any later version.
-.\"
-.\" This program is distributed in the hope that it will be useful,
-.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
-.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-.\" GNU General Public License for more details.
-.\"
-.\" You should have received a copy of the GNU General Public License
-.\" along with this program.  If not, see <https://www.gnu.org/licenses/>.
+.\" Copyright The rpminspect Project Authors
+.\" SPDX-License-Identifier: GPL-3.0-or-later
 
 .TH RPMINSPECT "1" "February 2019" "rpminspect" "Red Hat"
 .SH NAME

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <stdio.h>

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/lib/elftest.c
+++ b/test/lib/elftest.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <stdio.h>

--- a/test/lib/test-abspath.c
+++ b/test/lib/test-abspath.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2021 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <stdlib.h>

--- a/test/lib/test-badwords.c
+++ b/test/lib/test-badwords.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <stdlib.h>

--- a/test/lib/test-init.c
+++ b/test/lib/test-init.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <CUnit/Basic.h>

--- a/test/lib/test-inspect_elf.c
+++ b/test/lib/test-inspect_elf.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <stdio.h>

--- a/test/lib/test-koji.c
+++ b/test/lib/test-koji.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <CUnit/Basic.h>

--- a/test/lib/test-main.c
+++ b/test/lib/test-main.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <stdarg.h>

--- a/test/lib/test-main.h
+++ b/test/lib/test-main.h
@@ -1,20 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Shea <dshea@redhat.com>
- *            David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #ifndef _LIBRPMINSPECT_TEST_MAIN_H

--- a/test/lib/test-strfuncs.c
+++ b/test/lib/test-strfuncs.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <CUnit/Basic.h>

--- a/test/lib/test-tty.c
+++ b/test/lib/test-tty.c
@@ -1,19 +1,6 @@
 /*
- * Copyright 2019 Red Hat, Inc.
- * Author(s): David Cantrell <dcantrell@redhat.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include <unistd.h>

--- a/test/test_abidiff.py
+++ b/test/test_abidiff.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_addedfiles.py
+++ b/test/test_addedfiles.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_annocheck.py
+++ b/test/test_annocheck.py
@@ -1,20 +1,6 @@
 #
-# Copyright 2022 Red Hat, Inc.
-# Author(s): Zuzana Miklankova <zmiklank@redhat.com>
-#            David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_badfuncs.py
+++ b/test/test_badfuncs.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_capabilities.py
+++ b/test/test_capabilities.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import subprocess

--- a/test/test_changedfiles.py
+++ b/test/test_changedfiles.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import datetime

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import subprocess

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/test/test_debuginfo.py
+++ b/test/test_debuginfo.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2022 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from baseclass import (

--- a/test/test_default.py
+++ b/test/test_default.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from baseclass import TestKoji

--- a/test/test_desktop.py
+++ b/test/test_desktop.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import json

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/test/test_elf.py
+++ b/test/test_elf.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_emptyrpm.py
+++ b/test/test_emptyrpm.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from baseclass import TestKoji, TestRPMs, TestSRPM

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/test/test_filesize.py
+++ b/test/test_filesize.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): Jeremy Cline <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import platform

--- a/test/test_kmod.py
+++ b/test/test_kmod.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import glob

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import unittest

--- a/test/test_lostpayload.py
+++ b/test/test_lostpayload.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from baseclass import TestCompareKoji

--- a/test/test_lto.py
+++ b/test/test_lto.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_manpage.py
+++ b/test/test_manpage.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from baseclass import (

--- a/test/test_modularity.py
+++ b/test/test_modularity.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2022 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from baseclass import TestModule, TestCompareModules

--- a/test/test_ownership.py
+++ b/test/test_ownership.py
@@ -1,20 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#            Jim Bair <jbair@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import subprocess

--- a/test/test_pathmigration.py
+++ b/test/test_pathmigration.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from baseclass import TestRPMs, TestCompareRPMs, TestKoji, TestCompareKoji

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/test/test_politics.py
+++ b/test/test_politics.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/test/test_removedfiles.py
+++ b/test/test_removedfiles.py
@@ -1,20 +1,6 @@
 #
-# Copyright 2022 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#            Preston Watson <prwatson@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_rpmdeps_conflicts.py
+++ b/test/test_rpmdeps_conflicts.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_rpmdeps_enhances.py
+++ b/test/test_rpmdeps_enhances.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_rpmdeps_obsoletes.py
+++ b/test/test_rpmdeps_obsoletes.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_rpmdeps_provides.py
+++ b/test/test_rpmdeps_provides.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_rpmdeps_recommends.py
+++ b/test/test_rpmdeps_recommends.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_rpmdeps_requires.py
+++ b/test/test_rpmdeps_requires.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_rpmdeps_suggests.py
+++ b/test/test_rpmdeps_suggests.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_rpmdeps_supplements.py
+++ b/test/test_rpmdeps_supplements.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_runpath.py
+++ b/test/test_runpath.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_securitypath.py
+++ b/test/test_securitypath.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/test/test_shellsyntax.py
+++ b/test/test_shellsyntax.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from baseclass import TestRPMs, TestKoji

--- a/test/test_specname.py
+++ b/test/test_specname.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import unittest

--- a/test/test_symlinks.py
+++ b/test/test_symlinks.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/test/test_unicode.py
+++ b/test/test_unicode.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2021 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/test/test_virus.py
+++ b/test/test_virus.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2020 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import timeout_decorator

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -1,19 +1,6 @@
 #
-# Copyright 2019 Red Hat, Inc.
-# Author(s): David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import rpmfluff

--- a/utils/gate.sh
+++ b/utils/gate.sh
@@ -1,21 +1,8 @@
 #!/bin/sh
 # Helper script to test rpminspect builds in copr during build
 #
-# Copyright (C) 2020 Jim Bair <jbair@redhat.com>
-#                    David Cantrell <dcantrell@redhat.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Arguments:
 # $1   Full path to rpminspect command to use

--- a/utils/mkannounce.sh
+++ b/utils/mkannounce.sh
@@ -4,20 +4,8 @@
 # blog post.  Groups git log summaries by category and only includes
 # those log entries that have a category marking.
 #
-# Copyright © 2021 David Cantrell <david.l.cantrell@gmail.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright David Cantrell
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 PATH=/bin:/usr/bin

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -4,20 +4,8 @@
 # use Copr for automated builds and that carry template RPM spec
 # files.  See README for more information.
 #
-# Copyright © 2019 David Cantrell <david.l.cantrell@gmail.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright David Cantrell
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 PATH=/usr/bin

--- a/utils/srpm.sh
+++ b/utils/srpm.sh
@@ -1,19 +1,7 @@
 #!/bin/sh
 #
-# Copyright © 2019 David Cantrell <david.l.cantrell@gmail.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright David Cantrell
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 PATH=/usr/bin

--- a/utils/submit-koji-builds.sh
+++ b/utils/submit-koji-builds.sh
@@ -2,20 +2,8 @@
 #
 # Build new releases in Koji
 #
-# Copyright © 2019 David Cantrell <david.l.cantrell@gmail.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Copyright David Cantrell
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 # Arguments:


### PR DESCRIPTION
After discussing open source licensing and source code license boilerplates with representatives from the Red Hat Legal team, they directed me to Red Hat's current source code recommendations regarding copyright and license notices.  A lot has changed over the years and the accepted recommendation now from the Red Hat Legal department (Red Hat is my employer and pays me to work on rpminspect) is to use a format like this:

    /*
     * Copyright The PROJECT Authors
     * SPDX-License-Identifier: SPDX_LICENSE_EXPRESSION */

(adjust comments depending on the language)

Alternatively, Red Hat will permit a "Copyright Red Hat" line, but the general recommendation is to state the "project authors" as a collective.

Noticeable right away is the lack of a copyright year.  Also, the usual GPL, LGPL, MIT, or BSD license boilerplate text is missing.  The nice thing here is that projects using git or some other version control system retain all of that information in the commit logs, so you can research projects that way to find the actual individual authors (who hold the copyrights) and the year of first publication. It is not necessary per current copyright law and conventions to state this information in a Copyright statement.

Also, the lack of a (C), (c), or Unicode copyright symbol.  The (C) and (c) were never accepted anyway and because they followed the word "Copyright", that's the word that actually had effect.  The Unicode copyright symbol can be used in place of "Copyright", but the general recommendation is to avoid that because of the limitations of various text editors in use today.

SPDX is a project that has cataloged open source licenses, given then short identifiers, and documented acceptance criteria for what license text matches that license.  The project is active and new licenses are added quarterly.  Fedora Linux has moved to preferring these identifiers in RPM spec files over the legacy Fedora names.  Find yours at https://spdx.org/licenses/

What about what follows the word "Copyright".  The PROJECT Authors is sort of vague.  Well, when you write code you own it.  Your version control system has recorded that.  The Copyright statement is more of a heads up to other readers that they are looking at copyrighted code and that multiple authors have had their hands in it.  This project carries an AUTHORS.md file that lists all of the contributors, but that's not really necessary.  It's just a nice to have.

If you don't use "The PROJECT Authors" after "Copyright", why does Red Hat recommend just "Red Hat" and not something like "Red Hat, Inc." or "Red Hat GmbH" or "Red Hat Czech, s.r.o."?  It turns out that actually makes it harder for lawyers should ownership should there ever be legal questions.  It is known and understood that "Red Hat" in this context refers to all of the legal entities that make up Red Hat, so keep the notice simple.  Still, it's beter to name the project authors rather that Red Hat (or your employer).

NOTE: There are some source files that come from other projects and have been imported in to rpminspect.  Those license and copyright comment blocks remain untouched.  That consists of some Apache-2.0 licensed files in lib/, the LGPL-2.1-or-later licensed libxdiff/ subdirectory, the BSD-1-Clause licensed include/uthash.h, and the BSD-3-Clause licensed include/compat/queue.h.

Signed-off-by: David Cantrell <dcantrell@redhat.com>