### PR TITLE
[bld] Add a Makefile target and script to update uthash.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,9 @@ authors:
 	head -n $$(($$(wc -l < AUTHORS.md) - 1)) AUTHORS.md > AUTHORS.md.new
 	mv AUTHORS.md.new AUTHORS.md
 
+update-uthash:
+	$(topdir)/utils/update-uthash.sh $(topdir)/include
+
 help:
 	@echo "rpminspect helper Makefile"
 	@echo "The source tree uses meson(1) for building and testing, but this Makefile"
@@ -179,6 +182,7 @@ help:
 	@echo "    clean             Run 'rm -rf $(MESON_BUILD_DIR)'"
 	@echo "    instreqs          Install required build and runtime packages"
 	@echo "    authors           Generate a new AUTHORS.md file"
+	@echo "    update-uthash     Update include/uthash.h from upstream"
 	@echo
 	@echo "To build:"
 	@echo "    make"

--- a/utils/update-uthash.sh
+++ b/utils/update-uthash.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Pull down the latest uthash.h file from upstream
+#
+
+PATH=/bin:/usr/bin
+TMPDIR="$(mktemp -d)"
+DESTDIR="${1}"
+
+trap 'rm -rf ${TMPDIR}' EXIT
+
+if [ ! -d "${DESTDIR}" ]; then
+    echo "*** ${DESTDIR} is not a directory" >&2
+    exit 1
+fi
+
+cd "${TMPDIR}" || exit 1
+git clone https://github.com/troydhanson/uthash.git
+cp -p uthash/src/uthash.h "${DESTDIR}"/uthash.h
+
+exit 0


### PR DESCRIPTION
uthash.h comes from https://github.com/troydhanson/uthash. Periodically I pull down the latest copy of the header file, but it never really changes that much.  It's nice to check to see if there's major refactoring and things like that.

I can now type "make update-uthash" to get the latest copy in the tree.

Signed-off-by: David Cantrell <dcantrell@redhat.com>