### PR TITLE
[bld] Use SPDX license identifiers in rpminspect.spec.in

### DIFF
--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -1,14 +1,25 @@
 Name:           rpminspect
 Version:        %%VERSION%%
 Release:        1%{?dist}
-Summary:        Build deviation compliance tool
+Summary:        Build deviation analysis and compliance tool
 Group:          Development/Tools
-# librpminspect is licensed under the LGPLv3+, but 5 source files in
-# the library are from an Apache 2.0 licensed project.  The
-# rpminspect(1) command line tool is licensed under the GPLv3+.  And
-# the rpminspect-data-generic package is licensed under the CC-BY-4.0
-# license.
-License:        GPLv3+ and LGPLv3+ and ASL 2.0 and MIT and CC-BY
+# librpminspect is licensed under the LGPL-3.0-or-later, and:
+# * 5 source files in the library are from an Apache-2.0 licensed
+#   project
+# * Some code in inspect_unicode.c was taken from a blog post about
+#   using icu4c and Unicode, it is under the MIT license.
+#
+# The rpminspect(1) command line tool is licensed under the
+# GPL-3.0-or-later.
+#
+# The rpminspect-data-generic package is licensed under the
+# CC-BY-4.0 license.
+#
+# Not packaged, but in the source:
+# * include/uthash.h is BSD-1-Clause
+# * include/compat/queue.h is BSD-3-Clause
+# * libxdiff/ is LGPL-2.1-or-later
+License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND MIT AND BSD-1-Clause AND BSD-3-Clause AND CC-BY-4.0
 URL:            https://github.com/rpminspect/rpminspect
 Source0:        https://github.com/rpminspect/rpminspect/releases/download/v%{version}/%{name}-%{version}.tar.xz
 Source1:        https://github.com/rpminspect/rpminspect/releases/download/v%{version}/%{name}-%{version}.tar.xz.asc


### PR DESCRIPTION
Migrate the License tag over to SPDX license identifiers.

Signed-off-by: David Cantrell <dcantrell@redhat.com>