### PR TITLE
[fix] Do not report "New patch file (null) has appeared"

### DIFF
--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -462,7 +462,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
         }
     } else if (comparison && file->peer_file == NULL) {
-        xasprintf(&params.msg, _("New patch file `%s` appeared"), params.file);
+        xasprintf(&params.msg, _("New patch file `%s` appeared"), file->localpath);
         params.severity = RESULT_INFO;
         params.waiverauth = NOT_WAIVABLE;
         params.verb = VERB_ADDED;


### PR DESCRIPTION
Instead of "(null)", give the actual filename of the new patch.  It's more useful.

Fixes: #957

Signed-off-by: David Cantrell <dcantrell@redhat.com>