### PR TITLE
Move to using the libannocheck library rather than running annocheck(1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ meson and ninja, plus the following libraries:
 | [curl](https://curl.se/) | :heavy_check_mark: | | [MIT](https://spdx.org/licenses/MIT.html) |
 | [ClamAV](https://www.clamav.net/) | :heavy_check_mark: | | [GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html) |
 | [gettext](https://www.gnu.org/software/gettext/) | | .po to .mo | [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later.html) |
+| [libannocheck](https://sourceware.org/annobin/) | | | [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later.html) |
 
 Additionally, the unit test suite requires the following packages:
 
@@ -143,7 +144,6 @@ there are a number of userspace programs used:
     /usr/bin/msgunfmt
     /usr/bin/abidiff [optional]
     /usr/bin/kmidiff [optional]
-    /usr/bin/annocheck [optional]
 
 The provided spec file template uses the Fedora locations for these
 files, but in the program, they must be on the runtime system.

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -57,10 +57,6 @@ commands:
     # Freedesktop.org
     #desktop-file-validate: /usr/bin/desktop-file-validate
 
-    # annocheck(1) from the annobin project:
-    # https://sourceware.org/git/annobin.git
-    #annocheck: /usr/bin/annocheck
-
     # abidiff(1) and kmidiff(1) from libabigail
     #abidiff: /usr/bin/abidiff
     #kmidiff: /usr/bin/kmidiff
@@ -579,10 +575,24 @@ annocheck:
     # the output.
     failure_severity: VERIFY
 
-    # annocheck(1) tests to run.  The left side of the colon is the
-    # test name you want to use and the right side are the arguments
-    # to the annocheck executable before giving it the full path to
-    # the filename.
+    # Optional name of the annocheck profile to set.  If used this
+    # must be a valid profile name from annocheck.  That is, one that
+    # is returned by libannocheck_get_known_profiles() which does not
+    # necessarily include aliases as shown in annocheck(1) --help
+    # output.
+    #
+    # This setting should be enable in vendor data packages as
+    # necessary.  The default mode of operation in rpminspect is to
+    # not enable a profile.
+    #profile: rawhide
+
+    # annocheck(1) hardened tests to run.  The left side of the colon
+    # is the test name you want to use and the right side are the
+    # arguments to the annocheck executable.  Valid options can be
+    # seen with 'annocheck --help-hardened' and specifically the
+    # '--skip-* and corresponding '--test-*' options.  Options that
+    # affect the output of the annocheck executable are ignored by
+    # rpminspect as it has its own reporting format.
     #
     # This section is optional.  If no annocheck tests are defined
     # here, rpminspect will skip the annocheck inspection.
@@ -590,7 +600,7 @@ annocheck:
     # These job entries may be listed here or under a block named
     # 'jobs:' if you prefer.
     jobs:
-        - hardened: --ignore-unknown --verbose
+        - hardened: --ignore-unknown
 
     # In an optional rpminspect.yaml file in the current directory,
     # you can supply extra arguments to defined annocheck runs.  If

--- a/include/constants.h
+++ b/include/constants.h
@@ -281,13 +281,6 @@
 #define DESKTOP_FILE_VALIDATE_CMD "desktop-file-validate"
 
 /**
- * @def ANNOCHECK_CMD
- *
- * Executable providing annocheck(1)
- */
-#define ANNOCHECK_CMD "annocheck"
-
-/**
  * @def ABIDIFF_CMD
  *
  * Executable providing abidiff(1)

--- a/include/init.h
+++ b/include/init.h
@@ -66,6 +66,7 @@
 #define SECTION_PRIMARY                  "primary"
 #define SECTION_PRODUCT_RELEASE          "product_release"
 #define SECTION_PRODUCTS                 "products"
+#define SECTION_PROFILE                  "profile"
 #define SECTION_PROFILEDIR               "profiledir"
 #define SECTION_PROVIDES                 "provides"
 #define SECTION_RECOMMENDS               "recommends"

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -111,7 +111,9 @@ extern volatile sig_atomic_t terminal_resized;
 
 /* init.c */
 bool init_fileinfo(struct rpminspect *);
+#ifdef _WITH_LIBCAP
 bool init_caps(struct rpminspect *);
+#endif
 bool init_rebaseable(struct rpminspect *);
 bool init_politics(struct rpminspect *ri);
 bool init_security(struct rpminspect *ri);
@@ -307,7 +309,9 @@ void free_argv(char **argv);
 bool match_fileinfo_mode(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *);
 bool match_fileinfo_owner(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *);
 bool match_fileinfo_group(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *);
+#ifdef _WITH_LIBCAP
 caps_filelist_entry_t *get_caps_entry(struct rpminspect *, const char *, const char *);
+#endif
 
 /* flags.c */
 bool process_inspection_flag(const char *, const bool, uint64_t *);

--- a/include/types.h
+++ b/include/types.h
@@ -376,7 +376,6 @@ struct command_paths {
     char *diff;
     char *msgunfmt;
     char *desktop_file_validate;
-    char *annocheck;
     char *abidiff;
     char *kmidiff;
 };
@@ -588,6 +587,7 @@ struct rpminspect {
     /* hash table of annocheck tests */
     string_map_t *annocheck;
     severity_t annocheck_failure_severity;
+    char *annocheck_profile;
 
     /* hash table of path migrations */
     string_map_t *pathmigration;

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -122,10 +122,6 @@ void dump_cfg(const struct rpminspect *ri)
         printf("    desktop-file-validate: %s\n", ri->commands.desktop_file_validate);
     }
 
-    if (ri->commands.annocheck) {
-        printf("    annocheck: %s\n", ri->commands.annocheck);
-    }
-
     if (ri->commands.abidiff) {
         printf("    abidiff: %s\n", ri->commands.abidiff);
     }

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -16,6 +16,10 @@
 #include <xmlrpc-c/client.h>
 #include <openssl/crypto.h>
 
+#ifdef _WITH_LIBANNOCHECK
+#include <libannocheck.h>
+#endif
+
 #include "rpminspect.h"
 
 /* For older versions of OpenSSL */
@@ -173,6 +177,14 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     xasprintf(&entry->data, "xmlrpc-c version %u.%u.%u", major, minor, update);
     TAILQ_INSERT_TAIL(list, entry, items);
 
+#ifdef _WITH_LIBANNOCHECK
+    /* libannocheck */
+    entry = calloc(1, sizeof(*entry));
+    assert(entry != NULL);
+    xasprintf(&entry->data, "libannocheck version %u", libannocheck_get_version());
+    TAILQ_INSERT_TAIL(list, entry, items);
+#endif
+
     /*
      * COMMANDS
      * External commands rpminspect runs.  We capture version info.
@@ -185,22 +197,6 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strdup(entry->data);
-    list_free(details, free);
-
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
-    xasprintf(&entry->data, "%s", ver);
-    TAILQ_INSERT_TAIL(list, entry, items);
-
-    free(ver);
-
-    /* annocheck */
-    tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.annocheck, "--version", NULL);
-    details = strsplit(tmp, "\n");
-    free(tmp);
-
-    entry = TAILQ_FIRST(details);
-    ver = strreplace(entry->data, ": Version ", " version ");
     list_free(details, free);
 
     entry = calloc(1, sizeof(*entry));

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -241,6 +241,7 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
  * If it doesn't exist on the list, return NULL.  This function will
  * take care of initializing the caps list if necessary.
  */
+#ifdef _WITH_LIBCAP
 caps_filelist_entry_t *get_caps_entry(struct rpminspect *ri, const char *pkg, const char *filepath)
 {
     bool found = false;
@@ -283,3 +284,4 @@ caps_filelist_entry_t *get_caps_entry(struct rpminspect *ri, const char *pkg, co
 
     return flentry;
 }
+#endif

--- a/lib/free.c
+++ b/lib/free.c
@@ -219,7 +219,6 @@ void free_rpminspect(struct rpminspect *ri)
 
     free(ri->commands.msgunfmt);
     free(ri->commands.desktop_file_validate);
-    free(ri->commands.annocheck);
     free(ri->commands.abidiff);
     free(ri->commands.kmidiff);
 
@@ -242,6 +241,7 @@ void free_rpminspect(struct rpminspect *ri)
     list_free(ri->shells, free);
     free_string_map(ri->jvm);
     free_string_map(ri->annocheck);
+    free(ri->annocheck_profile);
     free_string_map(ri->pathmigration);
     list_free(ri->pathmigration_excluded_paths, free);
     free_string_map(ri->products);

--- a/lib/init.c
+++ b/lib/init.c
@@ -123,10 +123,14 @@ enum {
     BLOCK_RPMDEPS = 60,
     BLOCK_MOVEDFILES = 61,
     BLOCK_POLITICS = 62,
+#ifdef _WITH_LIBCAP
     BLOCK_CAPABILITIES = 63,
+#endif
     BLOCK_CONFIG = 64,
     BLOCK_DOC = 65,
+#ifdef _WITH_LIBKMOD
     BLOCK_KMOD = 66,
+#endif
     BLOCK_PERMISSIONS = 67,
     BLOCK_REMOVEDFILES = 68,
     BLOCK_SYMLINKS = 69,
@@ -302,14 +306,18 @@ static void add_ignore(string_list_map_t **table, int i, char *s)
         inspection = NAME_MOVEDFILES;
     } else if (i == BLOCK_POLITICS) {
         inspection = NAME_POLITICS;
+#ifdef _WITH_LIBCAP
     } else if (i == BLOCK_CAPABILITIES) {
         inspection = NAME_CAPABILITIES;
+#endif
     } else if (i == BLOCK_CONFIG) {
         inspection = NAME_CONFIG;
     } else if (i == BLOCK_DOC) {
         inspection = NAME_DOC;
+#ifdef _WITH_LIBKMOD
     } else if (i == BLOCK_KMOD) {
         inspection = NAME_KMOD;
+#endif
     } else if (i == BLOCK_PERMISSIONS) {
         inspection = NAME_PERMISSIONS;
     } else if (i == BLOCK_REMOVEDFILES) {
@@ -691,7 +699,9 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                                                                 group != BLOCK_ADDEDFILES &&
                                                                 group != BLOCK_ANNOCHECK &&
                                                                 group != BLOCK_BADFUNCS &&
+#ifdef _WITH_LIBCAP
                                                                 group != BLOCK_CAPABILITIES &&
+#endif
                                                                 group != BLOCK_CHANGEDFILES &&
                                                                 group != BLOCK_CONFIG &&
                                                                 group != BLOCK_DESKTOP &&
@@ -702,7 +712,9 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                                                                 group != BLOCK_FILESIZE &&
                                                                 group != BLOCK_JAVABYTECODE &&
                                                                 group != BLOCK_KMIDIFF &&
+#ifdef _WITH_LIBKMOD
                                                                 group != BLOCK_KMOD &&
+#endif
                                                                 group != BLOCK_LTO &&
                                                                 group != BLOCK_MANPAGE &&
                                                                 group != BLOCK_METADATA &&
@@ -831,18 +843,22 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     } else if (!strcmp(key, NAME_POLITICS)) {
                         block = BLOCK_NULL;
                         group = BLOCK_POLITICS;
+#ifdef _WITH_LIBCAP
                     } else if (!strcmp(key, NAME_CAPABILITIES)) {
                         block = BLOCK_NULL;
                         group = BLOCK_CAPABILITIES;
+#endif
                     } else if (!strcmp(key, NAME_CONFIG)) {
                         block = BLOCK_NULL;
                         group = BLOCK_CONFIG;
                     } else if (!strcmp(key, NAME_DOC)) {
                         block = BLOCK_NULL;
                         group = BLOCK_DOC;
+#ifdef _WITH_LIBKMOD
                     } else if (!strcmp(key, NAME_KMOD)) {
                         block = BLOCK_NULL;
                         group = BLOCK_KMOD;
+#endif
                     } else if (!strcmp(key, NAME_PERMISSIONS)) {
                         block = BLOCK_NULL;
                         group = BLOCK_PERMISSIONS;
@@ -1024,10 +1040,12 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         if (!strcmp(key, SECTION_IGNORE)) {
                             block = BLOCK_IGNORE;
                         }
+#ifdef _WITH_LIBCAP
                     } else if (group == BLOCK_CAPABILITIES) {
                         if (!strcmp(key, SECTION_IGNORE)) {
                             block = BLOCK_IGNORE;
                         }
+#endif
                     } else if (group == BLOCK_CONFIG) {
                         if (!strcmp(key, SECTION_IGNORE)) {
                             block = BLOCK_IGNORE;
@@ -1036,10 +1054,12 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         if (!strcmp(key, SECTION_IGNORE)) {
                             block = BLOCK_IGNORE;
                         }
+#ifdef _WITH_LIBKMOD
                     } else if (group == BLOCK_KMOD) {
                         if (!strcmp(key, SECTION_IGNORE)) {
                             block = BLOCK_IGNORE;
                         }
+#endif
                     } else if (group == BLOCK_PERMISSIONS) {
                         if (!strcmp(key, SECTION_IGNORE)) {
                             block = BLOCK_IGNORE;
@@ -1621,6 +1641,7 @@ bool init_fileinfo(struct rpminspect *ri)
  * Initialize the caps list for the given product release.  If the
  * file cannot be found, return false.
  */
+#ifdef _WITH_LIBCAP
 bool init_caps(struct rpminspect *ri)
 {
     char *line = NULL;
@@ -1739,6 +1760,7 @@ bool init_caps(struct rpminspect *ri)
 
     return true;
 }
+#endif
 
 /*
  * Initialize the rebaseable list for the given product release and

--- a/lib/init.c
+++ b/lib/init.c
@@ -140,7 +140,8 @@ enum {
     BLOCK_LICENSEDB = 73,
     BLOCK_DEBUGINFO = 74,
     BLOCK_PATCH_AUTOMACROS = 75,
-    BLOCK_MODULARITY = 76
+    BLOCK_MODULARITY = 76,
+    BLOCK_ANNOCHECK_PROFILE = 77
 };
 
 static int add_regex(const char *pattern, regex_t **regex_out)
@@ -998,6 +999,8 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                             block = BLOCK_ANNOCHECK_EXTRA_OPTS;
                         } else if (!strcmp(key, SECTION_IGNORE)) {
                             block = BLOCK_IGNORE;
+                        } else if (!strcmp(key, SECTION_PROFILE)) {
+                            block = BLOCK_ANNOCHECK_PROFILE;
                         } else if (strcmp(key, t)) {
                             /* continue support the old syntax for the yaml file */
                             process_table(key, t, false, false, &ri->annocheck);
@@ -1120,9 +1123,6 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         } else if (!strcmp(key, SECTION_DESKTOP_FILE_VALIDATE)) {
                             free(ri->commands.desktop_file_validate);
                             ri->commands.desktop_file_validate = strdup(t);
-                        } else if (!strcmp(key, SECTION_ANNOCHECK)) {
-                            free(ri->commands.annocheck);
-                            ri->commands.annocheck = strdup(t);
                         } else if (!strcmp(key, SECTION_ABIDIFF)) {
                             free(ri->commands.abidiff);
                             ri->commands.abidiff = strdup(t);
@@ -1293,6 +1293,9 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                                 warnx(_("Invalid annocheck failure_reporting_level: %s, defaulting to %s."), t, strseverity(RESULT_VERIFY));
                                 ri->annocheck_failure_severity = RESULT_VERIFY;
                             }
+                        } else if (block == BLOCK_ANNOCHECK_PROFILE) {
+                            free(ri->annocheck_profile);
+                            ri->annocheck_profile = strdup(t);
                         }
                     } else if (group == BLOCK_JAVABYTECODE) {
                         process_table(key, t, false, true, &ri->jvm);
@@ -2227,7 +2230,6 @@ struct rpminspect *calloc_rpminspect(struct rpminspect *ri)
     /* Initialize commands */
     ri->commands.msgunfmt = strdup(MSGUNFMT_CMD);
     ri->commands.desktop_file_validate = strdup(DESKTOP_FILE_VALIDATE_CMD);
-    ri->commands.annocheck = strdup(ANNOCHECK_CMD);
     ri->commands.abidiff = strdup(ABIDIFF_CMD);
     ri->commands.kmidiff = strdup(KMIDIFF_CMD);
 

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -47,7 +47,9 @@ struct inspect inspections[] = {
     { INSPECT_UPSTREAM,      "upstream",      false, &inspect_upstream },
     { INSPECT_OWNERSHIP,     "ownership",     true,  &inspect_ownership },
     { INSPECT_SHELLSYNTAX,   "shellsyntax",   true,  &inspect_shellsyntax },
+#ifdef _WITH_LIBANNOCHECK
     { INSPECT_ANNOCHECK,     "annocheck",     true,  &inspect_annocheck },
+#endif
     { INSPECT_DSODEPS,       "dsodeps",       false, &inspect_dsodeps },
     { INSPECT_FILESIZE,      "filesize",      false, &inspect_filesize },
     { INSPECT_PERMISSIONS,   "permissions",   true,  &inspect_permissions },
@@ -169,8 +171,10 @@ uint64_t inspection_id(const char *name)
         return INSPECT_OWNERSHIP;
     } else if (!strcmp(name, NAME_SHELLSYNTAX)) {
         return INSPECT_SHELLSYNTAX;
+#ifdef _WITH_LIBANNOCHECK
     } else if (!strcmp(name, NAME_ANNOCHECK)) {
         return INSPECT_ANNOCHECK;
+#endif
     } else if (!strcmp(name, NAME_DSODEPS)) {
         return INSPECT_DSODEPS;
     } else if (!strcmp(name, NAME_FILESIZE)) {
@@ -274,8 +278,10 @@ const char *inspection_desc(const uint64_t inspection)
             return DESC_OWNERSHIP;
         case INSPECT_SHELLSYNTAX:
             return DESC_SHELLSYNTAX;
+#ifdef _WITH_LIBANNOCHECK
         case INSPECT_ANNOCHECK:
             return DESC_ANNOCHECK;
+#endif
         case INSPECT_DSODEPS:
             return DESC_DSODEPS;
         case INSPECT_FILESIZE:
@@ -380,6 +386,10 @@ const char *inspection_header_to_desc(const char *header)
         i = INSPECT_OWNERSHIP;
     } else if (!strcmp(header, NAME_SHELLSYNTAX)) {
         i = INSPECT_SHELLSYNTAX;
+#ifdef _WITH_LIBANNOCHECK
+    } else if (!strcmp(header, NAME_ANNOCHECK)) {
+        i = INSPECT_ANNOCHECK;
+#endif
     } else if (!strcmp(header, NAME_DSODEPS)) {
         i = INSPECT_DSODEPS;
     } else if (!strcmp(header, NAME_FILESIZE)) {

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -6,81 +6,204 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <err.h>
 #include <assert.h>
+#include <libannocheck.h>
 
 #include "rpminspect.h"
 
+/* Global variables */
 static bool reported = false;
 
-/* Trim workdir substrings from a generated string. */
-static char *trim_workdir(const rpmfile_entry_t *file, char *s)
+/*
+ * Try to map the product release string to an appropriate
+ * libannocheck profile.  This is going to be something that will need
+ * maintenance over time.  Since the profile list is embedded in
+ * libannocheck, there's no easy way to discover changes.  The
+ * assumption here is the profile naming scheme remains the same.
+ */
+static void set_libannocheck_profile(struct libannocheck_internals *anno, const char *product_release)
 {
-    size_t fl = 0;
-    size_t ll = 0;
-    char *workdir = NULL;
-    char *tmp = NULL;
+    const char **profiles = NULL;
+    unsigned int num_profiles = 0;
+    unsigned int i = 0;
+    libannocheck_error annoerr = 0;
 
-    assert(file != NULL);
-
-    if (s == NULL) {
-        return s;
+    if (anno == NULL || product_release == NULL) {
+        return;
     }
 
-    fl = strlen(file->fullpath);
-    ll = strlen(file->localpath);
+    /* get libannocheck profiles first */
+    annoerr = libannocheck_get_known_profiles(anno, &profiles, &num_profiles);
 
-    if (fl > ll) {
-        workdir = strndup(file->fullpath, fl - ll);
+    if (annoerr != libannocheck_error_none) {
+         warnx(_("libannocheck_get_known_profiles error: %s"), libannocheck_get_error_message(anno, annoerr));
+         return;
     }
 
-    if (workdir) {
-        tmp = strreplace(s, workdir, NULL);
-        free(s);
-        free(workdir);
-        s = tmp;
+    /* iterate over the profiles to try and find a match */
+    for (i = 0; i < num_profiles; i++) {
+        /* XXX: this needs a map in the config file */
+        if (strsuffix(product_release, profiles[i]) || (strprefix(product_release, ".fc") && !strcmp(profiles[i], "rawhide"))) {
+            annoerr = libannocheck_enable_profile(anno, profiles[i]);
+
+            if (annoerr != libannocheck_error_none) {
+                warnx(_("libannocheck_enable_profile error: %s"), libannocheck_get_error_message(anno, annoerr));
+            }
+
+            return;
+        }
     }
 
-    return s;
+    return;
 }
 
 /*
- * Build the annocheck command to run and report in the output.  This
- * is a single string the caller must free.
+ * Convert a libannocheck_test_state enum to a string suitable for
+ * reporting.  Do not free this string.
  */
-static char *build_annocheck_cmd(const char *cmd, const char *opts, const char *debugpath, const char *path)
+static const char *get_state(libannocheck_test_state s)
 {
-    char *r = NULL;
+    if (s == libannocheck_test_state_not_run) {
+        return _("NOT RUN");
+    } else if (s == libannocheck_test_state_passed) {
+        return _("PASSED");
+    } else if (s == libannocheck_test_state_failed) {
+        return _("FAILED");
+    } else if (s == libannocheck_test_state_maybe) {
+        return _("MAYBE");
+    } else if (s == libannocheck_test_state_skipped) {
+        return _("skipped");
+    } else {
+        return _("UNKNOWN");
+    }
+}
 
-    assert(cmd != NULL);
-    assert(path != NULL);
-
-    if (opts == NULL && debugpath == NULL) {
-        xasprintf(&r, "%s %s", cmd, path);
-    } else if (opts && debugpath == NULL) {
-        xasprintf(&r, "%s %s %s", cmd, opts, path);
-    } else if (opts && debugpath) {
-        xasprintf(&r, "%s %s --debug-dir=%s %s", cmd, opts, debugpath, path);
+/*
+ * Given the existing 'worst' value and a new libannocheck_test_state
+ * value, compare them returning the worst one.  This function ignores
+ * the 'not run' and 'skipped' states.
+ */
+static libannocheck_test_state get_worst(libannocheck_test_state worst, libannocheck_test_state s)
+{
+    /* ignore 'not run' and 'skipped' states */
+    if (s == libannocheck_test_state_not_run || s == libannocheck_test_state_skipped) {
+        return worst;
     }
 
-    return r;
+    if (s > worst) {
+        return s;
+    }
+
+    return worst;
+}
+
+/*
+ * Do the libannocheck setup for a file.  If this is the first call,
+ * it will initializae libannocheck.  Otherwise, it will reinit the
+ * existing handle.  Returns libannocheck handle on success, NULL
+ * otherwise.
+ */
+static struct libannocheck_internals *libannocheck_setup(struct rpminspect *ri, const rpmfile_entry_t *file, char *opts, struct libannocheck_internals *h)
+{
+    struct libannocheck_internals *anno = h;
+    const char *arch = NULL;
+    libannocheck_error annoerr = 0;
+    string_list_t *args = NULL;
+    string_entry_t *entry = NULL;
+    char *test = NULL;
+
+    assert(ri != NULL);
+    assert(file != NULL);
+
+    arch = get_rpm_header_arch(file->rpm_header);
+
+    if (anno == NULL) {
+        /* initialize libannocheck for this test on this file */
+        annoerr = libannocheck_init(LIBANNOCHECK_VERSION, file->fullpath, get_after_debuginfo_path(ri, file, arch), &anno);
+
+        if (annoerr != libannocheck_error_none) {
+             warnx(_("libannocheck_init error: %s"), libannocheck_get_error_message(anno, annoerr));
+             libannocheck_finish(anno);
+             return NULL;
+        }
+
+        /*
+         * handle annocheck options if there are any, otherwise
+         * enable all tests
+         */
+        if (opts) {
+            args = strsplit(opts, " \t");
+
+            if (args) {
+                TAILQ_FOREACH(entry, args, items) {
+                    if (strstr(entry->data, "=") || !strprefix(entry->data, "--test-") || !strprefix(entry->data, "--skip-")) {
+                        continue;
+                    }
+
+                    /* the argument past the leading --test- or --skip- */
+                    test = entry->data + 7;
+
+                    if (strprefix(entry->data, "--test-")) {
+                        annoerr = libannocheck_enable_test(anno, test);
+                        test = "enable";
+                    } else {
+                        annoerr = libannocheck_disable_test(anno, test);
+                        test = "disable";
+                    }
+
+                    if (annoerr != libannocheck_error_none) {
+                        warnx(_("libannocheck_%s_test error: %s:"), test, libannocheck_get_error_message(anno, annoerr));
+                        libannocheck_finish(anno);
+                        return NULL;
+                    }
+                }
+
+                list_free(args, free);
+            }
+        } else {
+            annoerr = libannocheck_enable_all_tests(anno);
+
+            if (annoerr != libannocheck_error_none) {
+                warnx(_("libannocheck_enable_all_tests error: %s:"), libannocheck_get_error_message(anno, annoerr));
+                libannocheck_finish(anno);
+                return NULL;
+            }
+        }
+
+        /* enable libannocheck profile if there's a match */
+        set_libannocheck_profile(anno, ri->product_release);
+    } else {
+        /* reinitialize with a new file */
+        annoerr = libannocheck_reinit(anno, file->fullpath, get_after_debuginfo_path(ri, file, arch));
+
+        if (annoerr != libannocheck_error_none) {
+             warnx(_("libannocheck_reinit error: %s"), libannocheck_get_error_message(anno, annoerr));
+             libannocheck_finish(anno);
+             return NULL;
+        }
+    }
+
+    return anno;
 }
 
 static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool result = true;
     const char *arch = NULL;
-    char **argv = NULL;
-    char *before_cmd = NULL;
-    char *after_cmd = NULL;
     string_map_t *hentry = NULL;
     string_map_t *tmp_hentry = NULL;
-    char *after_out = NULL;
-    int after_exit = 0;
-    char *before_out = NULL;
-    int before_exit = 0;
-    char *details = NULL;
-    string_list_t *slist = NULL;
-    string_entry_t *sentry = NULL;
+    struct libannocheck_internals *ah = NULL;
+    libannocheck_error annoerr = 0;
+    struct libannocheck_test *annotests = NULL;
+    unsigned int i = 0;
+    unsigned int numtests = 0;
+    unsigned int failed = 0;
+    unsigned int maybe = 0;
+    char *tmp = NULL;
+    string_list_t *details = NULL;
+    libannocheck_test_state after_worst = 0;
+    libannocheck_test_state before_worst = 0;
     struct result_params params;
 
     assert(ri != NULL);
@@ -107,120 +230,183 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Set up the result parameters */
     init_result_params(&params);
-    params.severity = RESULT_INFO;
-    params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_ANNOCHECK;
-    params.remedy = REMEDY_ANNOCHECK;
     params.arch = arch;
     params.file = file->localpath;
-    params.verb = VERB_OK;
 
     /* Run each annocheck test and report the results */
     HASH_ITER(hh, ri->annocheck, hentry, tmp_hentry) {
-        /* Run the test on the file */
-        after_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, get_after_debuginfo_path(ri, file, arch), file->fullpath);
-        argv = build_argv(after_cmd);
-        after_out = run_cmd_vpe(&after_exit, ri->worksubdir, argv);
-        free_argv(argv);
-
-        /* If we have a before build, run the command on that */
+        /* run libannocheck on the before build (if any) first */
         if (file->peer_file) {
-            before_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, get_before_debuginfo_path(ri, file, arch), file->peer_file->fullpath);
-            argv = build_argv(before_cmd);
-            before_out = run_cmd_vpe(&before_exit, ri->workdir, argv);
-            free_argv(argv);
+            ah = libannocheck_setup(ri, file->peer_file, hentry->value, ah);
 
-            /* Build a reporting message if we need to */
-            if (before_exit == 0 && after_exit == 0) {
-                xasprintf(&params.msg, _("annocheck '%s' test passes for %s on %s"), hentry->key, file->localpath, arch);
-            } else if (before_exit && after_exit == 0) {
-                xasprintf(&params.msg, _("annocheck '%s' test now passes for %s on %s"), hentry->key, file->localpath, arch);
-            } else if (before_exit == 0 && after_exit) {
-                xasprintf(&params.msg, _("annocheck '%s' test now fails for %s on %s"), hentry->key, file->localpath, arch);
-                params.severity = ri->annocheck_failure_severity;
+            if (ah == NULL) {
+                continue;
+            }
+
+            /* run the tests on the before build file (if any) */
+            annoerr = libannocheck_run_tests(ah, &failed, &maybe);
+
+            if (annoerr != libannocheck_error_none) {
+                warnx(_("blurp libannocheck_run_tests error: %s:"), libannocheck_get_error_message(ah, annoerr));
+                libannocheck_finish(ah);
+                continue;
+            }
+
+            /* collect the worst result from the build build now */
+            annoerr = libannocheck_get_known_tests(ah, &annotests, &numtests);
+
+            if (annoerr != libannocheck_error_none) {
+                warnx(_("libannocheck_get_known_tests error: %s"), libannocheck_get_error_message(ah, annoerr));
+                libannocheck_finish(ah);
+                continue;
+            }
+
+            for (i = 0; i < numtests; i++) {
+                if (!annotests[i].enabled || annotests[i].state == libannocheck_test_state_not_run) {
+                    continue;
+                }
+
+                /* capture worst result */
+                before_worst = get_worst(before_worst, annotests[i].state);
+            }
+
+            /* close the handle and prepare to start over */
+            annoerr = libannocheck_finish(ah);
+
+            if (annoerr != libannocheck_error_none) {
+                warnx(_("libannocheck_finish error: %s"), libannocheck_get_error_message(ah, annoerr));
+            }
+
+            ah = NULL;
+        }
+
+        /* set up libannocheck for the after build file */
+        ah = libannocheck_setup(ri, file, hentry->value, ah);
+
+        if (ah == NULL) {
+            continue;
+        }
+
+        /* run the tests on the after build file */
+        annoerr = libannocheck_run_tests(ah, &failed, &maybe);
+
+        if (annoerr != libannocheck_error_none) {
+            warnx(_("flurfle libannocheck_run_tests error: %s:"), libannocheck_get_error_message(ah, annoerr));
+            libannocheck_finish(ah);
+            continue;
+        }
+
+        /* get the list of known tests */
+        annoerr = libannocheck_get_known_tests(ah, &annotests, &numtests);
+
+        if (annoerr != libannocheck_error_none) {
+             warnx(_("libannocheck_get_known_tests error: %s"), libannocheck_get_error_message(ah, annoerr));
+             libannocheck_finish(ah);
+             continue;
+        }
+
+        /* build details */
+        for (i = 0; i < numtests; i++) {
+            if (!annotests[i].enabled || annotests[i].state == libannocheck_test_state_not_run) {
+                continue;
+            }
+
+            /* build the detailed reporting similar to annocheck(1) */
+            xasprintf(&tmp, "Hardened: %s: %.4s: '%s' test", file->localpath, get_state(annotests[i].state), annotests[i].name);
+            assert(tmp != NULL);
+            details = list_add(details, tmp);
+            free(tmp);
+
+            xasprintf(&tmp, "Hardened: %s: %.4s: %s", file->localpath, get_state(annotests[i].state), annotests[i].description);
+            assert(tmp != NULL);
+            details = list_add(details, tmp);
+            free(tmp);
+
+            if (annotests[i].state == libannocheck_test_state_failed || annotests[i].state == libannocheck_test_state_maybe) {
+                xasprintf(&tmp, "Hardened: %s: %.4s: %s", file->localpath, get_state(annotests[i].state), annotests[i].doc_url);
+                assert(tmp != NULL);
+                details = list_add(details, tmp);
+                free(tmp);
+            }
+
+            /* handle loss of -O2 -D_FORTIFY_SOURCE for reporting */
+            if ((!strcmp(annotests[i].name, "fortify") || !strcmp(annotests[i].name, "optimization")) &&
+                (annotests[i].state == libannocheck_test_state_maybe || annotests[i].state == libannocheck_test_state_failed)) {
+                params.waiverauth = WAIVABLE_BY_SECURITY;
+                params.remedy = REMEDY_ANNOCHECK_FORTIFY_SOURCE;
+                params.verb = VERB_REMOVED;
+                params.noun = _("lost -D_FORTIFY_SOURCE in ${FILE} on ${ARCH}");
+                params.severity = get_secrule_result_severity(ri, file, SECRULE_FORTIFYSOURCE);
+
+                xasprintf(&params.msg, _("%s may have lost -O2 -D_FORTIFY_SOURCE on %s"), file->localpath, arch);
+                params.details = NULL;
+
+                if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
+                    add_result(ri, &params);
+                    reported = true;
+                }
+
+                free(params.msg);
+                params.msg = NULL;
+            }
+
+            /* capture worst result */
+            after_worst = get_worst(after_worst, annotests[i].state);
+        }
+
+        /* report the results */
+        params.severity = RESULT_INFO;
+        params.waiverauth = NOT_WAIVABLE;
+        params.remedy = REMEDY_ANNOCHECK;
+        params.verb = VERB_OK;
+
+        if (after_worst == libannocheck_test_state_maybe || after_worst == libannocheck_test_state_failed) {
+            params.severity = ri->annocheck_failure_severity;
+            params.waiverauth = WAIVABLE_BY_ANYONE;
+        }
+
+        if (file->peer_file) {
+            if (before_worst == libannocheck_test_state_passed && after_worst == libannocheck_test_state_passed) {
+                xasprintf(&params.msg, _("libannocheck '%s' continues passing for %s on %s"), hentry->key, file->localpath, arch);
+            } else if ((before_worst == libannocheck_test_state_maybe || before_worst == libannocheck_test_state_failed) &&
+                       after_worst == libannocheck_test_state_passed) {
+                xasprintf(&params.msg, _("libannocheck '%s' test now passes for %s on %s"), hentry->key, file->localpath, arch);
+            } else if (before_worst == libannocheck_test_state_passed &&
+                       (after_worst == libannocheck_test_state_maybe || after_worst == libannocheck_test_state_failed)) {
+                xasprintf(&params.msg, _("libannocheck '%s' test now fails for %s on %s"), hentry->key, file->localpath, arch);
                 params.verb = VERB_CHANGED;
-                result = !(ri->annocheck_failure_severity >= RESULT_VERIFY);
-            } else if (after_exit) {
-                xasprintf(&params.msg, _("annocheck '%s' test fails for %s on %s"), hentry->key, file->localpath, arch);
-                params.severity = ri->annocheck_failure_severity;
+            } else if (after_worst == libannocheck_test_state_maybe || after_worst == libannocheck_test_state_failed) {
+                xasprintf(&params.msg, _("libannocheck '%s' test fails for %s on %s"), hentry->key, file->localpath, arch);
                 params.verb = VERB_CHANGED;
-                result = !(ri->annocheck_failure_severity >= RESULT_VERIFY);
             }
         } else {
-            if (after_exit == 0) {
-                xasprintf(&params.msg, _("annocheck '%s' test passes for %s on %s"), hentry->key, file->localpath, arch);
-            } else if (after_exit) {
-                xasprintf(&params.msg, _("annocheck '%s' test fails for %s on %s"), hentry->key, file->localpath, arch);
-                params.severity = ri->annocheck_failure_severity;
-                params.verb = VERB_CHANGED;
-                result = !(ri->annocheck_failure_severity >= RESULT_VERIFY);
-            }
-        }
-
-        /* Report the results */
-        if (params.msg) {
-            /* trim the before build working directory and generate details */
-            if (before_cmd) {
-                before_cmd = trim_workdir(file->peer_file, before_cmd);
-                xasprintf(&details, "Command: %s\nExit Code: %d\n    compared with the output of:\nCommand: %s\nExit Code: %d\n\n%s", before_cmd, before_exit, after_cmd, after_exit, after_out);
+            if (after_worst == libannocheck_test_state_passed) {
+                xasprintf(&params.msg, _("libannocheck '%s' test passes for %s on %s"), hentry->key, file->localpath, arch);
             } else {
-                xasprintf(&details, "Command: %s\nExit Code: %d\n\n%s", after_cmd, after_exit, after_out);
+                xasprintf(&params.msg, _("libannocheck '%s' test fails for %s on %s"), hentry->key, file->localpath, arch);
+                params.verb = VERB_CHANGED;
             }
-
-            /* trim the after build working directory */
-            details = trim_workdir(file, details);
-
-            params.details = details;
-            add_result(ri, &params);
-            reported = true;
-            free(params.msg);
         }
 
-        /* Check for loss of -O2 -D_FORTIFY_SOURCE=2 */
-        /* XXX: this will change with a move to libannocheck */
-        if (after_out) {
-            slist = strsplit(after_out, "\n");
-            assert(slist != NULL);
+        params.details = list_to_string(details, "\n");
+        add_result(ri, &params);
+        reported = true;
+        free(params.details);
+        free(params.msg);
+        list_free(details, free);
+    }
 
-            TAILQ_FOREACH(sentry, slist, items) {
-                if (strprefix(sentry->data, "FAIL:") && (strstr(sentry->data, "fortify") || strstr(sentry->data, "optimization"))) {
-                    init_result_params(&params);
-                    params.header = NAME_ANNOCHECK;
-                    params.waiverauth = WAIVABLE_BY_SECURITY;
-                    params.remedy = REMEDY_ANNOCHECK_FORTIFY_SOURCE;
-                    params.arch = arch;
-                    params.file = file->localpath;
-                    params.verb = VERB_REMOVED;
-                    params.noun = _("lost -D_FORTIFY_SOURCE in ${FILE} on ${ARCH}");
-                    params.severity = get_secrule_result_severity(ri, file, SECRULE_FORTIFYSOURCE);
+    /* set result based on worst result encountered */
+    if (after_worst >= libannocheck_test_state_maybe) {
+        result = !(ri->annocheck_failure_severity >= RESULT_VERIFY);
+    }
 
-                    xasprintf(&params.msg, _("%s may have lost -D_FORTIFY_SOURCE on %s"), file->localpath, arch);
-                    params.details = details;
+    /* close out */
+    annoerr = libannocheck_finish(ah);
 
-                    if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
-                        add_result(ri, &params);
-                        reported = true;
-                        result = !(params.severity >= RESULT_VERIFY);
-                    }
-
-                    break;
-                }
-            }
-
-            list_free(slist, free);
-        }
-
-        /* Cleanup */
-        free(details);
-
-        free(after_out);
-        free(before_out);
-
-        free(after_cmd);
-        free(before_cmd);
-
-        after_exit = 0;
-        before_exit = 0;
+    if (annoerr != libannocheck_error_none) {
+        warnx(_("libannocheck_finish error: %s"), libannocheck_get_error_message(ah, annoerr));
     }
 
     return result;
@@ -235,11 +421,6 @@ bool inspect_annocheck(struct rpminspect *ri)
     struct result_params params;
 
     assert(ri != NULL);
-
-    /* skip if we have no annocheck tests defined */
-    if (ri->annocheck == NULL) {
-        return true;
-    }
 
     /* run the annocheck tests across all ELF files */
     result = foreach_peer_file(ri, NAME_ANNOCHECK, annocheck_driver);

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -475,10 +475,14 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
                 add_execstack_flag_str(flaglist, "SHF_MASKOS");
             } else if (execstack_flags & SHF_MASKPROC) {
                 add_execstack_flag_str(flaglist, "SHF_MASKPROC");
+#ifdef SHF_ORDERED
             } else if (execstack_flags & SHF_ORDERED) {
                 add_execstack_flag_str(flaglist, "SHF_ORDERED");
+#endif
+#ifdef SHF_EXCLUDE
             } else if (execstack_flags & SHF_EXCLUDE) {
                 add_execstack_flag_str(flaglist, "SHF_EXCLUDE");
+#endif
             }
 
             fs = list_to_string(flaglist, ", ");

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -37,7 +37,6 @@ librpminspect_sources = [
     'inspect.c',
     'inspect_addedfiles.c',
     'inspect_abidiff.c',
-    'inspect_annocheck.c',
     'inspect_arch.c',
     'inspect_badfuncs.c',
     'inspect_changedfiles.c',
@@ -139,6 +138,11 @@ endif
 if get_option('with_libcap')
     librpminspect_sources += [ 'inspect_capabilities.c' ]
     deps += [ libcap ]
+endif
+
+if get_option('with_libannocheck')
+    librpminspect_sources += [ 'inspect_annocheck.c' ]
+    deps += [ libannocheck ]
 endif
 
 librpminspect = library(

--- a/meson.build
+++ b/meson.build
@@ -197,6 +197,15 @@ else
     libcap = disabler()
 endif
 
+# libannocheck
+if get_option('with_libannocheck')
+    libannocheck = dependency('libannocheck', required : true)
+    add_project_arguments('-D_WITH_LIBANNOCHECK', language : 'c')
+else
+    message('disable libannocheck support')
+    libannocheck = disabler()
+endif
+
 # dlopen
 if not cc.has_function('dlopen', args : ['-ldl'], dependencies : [zlib])
     error('*** unable to find dlopen() in libdl')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,3 +22,8 @@ option('with_libcap',
        type : 'boolean',
        value : true,
        description : 'Enable Linux capability(7) support using libcap.  Disabling libcap support will also disable capability(7)-related inspections.')
+
+option('with_libannocheck',
+       type : 'boolean',
+       value : true,
+       description : 'Enable libannocheck support for binary file analysis.  Disabling libannocheck support will also disable the annocheck inspection.')

--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -48,6 +48,7 @@ BuildRequires:  clamav-devel
 BuildRequires:  libmandoc-devel >= 1.14.5
 BuildRequires:  gnupg2
 BuildRequires:  libicu-devel
+BuildRequires:  annobin-annocheck
 
 
 %description
@@ -99,14 +100,6 @@ Requires:       zsh
 Requires:       tcsh
 Requires:       rc
 Requires:       bash
-%endif
-
-# The annocheck program is used by the annocheck inspection.  If it is
-# not present, you can disable the annocheck inspection.
-%if 0%{?rhel} >= 8 || 0%{?epel} >= 8 || 0%{?fedora}
-Recommends:     /usr/bin/annocheck
-%else
-Requires:       /usr/bin/annocheck
 %endif
 
 # The abidiff and kmidiff inspections require a external executable by

--- a/test/test_annocheck.py
+++ b/test/test_annocheck.py
@@ -74,7 +74,7 @@ class AnnocheckNotHardenedCompareRPMs(TestCompareRPMs):
 
         self.inspection = "annocheck"
         self.result = "VERIFY"
-        self.waiver_auth = "Not Waivable"
+        self.waiver_auth = "Anyone"
 
 
 @unittest.skipUnless(have_annocheck, "annocheck not available")
@@ -87,7 +87,7 @@ class AnnocheckNotHardenedCompareKoji(TestCompareKoji):
 
         self.inspection = "annocheck"
         self.result = "VERIFY"
-        self.waiver_auth = "Not Waivable"
+        self.waiver_auth = "Anyone"
 
 
 @unittest.skipUnless(have_annocheck, "annocheck not available")
@@ -143,7 +143,7 @@ class AnnocheckNotHardenedRPMs(TestRPMs):
 
         self.inspection = "annocheck"
         self.result = "VERIFY"
-        self.waiver_auth = "Not Waivable"
+        self.waiver_auth = "Anyone"
 
 
 @unittest.skipUnless(have_annocheck, "annocheck not available")
@@ -155,4 +155,4 @@ class AnnocheckNotHardenedKoji(TestKoji):
 
         self.inspection = "annocheck"
         self.result = "VERIFY"
-        self.waiver_auth = "Not Waivable"
+        self.waiver_auth = "Anyone"


### PR DESCRIPTION
This is a large patch set.  Also, I forgot to merge the previous PR with the FreeBSD CI fixes so that's bundled in here too.  They are different commits, so I don't care.

libannocheck is also something that can be disabled at build time for systems where libannocheck is not available.  Reporting is similar to what annocheck(1) reports.  A FAIL or MAYB result from a test will trigger an rpminspect failure (a VERIFY result) unless that has been overridden by the rpminspect config file.  The fortify-source check is a security check and will always be RESULT_BAD unless the vendor data package carries a rule instructing rpminspect to report that finding a different way for the file in question.

Test suite updated, meson files updated, spec file updated, and so on.