### PR TITLE
[lib] Bring back support for annocheck(1) in the annocheck inspection

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -280,6 +280,15 @@
  */
 #define DESKTOP_FILE_VALIDATE_CMD "desktop-file-validate"
 
+#ifdef _WITH_ANNOCHECK
+/**
+ * @def ANNOCHECK_CMD
+ *
+ * Executable providing annocheck(1)
+ */
+#define ANNOCHECK_CMD "annocheck"
+#endif
+
 /**
  * @def ABIDIFF_CMD
  *

--- a/include/types.h
+++ b/include/types.h
@@ -378,6 +378,9 @@ struct command_paths {
     char *desktop_file_validate;
     char *abidiff;
     char *kmidiff;
+#ifdef _WITH_ANNOCHECK
+    char *annocheck;
+#endif
 };
 
 /* Hash table used for key/value situations where each is a string. */

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -130,6 +130,12 @@ void dump_cfg(const struct rpminspect *ri)
         printf("    kmidiff: %s\n", ri->commands.kmidiff);
     }
 
+#ifdef _WITH_ANNOCHECK
+    if (ri->commands.annocheck) {
+        printf("    annocheck: %s\n", ri->commands.annocheck);
+    }
+#endif
+
     /* vendor */
 
     printf("vendor:\n");

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -206,6 +206,24 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     free(ver);
 
+#ifdef _WITH_ANNOCHECK
+    /* annocheck */
+    tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.annocheck, "--version", NULL);
+    details = strsplit(tmp, "\n");
+    free(tmp);
+
+    entry = TAILQ_FIRST(details);
+    ver = strreplace(entry->data, ": Version ", " version ");
+    list_free(details, free);
+
+    entry = calloc(1, sizeof(*entry));
+    assert(entry != NULL);
+    xasprintf(&entry->data, "%s", ver);
+    TAILQ_INSERT_TAIL(list, entry, items);
+
+    free(ver);
+#endif
+
     /* abidiff */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.abidiff, "--version", NULL);
     details = strsplit(tmp, "\n");

--- a/lib/free.c
+++ b/lib/free.c
@@ -221,6 +221,9 @@ void free_rpminspect(struct rpminspect *ri)
     free(ri->commands.desktop_file_validate);
     free(ri->commands.abidiff);
     free(ri->commands.kmidiff);
+#ifdef _WITH_ANNOCHECK
+    free(ri->commands.annocheck);
+#endif
 
     list_free(ri->buildhost_subdomain, free);
     list_free(ri->macrofiles, free);

--- a/lib/init.c
+++ b/lib/init.c
@@ -1127,6 +1127,11 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                         } else if (!strcmp(key, SECTION_DESKTOP_FILE_VALIDATE)) {
                             free(ri->commands.desktop_file_validate);
                             ri->commands.desktop_file_validate = strdup(t);
+#ifdef _WITH_ANNOCHECK
+                        } else if (!strcmp(key, SECTION_ANNOCHECK)) {
+                            free(ri->commands.annocheck);
+                            ri->commands.annocheck = strdup(t);
+#endif
                         } else if (!strcmp(key, SECTION_ABIDIFF)) {
                             free(ri->commands.abidiff);
                             ri->commands.abidiff = strdup(t);
@@ -2236,6 +2241,9 @@ struct rpminspect *calloc_rpminspect(struct rpminspect *ri)
     ri->commands.desktop_file_validate = strdup(DESKTOP_FILE_VALIDATE_CMD);
     ri->commands.abidiff = strdup(ABIDIFF_CMD);
     ri->commands.kmidiff = strdup(KMIDIFF_CMD);
+#ifdef _WITH_ANNOCHECK
+    ri->commands.annocheck = strdup(ANNOCHECK_CMD);
+#endif
 
     /* Store full paths to all config files read */
     if (ri->cfgfiles == NULL) {

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -47,7 +47,7 @@ struct inspect inspections[] = {
     { INSPECT_UPSTREAM,      "upstream",      false, &inspect_upstream },
     { INSPECT_OWNERSHIP,     "ownership",     true,  &inspect_ownership },
     { INSPECT_SHELLSYNTAX,   "shellsyntax",   true,  &inspect_shellsyntax },
-#ifdef _WITH_LIBANNOCHECK
+#if defined(_WITH_ANNOCHECK) || defined(_WITH_LIBANNOCHECK)
     { INSPECT_ANNOCHECK,     "annocheck",     true,  &inspect_annocheck },
 #endif
     { INSPECT_DSODEPS,       "dsodeps",       false, &inspect_dsodeps },
@@ -171,7 +171,7 @@ uint64_t inspection_id(const char *name)
         return INSPECT_OWNERSHIP;
     } else if (!strcmp(name, NAME_SHELLSYNTAX)) {
         return INSPECT_SHELLSYNTAX;
-#ifdef _WITH_LIBANNOCHECK
+#if defined(_WITH_ANNOCHECK) || defined(_WITH_LIBANNOCHECK)
     } else if (!strcmp(name, NAME_ANNOCHECK)) {
         return INSPECT_ANNOCHECK;
 #endif
@@ -278,7 +278,7 @@ const char *inspection_desc(const uint64_t inspection)
             return DESC_OWNERSHIP;
         case INSPECT_SHELLSYNTAX:
             return DESC_SHELLSYNTAX;
-#ifdef _WITH_LIBANNOCHECK
+#if defined(_WITH_ANNOCHECK) || defined(_WITH_LIBANNOCHECK_)
         case INSPECT_ANNOCHECK:
             return DESC_ANNOCHECK;
 #endif
@@ -386,7 +386,7 @@ const char *inspection_header_to_desc(const char *header)
         i = INSPECT_OWNERSHIP;
     } else if (!strcmp(header, NAME_SHELLSYNTAX)) {
         i = INSPECT_SHELLSYNTAX;
-#ifdef _WITH_LIBANNOCHECK
+#if defined(_WITH_ANNOCHECK) || defined(_WITH_LIBANNOCHECK)
     } else if (!strcmp(header, NAME_ANNOCHECK)) {
         i = INSPECT_ANNOCHECK;
 #endif

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -140,9 +140,12 @@ if get_option('with_libcap')
     deps += [ libcap ]
 endif
 
-if get_option('with_libannocheck')
+if get_option('with_annocheck') or get_option('with_libannocheck')
     librpminspect_sources += [ 'inspect_annocheck.c' ]
-    deps += [ libannocheck ]
+
+    if get_option('with_libannocheck')
+        deps += [ libannocheck ]
+    endif
 endif
 
 if build_machine.system() == 'freebsd'

--- a/meson.build
+++ b/meson.build
@@ -230,13 +230,20 @@ else
     libcap = disabler()
 endif
 
-# libannocheck
+# annocheck(1) or libannocheck
+if get_option('with_annocheck') and get_option('with_libannocheck')
+    error('*** you may only use with_annocheck or with_libannocheck, not both')
+endif
+
+if get_option('with_annocheck')
+    add_project_arguments('-D_WITH_ANNOCHECK', language : 'c')
+endif
+
 if get_option('with_libannocheck')
     libannocheck = dependency('libannocheck', required : true)
     add_project_arguments('-D_WITH_LIBANNOCHECK', language : 'c')
 else
     message('disable libannocheck support')
-    libannocheck = disabler()
 endif
 
 # dlopen

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,6 +23,11 @@ option('with_libcap',
        value : true,
        description : 'Enable Linux capability(7) support using libcap.  Disabling libcap support will also disable capability(7)-related inspections.')
 
+option('with_annocheck',
+       type : 'boolean',
+       value : false,
+       description : 'Enable annocheck(1) support for binary file analysis.  Disabling annocheck(1) support will also disable the annocheck inspection.')
+
 option('with_libannocheck',
        type : 'boolean',
        value : true,

--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -48,8 +48,13 @@ BuildRequires:  clamav-devel
 BuildRequires:  libmandoc-devel >= 1.14.5
 BuildRequires:  gnupg2
 BuildRequires:  libicu-devel
-BuildRequires:  annobin-libannocheck
 
+# libannocheck is only available in EPEL-7 and Fedora at the moment
+%if 0%{?epel} == 7 || 0%{?fedora}
+BuildRequires:  annobin-libannocheck
+%else
+BuildRequires:  annobin-annocheck
+%endif
 
 %description
 Build deviation and compliance tool.  This program runs a number of tests
@@ -145,7 +150,12 @@ control files.
 
 %build
 %meson -Dtests=false
+
+%if 0%{?rhel} >= 8 || 0%{?epel} >= 8 || 0%{?fedora}
 %meson_build
+%else
+%meson_build -D with_libannocheck=false -D with_annocheck=true
+%endif
 
 
 %install


### PR DESCRIPTION
Right now there are some target platforms that lack annobin that has libannocheck.  So for now add back in the old method of fork/exec annocheck(1) and let that be a build-time option.  Ideally libannocheck will be everywhere soon and I can remove this code [again].

Signed-off-by: David Cantrell <dcantrell@redhat.com>