### PR TITLE
[fix] Modify match_path() to work with paths without leading '/'

### DIFF
--- a/lib/paths.c
+++ b/lib/paths.c
@@ -263,14 +263,11 @@ bool match_path(const char *pattern, const char *root, const char *path)
         gp = stpcpy(gp, root);
     }
 
-    if (!strprefix(pattern, "/")) {
-        gp = stpcpy(gp, dirname(n));
-    }
-
     free(n);
 
     if (!strsuffix(globpath, "/") && !strprefix(pattern, "/")) {
         gp = stpcpy(gp, "/");
+        len++;
     }
 
     gp = stpcpy(gp, pattern);


### PR DESCRIPTION
match_path() should have worked for ignore list entries that lacked a leading slash, but it turned out it didn't.  This patch gets that work for RPM and SRPM files.

Signed-off-by: David Cantrell <dcantrell@redhat.com>