### PR TITLE
[fix] Read XMLRPC_TYPE_INT and XMLRPC_TYPE_I8 correctly

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -477,7 +477,7 @@ char *get_file_delta(const char *a, const char *b);
  * @param path The filesystem path to check.
  * @return Number of bytes available.
  */
-unsigned long get_available_space(const char *path);
+unsigned long int get_available_space(const char *path);
 
 /* curl.c */
 /**
@@ -526,7 +526,7 @@ bool is_remote_rpm(const char *url);
  * @return Allocated string containing human-readable size; caller
  *         must free.
  */
-char *human_size(const unsigned long bytes);
+char *human_size(const unsigned long int bytes);
 
 /* joinpath.c */
 /**

--- a/include/types.h
+++ b/include/types.h
@@ -781,8 +781,8 @@ typedef struct _koji_rpmlist_entry_t {
     char *name;
     char *version;
     char *release;
-    int epoch;
-    long long int size;
+    int32_t epoch;
+    unsigned long int size;
     TAILQ_ENTRY(_koji_rpmlist_entry_t) items;
 } koji_rpmlist_entry_t;
 
@@ -792,26 +792,26 @@ typedef TAILQ_HEAD(koji_rpmlist_s, _koji_rpmlist_entry_t) koji_rpmlist_t;
  * List of build IDs from a Koji build.
  */
 typedef struct _koji_buildlist_entry_t {
-    int build_id;
+    int32_t build_id;
     char *package_name;
     char *owner_name;
-    int task_id;
-    int state;
+    int32_t task_id;
+    int32_t state;
     char *nvr;
     char *start_time;
-    int create_event;
-    int creation_event_id;
+    int32_t create_event;
+    int32_t creation_event_id;
     char *creation_time;
-    int epoch;
-    int tag_id;
+    int32_t epoch;
+    int32_t tag_id;
     char *completion_time;
     char *tag_name;
     char *version;
-    int volume_id;
+    int32_t volume_id;
     char *release;
-    int package_id;
-    int owner_id;
-    int id;
+    int32_t package_id;
+    int32_t owner_id;
+    int32_t id;
     char *volume_name;
     char *name;
 
@@ -835,7 +835,7 @@ typedef TAILQ_HEAD(koji_buildlist_s, _koji_buildlist_entry_t) koji_buildlist_t;
 struct koji_build {
     /* These are all relevant to the name of the build */
     char *package_name;
-    int epoch;
+    int32_t epoch;
     char *name;
     char *version;
     char *release;
@@ -847,20 +847,20 @@ struct koji_build {
     /* Koji-specific information about the build */
     char *creation_time;
     char *completion_time;
-    int package_id;
-    int id;
-    int state;
+    int32_t package_id;
+    int32_t id;
+    int32_t state;
     double completion_ts;
-    int owner_id;
+    int32_t owner_id;
     char *owner_name;
     char *start_time;
-    int creation_event_id;
+    int32_t creation_event_id;
     double start_ts;
     double creation_ts;
-    int task_id;
+    int32_t task_id;
 
     /* Where to find the resulting build artifacts */
-    int volume_id;
+    int32_t volume_id;
     char *volume_name;
 
     /*
@@ -870,14 +870,14 @@ struct koji_build {
     char *original_url;
 
     /* Content Generator information (currently not used in rpminspect) */
-    int cg_id;
+    int32_t cg_id;
     char *cg_name;
 
     /* Module metadata -- only if this build is a module */
     char *modulemd_str;
     char *module_name;
     char *module_stream;
-    int module_build_service_id;
+    int32_t module_build_service_id;
     char *module_version;
     char *module_context;
     char *module_content_koji_tag;
@@ -912,24 +912,24 @@ typedef TAILQ_HEAD(koji_task_list_s, _koji_task_entry_t) koji_task_list_t;
 struct koji_task {
     /* members returned from getTaskInfo */
     double weight;
-    int parent;
+    int32_t parent;
     char *completion_time;
     char *start_time;
     double start_ts;
     bool waiting;
     bool awaited;
     char *label;
-    int priority;
-    int channel_id;
-    int state;
+    int32_t priority;
+    int32_t channel_id;
+    int32_t state;
     char *create_time;
     double create_ts;
-    int owner;
-    int host_id;
+    int32_t owner;
+    int32_t host_id;
     char *method;
     double completion_ts;
     char *arch;
-    int id;
+    int32_t id;
 
     /*
      * Total size of all RPMs (restricted to specified architectures
@@ -953,7 +953,7 @@ typedef struct _koji_task_entry_t {
     struct koji_task *task;
 
     /* results from getTaskResult */
-    int brootid;
+    int32_t brootid;
     string_list_t *srpms;
     string_list_t *rpms;
     string_list_t *logs;

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -218,7 +218,7 @@ static int copytree(const char *fpath, const struct stat *sb, int tflag, struct 
  */
 static int download_build(struct rpminspect *ri, const struct koji_build *build)
 {
-    unsigned long avail = 0;
+    unsigned long int avail = 0;
     char *availh = NULL;
     char *needh = NULL;
     size_t total_width = 0;
@@ -504,7 +504,7 @@ static int download_build(struct rpminspect *ri, const struct koji_build *build)
  */
 static int download_task(struct rpminspect *ri, struct koji_task *task)
 {
-    unsigned long avail = 0;
+    unsigned long int avail = 0;
     char *availh = NULL;
     char *needh = NULL;
     size_t len;
@@ -665,8 +665,8 @@ static int download_task(struct rpminspect *ri, struct koji_task *task)
  */
 static int download_rpm(struct rpminspect *ri, const char *rpm)
 {
-    unsigned long avail = 0;
-    unsigned long rpmsize = 0;
+    unsigned long int avail = 0;
+    unsigned long int rpmsize = 0;
     char *availh = NULL;
     char *needh = NULL;
     char *pkg = NULL;

--- a/lib/fs.c
+++ b/lib/fs.c
@@ -9,9 +9,9 @@
 
 #include "rpminspect.h"
 
-unsigned long get_available_space(const char *path)
+unsigned long int get_available_space(const char *path)
 {
-    unsigned long r = 0;
+    unsigned long int r = 0;
     struct statvfs svb;
 
     assert(path != NULL);

--- a/lib/humansize.c
+++ b/lib/humansize.c
@@ -8,7 +8,7 @@
 
 #include "rpminspect.h"
 
-char *human_size(const unsigned long bytes)
+char *human_size(const unsigned long int bytes)
 {
     char *r = NULL;
     double s = 0;

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -570,6 +570,8 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
     int size = 0;
     int subsize = 0;
     int modsize = 0;
+    int32_t isz = 0;
+    int64_t idsz = 0;
     xmlrpc_env env;
     xmlrpc_value *key = NULL;
     xmlrpc_value *value = NULL;
@@ -1009,9 +1011,13 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
                     xmlrpc_decompose_value(&env, value, "i", &rpm->epoch);
                 } else if (!strcmp(keyname, "size")) {
                     if (xmlrpc_value_type(value) == XMLRPC_TYPE_INT) {
-                        xmlrpc_decompose_value(&env, value, "i", &rpm->size);
+                        isz = 0;
+                        xmlrpc_decompose_value(&env, value, "i", &isz);
+                        rpm->size = isz;
                     } else if (xmlrpc_value_type(value) == XMLRPC_TYPE_I8) {
-                        xmlrpc_decompose_value(&env, value, "I", &rpm->size);
+                        idsz = 0;
+                        xmlrpc_decompose_value(&env, value, "I", &idsz);
+                        rpm->size = idsz;
                     } else {
                         /*
                          * XXX: have no idea what we got back here

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -148,7 +148,7 @@ void add_peer(rpmpeer_t **peers, int whichbuild, bool fetch_only, const char *pk
 
 int extract_peers(struct rpminspect *ri, bool fetchonly)
 {
-    unsigned long avail = 0;
+    unsigned long int avail = 0;
     char *availh = NULL;
     char *needh = NULL;
     rpmpeer_entry_t *peer = NULL;


### PR DESCRIPTION
When decomposing an XMLRPC_TYPE_INT librpminspect should use an int32_t and when decomposing an XMLRPC_TYPE_I8 librpminspect should use an int64_t.  This ensures the precision indicated in xmlrpc-c is correct given the differences in long int and long long int by platform.

For consistency, the existing XMLRPC_TYPE_INT values read by librpminspect now read in to an int32_t rather than an int.

Fixes: #966

Signed-off-by: David Cantrell <dcantrell@redhat.com>