### PR TITLE
Take rpminspect back to using /usr/bin/annocheck

### DIFF
--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -344,7 +344,8 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             ah = libannocheck_setup(ri, file->peer_file, hentry->value, ah);
 
             if (ah == NULL) {
-                continue;
+                /* failed to initialize libannocheck so call that a failure */
+                return false;
             }
 
             /* run the tests on the before build file (if any) */
@@ -501,7 +502,9 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* close out */
-    annoerr = libannocheck_finish(ah);
+    if (ah != NULL) {
+        annoerr = libannocheck_finish(ah);
+    }
 
     if (annoerr != libannocheck_error_none) {
         warnx(_("libannocheck_finish error: %s"), libannocheck_get_error_message(ah, annoerr));

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -209,7 +209,6 @@ static struct libannocheck_internals *libannocheck_setup(struct rpminspect *ri, 
 
         if (annoerr != libannocheck_error_none) {
              warnx(_("libannocheck_init error: %s"), libannocheck_get_error_message(anno, annoerr));
-             libannocheck_finish(anno);
              return NULL;
         }
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,10 +25,10 @@ option('with_libcap',
 
 option('with_annocheck',
        type : 'boolean',
-       value : false,
+       value : true,
        description : 'Enable annocheck(1) support for binary file analysis.  Disabling annocheck(1) support will also disable the annocheck inspection.')
 
 option('with_libannocheck',
        type : 'boolean',
-       value : true,
+       value : false,
        description : 'Enable libannocheck support for binary file analysis.  Disabling libannocheck support will also disable the annocheck inspection.')

--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -49,10 +49,6 @@ BuildRequires:  libmandoc-devel >= 1.14.5
 BuildRequires:  gnupg2
 BuildRequires:  libicu-devel
 
-# libannocheck is only available in Fedora >= 36 at the moment
-%if 0%{?fedora} >= 36
-BuildRequires:  annobin-libannocheck
-%endif
 
 %description
 Build deviation and compliance tool.  This program runs a number of tests
@@ -67,7 +63,9 @@ Group:          Development/Tools
 Requires:       desktop-file-utils
 Requires:       gettext
 
-%if 0%{?rhel} >= 7 || 0%{?epel} >= 7
+%if 0%{?rhel} >= 8 || 0%{?epel} >= 8 || 0%{?fedora}
+Recommends:     /usr/bin/annocheck
+%else
 Requires:       /usr/bin/annocheck
 %endif
 
@@ -151,13 +149,7 @@ control files.
 
 
 %build
-# libannocheck is only available in Fedora >= 36 at the moment
-%if 0%{?fedora} >= 36
-%meson -D tests=false
-%else
-%meson -D tests=false -D with_libannocheck=false -D with_annocheck=true
-%endif
-
+%meson -Dtests=false
 %meson_build
 
 


### PR DESCRIPTION
Due to some limitations in libannocheck, we need to switch back to using the executable.