### PR TITLE
[ci] Add 'env CRYPTOGRAPHY_DONT_BUILD_RUST=1' to PIP_CMD for fedora

### DIFF
--- a/osdeps/fedora-rawhide.i686/defs.mk
+++ b/osdeps/fedora-rawhide.i686/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = pip-3 install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install

--- a/osdeps/fedora-rawhide/defs.mk
+++ b/osdeps/fedora-rawhide/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = pip-3 install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install

--- a/osdeps/fedora.i686/defs.mk
+++ b/osdeps/fedora.i686/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = pip-3 install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install

--- a/osdeps/fedora/defs.mk
+++ b/osdeps/fedora/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = pip-3 install
+PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install


### PR DESCRIPTION
We don't need the Rust stuff in the Python modules for what we are using them for, so just disable it in our CI jobs.

Signed-off-by: David Cantrell <dcantrell@redhat.com>