### PR TITLE
[fix] Use libannocheck_get_version() in libannocheck_init() call

### DIFF
--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -205,7 +205,7 @@ static struct libannocheck_internals *libannocheck_setup(struct rpminspect *ri, 
 
     if (anno == NULL) {
         /* initialize libannocheck for this test on this file */
-        annoerr = libannocheck_init(LIBANNOCHECK_VERSION, file->fullpath, get_after_debuginfo_path(ri, file, arch), &anno);
+        annoerr = libannocheck_init(libannocheck_get_version(), file->fullpath, get_after_debuginfo_path(ri, file, arch), &anno);
 
         if (annoerr != libannocheck_error_none) {
              warnx(_("libannocheck_init error: %s"), libannocheck_get_error_message(anno, annoerr));


### PR DESCRIPTION
Rather than using the LIBANNOCHECK_VERSION macro, use the function so that at runtime we do not fail if the user has upgraded libannocheck to a newer version than we compiled against.

Signed-off-by: David Cantrell <dcantrell@redhat.com>