### PR TITLE
Fix handling of license validation when multiple licensedb files are given

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -74,13 +74,14 @@ vendor:
     # Main directory for the vendor-specific data.
     vendor_data_dir: /usr/share/rpminspect
 
-    # Either the name of a license database file under the 'licenses/'
-    # subdirectory in the vendor_data_dir or a full path to a license
-    # database file to use.  This file is used by the 'license'
-    # inspection.
+    # All of list of license database files.  Files can be specified
+    # with either the name of a license database file under the
+    # 'licenses/' subdirectory in the vendor_data_dir or a full path
+    # to a license database file to use.  This file is used by the
+    # 'license' inspection.
     licensedb:
+        #- /usr/share/vendor-license-data/licenses/vendor-licenses.json
         - generic.json
-        #- licensedb: /usr/share/vendor-license-data/licenses/vendor-licenses.json
 
     # Which product release string to favor.  By default, rpminspect
     # favors the newest product release string.  You can change this

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -256,7 +256,9 @@ static bool is_valid_expression(const struct json_object *db, const char *s, con
  */
 static bool is_valid_license(struct rpminspect *ri, struct result_params *params, const char *nevra, const char *tag)
 {
-    bool result = true;
+    bool result = false;
+    int good = 0;
+    int seen = 0;
     int balance = 0;
     size_t i = 0;
     char *tagtokens = NULL;
@@ -317,13 +319,23 @@ static bool is_valid_license(struct rpminspect *ri, struct result_params *params
                 continue;
             }
 
-            if (!is_valid_expression(db, token, nevra, params, &rq)) {
-                result = false;
+            if (is_valid_expression(db, token, nevra, params, &rq)) {
+                good++;
             }
+
+            seen++;
         }
 
         free(tagcopy);
         json_object_put(db);
+
+        if (good == seen) {
+            result = true;
+            break;
+        }
+
+        good = 0;
+        seen = 0;
     }
 
     /*


### PR DESCRIPTION
What was previously happening is that rpminspect would check every license database rather than stop once it had matched every token.