### PR TITLE
[lib] When an input cannot be found anywhere, tell the user

### DIFF
--- a/lib/builds.c
+++ b/lib/builds.c
@@ -926,6 +926,7 @@ int gather_builds(struct rpminspect *ri, bool fo)
                 return r;
             }
         } else {
+            warnx(_("unable to locate after build: %s"), ri->after);
             free_koji_task(task);
             free_koji_build(build);
             return -1;
@@ -997,6 +998,7 @@ int gather_builds(struct rpminspect *ri, bool fo)
             return r;
         }
     } else {
+        warnx(_("unable to locate after build: %s"), ri->after);
         free_koji_task(task);
         free_koji_build(build);
         return -1;


### PR DESCRIPTION
Inputs can be local Koji builds, local RPMs, local SRPMs, remote Koji buids, remote Koji tasks, remote RPMs, remote SRPMs...there's a lot. rpminspect will figure out where the inputs are and copy or download them to the working directory and then begin work.  In cases where an input cannot be located, gather_builds() returns -1 but it doesn't say what happened.  The most common case here is a user specifying a Koji build but Koji returns nothing.  Add a small message indicating the input could not be located.

Signed-off-by: David Cantrell <dcantrell@redhat.com>