### PR TITLE
[fix] Correct how the debuginfo checks for missing sections

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -1062,6 +1062,6 @@ debuginfo:
 
     # The ELF section name(s) required in debuginfo packages.  The
     # default is shown here.  Some older releases may have to change
-    # this to .gdb_index, for instance.  This is a space-delimited
-    # string of section names.
-    debuginfo_sections: .gnu_debugdata
+    # this to remove .gdb_index, for instance.  This is a
+    # space-delimited string of section names.
+    debuginfo_sections: .symtab .debug_info .gdb_index

--- a/include/constants.h
+++ b/include/constants.h
@@ -847,6 +847,13 @@
 #define ELF_GNU_DEBUGDATA ".gnu_debugdata"
 
 /**
+ * @def ELF_GNU_DEBUGLINK
+ *
+ * The '.gnu_debuglink' ELF section.
+ */
+#define ELF_GNU_DEBUGLINK ".gnu_debuglink"
+
+/**
  * @def ELF_DEBUG_INFO
  *
  * The '.debug_info' ELF section.

--- a/lib/init.c
+++ b/lib/init.c
@@ -2234,7 +2234,7 @@ struct rpminspect *calloc_rpminspect(struct rpminspect *ri)
     ri->kmidiff_debuginfo_path = strdup(DEBUG_PATH);
     ri->annocheck_failure_severity = RESULT_VERIFY;
     ri->size_threshold = -1;
-    ri->debuginfo_sections = strdup(ELF_GNU_DEBUGDATA);
+    ri->debuginfo_sections = strdup(ELF_SYMTAB" "ELF_DEBUG_INFO);
 
     /* Initialize commands */
     ri->commands.msgunfmt = strdup(MSGUNFMT_CMD);


### PR DESCRIPTION
The logic in this inspection was half-right or half-wrong, depending on your perspective.  After going back through this and how the predecessor to rpminspect handled it, I realized I was doing the wrong thing on files in regular packages.

I refactored the inspection and updated the test cases and now things should be working as expected.

NOTE: This change does require an update to the vendor data package. Specifically the debuginfo_sections setting in the config file.

Fixes: #991

Signed-off-by: David Cantrell <dcantrell@redhat.com>