### PR TITLE
[bld] Add BSD-2-Clause to the License list in the spec file

### DIFF
--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -19,7 +19,7 @@ Group:          Development/Tools
 # * include/uthash.h is BSD-1-Clause
 # * include/compat/queue.h is BSD-3-Clause
 # * libxdiff/ is LGPL-2.1-or-later
-License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND MIT AND BSD-1-Clause AND BSD-3-Clause AND CC-BY-4.0
+License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND MIT AND AND BSD-1-Clause AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-4.0
 URL:            https://github.com/rpminspect/rpminspect
 Source0:        https://github.com/rpminspect/rpminspect/releases/download/v%{version}/%{name}-%{version}.tar.xz
 Source1:        https://github.com/rpminspect/rpminspect/releases/download/v%{version}/%{name}-%{version}.tar.xz.asc


### PR DESCRIPTION
This license identifier was missing from the long list of licenses that apply to rpminspect's code base.

Signed-off-by: David Cantrell <dcantrell@redhat.com>