### PR TITLE
[fix] Correct results reporting for capabilities and permissions

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -306,9 +306,9 @@ char **build_argv(const char *cmd);
 void free_argv(char **argv);
 
 /* fileinfo.c */
-bool match_fileinfo_mode(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *);
-bool match_fileinfo_owner(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *);
-bool match_fileinfo_group(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *);
+bool match_fileinfo_mode(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, bool *, bool *);
+bool match_fileinfo_owner(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *, bool *, bool *);
+bool match_fileinfo_group(struct rpminspect *, const rpmfile_entry_t *, const char *, const char *, const char *, const char *, bool *, bool *);
 #ifdef _WITH_LIBCAP
 caps_filelist_entry_t *get_caps_entry(struct rpminspect *, const char *, const char *);
 #endif

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -23,9 +23,12 @@
  *               file is found.
  * @param remedy The remedy string to use for results reporting if the
  *               file is found.
+ * @param result The rpminspect test driver result.
+ * @param reported The rpminspect test driver reported indicator.
  * @return True if the file is on the fileinfo list, false otherwise.
  */
-bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, const char *header, const char *remedy)
+bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, const char *header,
+                         const char *remedy, bool *result, bool *reported)
 {
     fileinfo_entry_t *fientry = NULL;
     mode_t interesting = S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO;
@@ -58,6 +61,7 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
                     add_result(ri, &params);
                     free(params.msg);
                     free(params.remedy);
+                    *reported = true;
                     return true;
                 } else {
                     params.severity = get_secrule_result_severity(ri, file, SECRULE_MODES);
@@ -68,6 +72,8 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
                         add_result(ri, &params);
                         free(params.msg);
                         free(params.remedy);
+                        *result = false;
+                        *reported = true;
                         return true;
                     }
                 }
@@ -87,6 +93,8 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
             add_result(ri, &params);
             free(params.msg);
             free(params.remedy);
+            *result = false;
+            *reported = true;
         }
     }
 
@@ -105,9 +113,11 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
  * @param remedy The remedy string to use for results reporting if the
  *               file is found.  Must contain %s for fname.
  * @param fname The filename of the data package file to update.
+ * @param result The rpminspect test driver result for the caller.
  * @return True if the file is on the fileinfo list, false otherwise.
  */
-bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, const char *owner, const char *header, const char *remedy, const char *fname)
+bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, const char *owner, const char *header,
+                          const char *remedy, const char *fname, bool *result, bool *reported)
 {
     fileinfo_entry_t *fientry = NULL;
     const char *pkg = NULL;
@@ -142,6 +152,7 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
                     add_result(ri, &params);
                     free(params.msg);
                     free(params.remedy);
+                    *reported = true;
                     return true;
                 } else {
                     params.severity = get_secrule_result_severity(ri, file, SECRULE_MODES);
@@ -152,6 +163,8 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
                         add_result(ri, &params);
                         free(params.msg);
                         free(params.remedy);
+                        *result = false;
+                        *reported = true;
                         return true;
                     }
                 }
@@ -177,9 +190,11 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
  * @param remedy The remedy string to use for results reporting if the
  *               file is found.  Must contain %s for fname.
  * @param fname The filename of the data package file to update.
+ * @param result The rpminspect test driver result for the caller.
  * @return True if the file is on the fileinfo list, false otherwise.
  */
-bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, const char *group, const char *header, const char *remedy, const char *fname)
+bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, const char *group, const char *header,
+                          const char *remedy, const char *fname, bool *result, bool *reported)
 {
     fileinfo_entry_t *fientry = NULL;
     const char *pkg = NULL;
@@ -213,6 +228,7 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
                     add_result(ri, &params);
                     free(params.msg);
                     free(params.remedy);
+                    *reported = true;
                     return true;
                 } else {
                     params.severity = get_secrule_result_severity(ri, file, SECRULE_MODES);
@@ -223,6 +239,8 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
                         add_result(ri, &params);
                         free(params.msg);
                         free(params.remedy);
+                        *result = false;
+                        *reported = false;
                         return true;
                     }
                 }

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -228,7 +228,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Check for any new setuid or setgid files */
     if (!S_ISDIR(file->st.st_mode) && (file->st.st_mode & (S_ISUID|S_ISGID))) {
-        match_fileinfo_mode(ri, file, NAME_ADDEDFILES, remedy_addedfiles);
+        match_fileinfo_mode(ri, file, NAME_ADDEDFILES, remedy_addedfiles, &result, &reported);
         goto done;
     }
 

--- a/test/test_capabilities.py
+++ b/test/test_capabilities.py
@@ -118,7 +118,8 @@ class ApprovedCapabilitiesKoji(TestKoji):
         )
 
         self.inspection = "capabilities"
-        self.result = "OK"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class ApprovedCapabilitiesCompareRPMs(TestCompareRPMs):
@@ -133,7 +134,8 @@ class ApprovedCapabilitiesCompareRPMs(TestCompareRPMs):
         )
 
         self.inspection = "capabilities"
-        self.result = "OK"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class ApprovedCapabilitiesCompareKoji(TestCompareKoji):
@@ -148,7 +150,8 @@ class ApprovedCapabilitiesCompareKoji(TestCompareKoji):
         )
 
         self.inspection = "capabilities"
-        self.result = "OK"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class SecuritySKIPUnapprovedCapabilitiesRPMs(TestRPMs):


### PR DESCRIPTION
Even when problems were reported by these inspections, the main driver would report "OK".  Fix up these inspections to report findings correctly.

Fixes: #1003

Signed-off-by: David Cantrell <dcantrell@redhat.com>