### PR TITLE
[fix] Support systems with libkmod.h in /usr/include/kmod

### DIFF
--- a/include/inspect.h
+++ b/include/inspect.h
@@ -26,8 +26,12 @@
 #include <libelf.h>
 
 #ifdef _WITH_LIBKMOD
+#ifdef _LIBKMOD_HEADER_SUBDIR
+#include <kmod/libkmod.h>
+#else
 #include <libkmod.h>
-#endif
+#endif /* _LIBKMOD_HEADER_HEADER */
+#endif /* _WITH_LIBKMOD */
 
 #include "types.h"
 

--- a/include/types.h
+++ b/include/types.h
@@ -16,8 +16,12 @@
 #include <unicode/utypes.h>
 
 #ifdef _WITH_LIBKMOD
+#ifdef _LIBKMOD_HEADER_SUBDIR
+#include <kmod/libkmod.h>
+#else
 #include <libkmod.h>
-#endif
+#endif /* _LIBKMOD_HEADER_HEADER */
+#endif /* _WITH_LIBKMOD */
 
 #ifdef _WITH_LIBCAP
 #include <sys/capability.h>

--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -8,7 +8,13 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _LIBKMOD_HEADER_SUBDIR
+#include <kmod/libkmod.h>
+#else
 #include <libkmod.h>
+#endif /* _LIBKMOD_HEADER_SUBDIR */
+
 #include "queue.h"
 #include "uthash.h"
 #include "inspect.h"

--- a/meson.build
+++ b/meson.build
@@ -71,6 +71,14 @@ icu_io = dependency('icu-io', required : true)
 if get_option('with_libkmod')
     libkmod = dependency('libkmod', required : true)
     add_project_arguments('-D_WITH_LIBKMOD', language : 'c')
+
+    if not cc.has_header('libkmod.h')
+        if cc.has_header('kmod/libkmod.h')
+            add_project_arguments('-D_LIBKMOD_HEADER_SUBDIR', language : 'c')
+        else
+            error('*** unable to find libkmod.h')
+        endif
+    endif
 else
     message('disabling Linux kernel module support (libkmod)')
     libkmod = disabler()


### PR DESCRIPTION
OpenSUSE moved libkmod.h in to /usr/include/kmod.

Signed-off-by: David Cantrell <dcantrell@redhat.com>