### PR TITLE
[lib] Disable the modularity inspection if librpm lacks support

### DIFF
--- a/include/inspect.h
+++ b/include/inspect.h
@@ -786,11 +786,15 @@ bool inspect_debuginfo(struct rpminspect *ri);
  */
 #define INSPECT_SPECNAME                    (((uint64_t) 1) << 9)
 
+#ifdef _HAVE_MODULARITYLABEL
+
 /**
  * @def INSPECT_MODULARITY
  * 'modularity' inspection ID.
  */
 #define INSPECT_MODULARITY                  (((uint64_t) 1) << 10)
+
+#endif
 
 /**
  * @def INSPECT_JAVABYTECODE
@@ -1074,11 +1078,15 @@ bool inspect_debuginfo(struct rpminspect *ri);
  */
 #define NAME_SPECNAME                       "specname"
 
+#ifdef _HAVE_MODULARITYLABEL
+
 /**
  * @def NAME_MODULARITY
  * The string "modularity"
  */
 #define NAME_MODULARITY                     "modularity"
+
+#endif
 
 /**
  * @def NAME_JAVABYTECODE
@@ -1364,11 +1372,15 @@ bool inspect_debuginfo(struct rpminspect *ri);
  */
 #define DESC_SPECNAME _("Ensure the spec file name conforms to the NAME.spec naming format.")
 
+#ifdef _HAVE_MODULARITYLABEL
+
 /**
  * @def DESC_MODULARITY
  * The description for the 'modularity' inspection.
  */
 #define DESC_MODULARITY _("Ensure compliance with modularity build and packaging policies (only valid for module builds, no-op otherwise).")
+
+#endif
 
 /**
  * @def DESC_JAVABYTECODE

--- a/include/results.h
+++ b/include/results.h
@@ -237,6 +237,8 @@
 
 /** @} */
 
+#ifdef _HAVE_MODULARITYLABEL
+
 /**
  * @defgroup modularity inspection remedy strings
  *
@@ -258,6 +260,8 @@
 #define REMEDY_MODULARITY_STATIC_CONTEXT _("This build either contains a valid or invalid /data/static_context setting.  Refer to the module rules for the product you are building to determine what the setting should be.  The rpminspect configuration settings also set the rules determining if the /data/static_context setting is required, forbidden, or recommend.")
 
 /** @} */
+
+#endif
 
 /**
  * @defgroup javabytecode inspection remedy strings

--- a/include/types.h
+++ b/include/types.h
@@ -321,6 +321,8 @@ typedef struct _caps_entry_t {
 
 typedef TAILQ_HEAD(caps_entry_s, _caps_entry_t) caps_t;
 
+#ifdef _HAVE_MODULARITYLABEL
+
 /* Modularity static context types */
 typedef enum _static_context_t {
     STATIC_CONTEXT_NULL = 0,
@@ -328,6 +330,8 @@ typedef enum _static_context_t {
     STATIC_CONTEXT_FORBIDDEN = 2,
     STATIC_CONTEXT_RECOMMEND = 3
 } static_context_t;
+
+#endif
 
 /* Spec filename matching types */
 typedef enum _specname_match_t {
@@ -497,8 +501,10 @@ struct rpminspect {
                                 */
     char *vendor;              /* Required vendor string */
 
+#ifdef _HAVE_MODULARITYLABEL
     /* Modularity values */
     static_context_t modularity_static_context;
+#endif
 
     /* Required subdomain for buildhosts -- multiple subdomains allowed */
     string_list_t *buildhost_subdomain;

--- a/lib/init.c
+++ b/lib/init.c
@@ -140,7 +140,9 @@ enum {
     BLOCK_LICENSEDB = 73,
     BLOCK_DEBUGINFO = 74,
     BLOCK_PATCH_AUTOMACROS = 75,
+#ifdef _HAVE_MODULARITYLABEL
     BLOCK_MODULARITY = 76,
+#endif
     BLOCK_ANNOCHECK_PROFILE = 77
 };
 
@@ -760,9 +762,11 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                     } else if (!strcmp(key, NAME_METADATA)) {
                         block = BLOCK_NULL;
                         group = BLOCK_METADATA;
+#ifdef _HAVE_MODULARITYLABEL
                     } else if (!strcmp(key, NAME_MODULARITY)) {
                         block = BLOCK_MODULARITY;
                         group = BLOCK_NULL;
+#endif
                     } else if (!strcmp(key, NAME_ELF)) {
                         block = BLOCK_NULL;
                         group = BLOCK_ELF;
@@ -1191,6 +1195,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                                 warnx(_("*** unknown specname primary setting '%s', defaulting to 'name'"), t);
                             }
                         }
+#ifdef _HAVE_MODULARITYLABEL
                     } else if (block == BLOCK_MODULARITY) {
                         if (!strcmp(key, SECTION_STATIC_CONTEXT)) {
                             if (!strcasecmp(t, TOKEN_REQUIRED)) {
@@ -1204,6 +1209,7 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
                                 warnx(_("*** unknown modularity static context settings '%s'"), t);
                             }
                         }
+#endif
                     } else if (group == BLOCK_ELF) {
                         if (!strcmp(key, SECTION_INCLUDE_PATH)) {
                             if (debug_mode) {

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -38,7 +38,9 @@ struct inspect inspections[] = {
     { INSPECT_DESKTOP,       "desktop",       true,  &inspect_desktop },
     { INSPECT_DISTTAG,       "disttag",       true,  &inspect_disttag },
     { INSPECT_SPECNAME,      "specname",      true,  &inspect_specname },
+#ifdef _HAVE_MODULARITYLABEL
     { INSPECT_MODULARITY,    "modularity",    true,  &inspect_modularity },
+#endif
     { INSPECT_JAVABYTECODE,  "javabytecode",  true,  &inspect_javabytecode },
     { INSPECT_CHANGEDFILES,  "changedfiles",  false, &inspect_changedfiles },
     { INSPECT_MOVEDFILES,    "movedfiles",    false, &inspect_movedfiles },
@@ -153,8 +155,10 @@ uint64_t inspection_id(const char *name)
         return INSPECT_DISTTAG;
     } else if (!strcmp(name, NAME_SPECNAME)) {
         return INSPECT_SPECNAME;
+#ifdef _HAVE_MODULARITYLABEL
     } else if (!strcmp(name, NAME_MODULARITY)) {
         return INSPECT_MODULARITY;
+#endif
     } else if (!strcmp(name, NAME_JAVABYTECODE)) {
         return INSPECT_JAVABYTECODE;
     } else if (!strcmp(name, NAME_CHANGEDFILES)) {
@@ -260,8 +264,10 @@ const char *inspection_desc(const uint64_t inspection)
             return DESC_DISTTAG;
         case INSPECT_SPECNAME:
             return DESC_SPECNAME;
+#ifdef _HAVE_MODULARITYLABEL
         case INSPECT_MODULARITY:
             return DESC_MODULARITY;
+#endif
         case INSPECT_JAVABYTECODE:
             return DESC_JAVABYTECODE;
         case INSPECT_CHANGEDFILES:
@@ -368,8 +374,10 @@ const char *inspection_header_to_desc(const char *header)
         i = INSPECT_DISTTAG;
     } else if (!strcmp(header, NAME_SPECNAME)) {
         i = INSPECT_SPECNAME;
+#ifdef _HAVE_MODULARITYLABEL
     } else if (!strcmp(header, NAME_MODULARITY)) {
         i = INSPECT_MODULARITY;
+#endif
     } else if (!strcmp(header, NAME_JAVABYTECODE)) {
         i = INSPECT_JAVABYTECODE;
     } else if (!strcmp(header, NAME_CHANGEDFILES)) {

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -58,7 +58,6 @@ librpminspect_sources = [
     'inspect_lto.c',
     'inspect_manpage.c',
     'inspect_metadata.c',
-    'inspect_modularity.c',
     'inspect_movedfiles.c',
     'inspect_ownership.c',
     'inspect_patches.c',
@@ -129,6 +128,10 @@ deps = [
     icu_io,
     m,
 ]
+
+if have_modularitylabel
+    librpminspect_sources += [ 'inspect_modularity.c' ]
+endif
 
 if get_option('with_libkmod')
     librpminspect_sources += [ 'inspect_kmod.c', 'kmods.c' ]

--- a/meson.build
+++ b/meson.build
@@ -103,6 +103,20 @@ else
     error('*** unable to find librpmbuild')
 endif
 
+# check for RPMTAG_MODULARITYLABEL usability
+rpmtag_src = '''
+    #include <rpm/rpmtag.h>
+    int main(int argc, char **argv)
+    {
+        return RPMTAG_MODULARITYLABEL;
+    }
+    '''
+have_modularitylabel = cc.compiles(rpmtag_src, args: [ '-Werror' ], name: 'RPMTAG_MODULARITYLABEL availability test')
+
+if have_modularitylabel
+    add_project_arguments('-D_HAVE_MODULARITYLABEL', language : 'c')
+endif
+
 # libarchive (need to check for specific functions)
 libarchive = dependency('libarchive', required : true)
 

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -891,7 +891,7 @@ class TestModule(TestKoji):
 
         # add the modularitylabel to the built RPMs
         if modularitylabel:
-            self.rpm.header += "\n%define modularitylabel TEST_LABEL\n"
+            self.rpm.header += "\nModularityLabel: TEST_LABEL\n"
 
         # create the modulemd.txt file
         filesdir = os.path.join(self.kojidir, "files")
@@ -918,8 +918,8 @@ class TestCompareModules(TestCompareKoji):
 
         # add the modularitylabel to the built RPMs
         if modularitylabel:
-            self.before_rpm.header += "\n%define modularitylabel TEST_LABEL\n"
-            self.after_rpm.header += "\n%define modularitylabel TEST_LABEL\n"
+            self.before_rpm.header += "\nModularityLabel: TEST_LABEL\n"
+            self.after_rpm.header += "\nModularityLabel: TEST_LABEL\n"
 
         # create the modulemd.txt file
         beforefilesdir = os.path.join(self.kojidir, "before", "files")

--- a/test/test_modularity.py
+++ b/test/test_modularity.py
@@ -3,11 +3,20 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+import os
+import unittest
 from baseclass import TestModule, TestCompareModules
 
+have_modularitylabel = False
+if os.system("grep -q MODULARITYLABEL /usr/include/rpm/rpmtag.h 2>/dev/null") == 0:
+    have_modularitylabel = True
 
-# Module has %{modularitylabel} defined (OK)
+
+# Module has ModularityLabel defined (OK)
 class ModuleHasModularityLabel(TestModule):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(modularitylabel=True)
 
@@ -20,6 +29,9 @@ class ModuleHasModularityLabel(TestModule):
 
 
 class ModulesHaveModularityLabel(TestCompareModules):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(modularitylabel=True)
 
@@ -31,8 +43,11 @@ class ModulesHaveModularityLabel(TestCompareModules):
         self.result = "OK"
 
 
-# Module does not have %{modularitylabel} defined (BAD)
+# Module does not have ModularityLabel defined (BAD)
 class ModuleLacksModularityLabel(TestModule):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(modularitylabel=False)
 
@@ -46,6 +61,9 @@ class ModuleLacksModularityLabel(TestModule):
 
 
 class ModulesLacksModularityLabel(TestCompareModules):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(modularitylabel=False)
 
@@ -60,6 +78,9 @@ class ModulesLacksModularityLabel(TestCompareModules):
 
 # Module has static_context and rules require it (OK)
 class ModuleHasStaticContext(TestModule):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(static_context=True)
 
@@ -68,6 +89,9 @@ class ModuleHasStaticContext(TestModule):
 
 
 class ModulesHaveStaticContext(TestCompareModules):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(static_context=True)
 
@@ -77,6 +101,9 @@ class ModulesHaveStaticContext(TestCompareModules):
 
 # Module has static_context and rules recommend it (OK)
 class ModuleHasStaticContextAndRecommended(TestModule):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(static_context=True)
 
@@ -89,6 +116,9 @@ class ModuleHasStaticContextAndRecommended(TestModule):
 
 
 class ModulesHaveStaticContextAndRecommended(TestCompareModules):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(static_context=True)
 
@@ -102,6 +132,9 @@ class ModulesHaveStaticContextAndRecommended(TestCompareModules):
 
 # Module has static_context and rules forbid it (VERIFY)
 class ModuleHasStaticContextAndForbidden(TestModule):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(static_context=True)
 
@@ -115,6 +148,9 @@ class ModuleHasStaticContextAndForbidden(TestModule):
 
 
 class ModulesHaveStaticContextAndForbidden(TestCompareModules):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(static_context=True)
 
@@ -129,6 +165,9 @@ class ModulesHaveStaticContextAndForbidden(TestCompareModules):
 
 # Module has static_context and rules do not exist (INFO)
 class ModuleHasStaticContextWithNoRule(TestModule):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(static_context=True)
 
@@ -137,6 +176,9 @@ class ModuleHasStaticContextWithNoRule(TestModule):
 
 
 class ModulesHaveStaticContextWithNoRule(TestCompareModules):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
     def setUp(self):
         super().setUp(static_context=True)
 


### PR DESCRIPTION
This is a build time improvement for librpminspect and the test suite. If the version of librpm on the system lacks RPMTAG_MODULARITYLABEL, then do not include the modularity inspection or run any of those tests.

Signed-off-by: David Cantrell <dcantrell@redhat.com>