### PR TITLE
[ci] Fix up the Alpine Linux post.sh script and reqs.txt list

### DIFF
--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -52,10 +52,21 @@ cd libabigail || exit 1
 TAG="$(git tag -l | grep ^libabigail- | grep -v '\.rc' | sort -n | tail -n 1)"
 git checkout -b "${TAG}" "${TAG}"
 autoreconf -f -i -v
-if ! grep -q "<libgen\.h>" tools/abisym.cc >/dev/null 2>&1 ; then
-    sed -i -r '/^#include\ <elf\.h>/a #include <libgen.h>' tools/abisym.cc
+if [ ! -r /usr/lib/pkgconfig/fts-standalone.pc ]; then
+    ln -sf musl-fts.pc /usr/lib/pkgconfig/fts-standalone.pc
 fi
-env LIBS="-lfts" ./configure --prefix=/usr/local
+./configure --prefix=/usr/local
+make V=1
+make install
+
+# Install debugedit (/usr/bin/find-debuginfo) from git
+cd "${CWD}" || exit 1
+git clone git://sourceware.org/git/debugedit.git
+cd debugedit || exit 1
+TAG="$(git tag -l | grep ^debugedit- | sort -n | tail -n 1)"
+git checkout -b "${TAG}" "${TAG}"
+autoreconf -f -i -v
+./configure --prefix=/usr
 make V=1
 make install
 

--- a/osdeps/alpine/reqs.txt
+++ b/osdeps/alpine/reqs.txt
@@ -11,14 +11,16 @@ cunit-dev
 curl
 curl-dev
 desktop-file-utils
+elfutils
 elfutils-dev
+file
 freshclam
-fts-dev
 g++
 gcc
 gcovr
 gettext
 git
+help2man
 icu-dev
 json-c-dev
 kmod-dev
@@ -29,6 +31,8 @@ make
 meson
 mksh
 musl-dev
+musl-fts-dev
+musl-legacy-error
 musl-libintl
 patchelf
 pkgconf


### PR DESCRIPTION
Some package names changed names on Alpine.  We also need to install debugedit in order to get /usr/bin/find-debuginfo.  And libabigail was not building because of the fts package changes on Alpine, so fixed that up too.

Signed-off-by: David Cantrell <dcantrell@redhat.com>