### PR TITLE
[ci] Fix Slackware Linux CI job

### DIFF
--- a/osdeps/slackware/reqs.txt
+++ b/osdeps/slackware/reqs.txt
@@ -41,7 +41,6 @@ python3
 python-pip
 python-setuptools
 rpm
-rust
 serf
 sqlite
 subversion


### PR DESCRIPTION
The big change is needing to install Rust from upstream and not use the package in Slackware.  The included package is now too old to build clamav, which we need but Slackware does not provide.

Signed-off-by: David Cantrell <dcantrell@redhat.com>