### PR TITLE
[fix] Modularity support detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,7 +130,6 @@ rpmtag_src = '''
     }
     '''
 have_modularitylabel = cc.compiles(rpmtag_src,
-                                   args: [ '-Werror' ],
                                    name: 'RPMTAG_MODULARITYLABEL availability test')
 
 if have_modularitylabel


### PR DESCRIPTION
Don't treat warnings as errors in the modularity detection code.

There are unused variables (argc/argv) and thus the code fails to compile if -Wall flag is also used. For example Fedora and RHEL use the -Wall flag by default.

Signed-off-by: Michal Srb <michal@redhat.com>