### PR TITLE
Update secrule description comment

### DIFF
--- a/data/security/GENERIC
+++ b/data/security/GENERIC
@@ -7,7 +7,7 @@
 # careful of ordering of explicit files and packages and then wildcard
 # rules.
 #
-# Each rule consists of four fields separated by spaces or tabs (any
+# Each rule consists of five fields separated by spaces or tabs (any
 # number):
 #
 #     path           The file or path, can use glob(7) syntax


### PR DESCRIPTION
Commit dde6edc069 extended the security rule format to include path, increasing the number of fields from four to five.  The mention of the number of fields in the comment of the template file was missed and not updated.