### PR TITLE
[bld] Set warning_level=3 for default builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('rpminspect',
         version : '1.11',
         default_options : [
             'c_std=c99',
-            'warning_level=2',
+            'warning_level=3',
             'werror=true',
             'buildtype=debugoptimized'
         ],


### PR DESCRIPTION
Go ahead and use more warning options.

Signed-off-by: David Cantrell <dcantrell@redhat.com>