### PR TITLE
[fix] Add back support for older libcurl versions

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -76,8 +76,7 @@ jobs:
                   meson setup build --werror -Db_buildtype=debug -Db_coverage=true
                   ninja -C build -v
                   meson test -C build -v
-                  ninja -C build coverage
-                  curl -s https://codecov.io/bash | bash
+                  ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :
 
     # Fedora on i386
     i386:
@@ -114,5 +113,4 @@ jobs:
                   env CFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig meson setup build --werror -Db_buildtype=debug -Db_coverage=true
                   ninja -C build -v
                   meson test -C build -v
-                  ninja -C build coverage
-                  curl -s https://codecov.io/bash | bash
+                  ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/lib/curl.c
+++ b/lib/curl.c
@@ -230,6 +230,9 @@ curl_off_t curl_get_size(const char *src)
     curl_off_t r = 0;
     CURL *c = NULL;
     CURLcode cc;
+#ifndef _HAVE_NEWER_CURLINFO
+    double len = 0;
+#endif
 
     assert(src != NULL);
 
@@ -253,7 +256,12 @@ curl_off_t curl_get_size(const char *src)
         return 0;
     }
 
+#ifdef _HAVE_NEWER_CURLINFO
     curl_easy_getinfo(c, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &r);
+#else
+    curl_easy_getinfo(c, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &len);
+    r = (curl_off_t) len;
+#endif
     curl_easy_cleanup(c);
 
     return r;

--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,24 @@ clamav = dependency('libclamav', required : true)
 icu_uc = dependency('icu-uc', required : true)
 icu_io = dependency('icu-io', required : true)
 
+# Check for newer CURLcode in libcurl
+curlinfo_src = '''
+    #include <curl/curl.h>
+    int main(void)
+    {
+        CURLcode info = CURLINFO_CONTENT_LENGTH_DOWNLOAD_T;
+        return 0;
+    }
+    '''
+have_newer_curlinfo = cc.compiles(curlinfo_src,
+                                  args: [ '-Werror' ],
+                                  dependencies: [ libcurl ],
+                                  name: 'CURLINFO_CONTENT_LENGTH_DOWNLOAD_T availability test')
+
+if have_newer_curlinfo
+    add_project_arguments('-D_HAVE_NEWER_CURLINFO', language : 'c')
+endif
+
 # libkmod
 if get_option('with_libkmod')
     libkmod = dependency('libkmod', required : true)


### PR DESCRIPTION
At least on CentOS 7 and similar systems, the version of libcurl lacks CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.  So add back support for that with detection in meson.build since they are part of an enum and not a macro.

Signed-off-by: David Cantrell <dcantrell@redhat.com>