### PR TITLE
Add devel-rpminspect wrapper script to contrib/

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,5 +1,12 @@
 # Contrib
 
+## devel-rpminspect
+
+This is a script you can use to run rpminspect built from the source
+directory and pointing to the git clone of a vendor data package.  It
+may be easier to copy this script to a directory in your $PATH and
+then edit the top part to suit your directory layout.
+
 ## rpminspect-report
 
 [rpminspect-report](https://softwarefactory-project.io/r/plugins/gitiles/software-factory/rpminspect-report)

--- a/contrib/devel-rpminspect
+++ b/contrib/devel-rpminspect
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# Run local build of rpminspect using a local git clone of a vendor
+# data package.
+#
+
+### BEGIN CONFIGURATION ###
+
+# Set this to the directory where your clone of the rpminspect repo
+# lives.
+RPMINSPECT_SRC=${HOME}/scm/rpminspect
+
+# The default working directory for rpminspect is /var/tmp, but you
+# may override that here.
+#WORKDIR=/var/tmp
+
+# Set this to where your vendor data directory's main configuration
+# lives.
+CONF=${HOME}/scm/rpminspect-data-fedora/fedora.yaml
+
+### END CONFIGURATION ###
+
+PATH=/usr/bin
+RPMINSPECT_BIN=${RPMINSPECT_SRC}/build/src/rpminspect
+PROFILES="$(dirname "${CONF}")/profiles/$(basename "${CONF}" .yaml)"
+[ -z "${WORKDIR}" ] && WORKDIR=/var/tmp
+
+if [ ! -f "${CONF}" ]; then
+    echo "Missing ${CONF}, exiting." >&2
+    exit 1
+fi
+
+if [ ! -x "${RPMINSPECT_BIN}" ]; then
+    cd "${RPMINSPECT_SRC}" || exit 1
+    [ -d build ] || meson setup build
+    ninja -C build -v
+fi
+
+TMPCONF="$(mktemp -p ${WORKDIR} -t rpminspect.yaml.XXXXXX)"
+sed -e "s|profiledir:.*$|profiledir: ${PROFILES}|g" < "${CONF}" > "${TMPCONF}"
+sed -i -e "s|vendor_data_dir:.*$|vendor_data_dir: $(dirname "${CONF}")|g" "${TMPCONF}"
+trap 'rm "${TMPCONF}"' EXIT
+
+if [ "$1" = "-VG" ]; then
+    shift
+    valgrind --leak-check=full --track-fds=all --track-origins=yes "${RPMINSPECT_BIN}" -w "${WORKDIR}" -c "${TMPCONF}" "$@"
+elif [ "$1" = "-MG" ]; then
+    shift
+    valgrind --tool=massif "${RPMINSPECT_BIN}" -w "${WORKDIR}" -c "${TMPCONF}" "$@"
+elif [ "$1" = "-CG" ]; then
+    shift
+    valgrind --tool=callgrind "${RPMINSPECT_BIN}" -w "${WORKDIR}" -c "${TMPCONF}" "$@"
+else
+    ${RPMINSPECT_BIN} -w "${WORKDIR}" -c "${TMPCONF}" "$@"
+fi


### PR DESCRIPTION
This is a copy of the wrapper script I use when testing rpminspect locally.  I have a git clone of the rpminspect source repo where I do my work.  There's a Makefile so I can just type "make" and build the program.  Since I use meson, the build directory is set to 'build' which the wrapper script assumes.

When I need to test rpminspect against Fedora, I need it to use the rpminspect-data-fedora data, but I want it to use the git clone of that.  That's where this script can help.  I actually have copies of this script in my ~/bin directory, all edited to point to a different vendor data directory git clone.  I have one for fedora, one for centos, and one for redhat.

I can make vendor data changes to the git clone of that project at the same time I am working on rpminspect.  Sometimes a fix is updating the vendor data project.

Signed-off-by: David Cantrell <dcantrell@redhat.com>