### PR TITLE
[ci] Use gcc for the FreeBSD CI job

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -63,7 +63,7 @@ jobs:
                       echo $? > exitcodes/instreqs
 
                       # Build the software and run the test suite
-                      env CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib meson setup build --werror -D b_buildtype=debug -D b_coverage=true -D with_libkmod=false -D with_libcap=false -D with_libannocheck=false
+                      env CC=gcc CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib meson setup build --werror -D b_buildtype=debug -D b_coverage=true -D with_libkmod=false -D with_libcap=false -D with_libannocheck=false
                       echo $? > exitcodes/setup
                       ninja -C build -v
                       echo $? > exitcodes/build


### PR DESCRIPTION
The default cc on FreeBSD is clang, but tell it to use gcc instead.

Signed-off-by: David Cantrell <dcantrell@redhat.com>