### PR TITLE
[bld] Adjust the CURLINFO_CONTENT_LENGTH_DOWNLOAD_T test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,9 +77,9 @@ curlinfo_src = '''
     }
     '''
 have_newer_curlinfo = cc.compiles(curlinfo_src,
-                                  args: [ '-Werror' ],
                                   dependencies: [ libcurl ],
-                                  name: 'CURLINFO_CONTENT_LENGTH_DOWNLOAD_T availability test')
+                                  name: 'CURLINFO_CONTENT_LENGTH_DOWNLOAD_T availability test',
+                                  no_builtin_args: true)
 
 if have_newer_curlinfo
     add_project_arguments('-D_HAVE_NEWER_CURLINFO', language : 'c')


### PR DESCRIPTION
Drop the builtin compiler args since this is a simple test to see what is in the enum.

Signed-off-by: David Cantrell <dcantrell@redhat.com>