### PR TITLE
[fix] Avoid duplicate --hd1/--hd2 args to abidiff

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -128,6 +128,7 @@ void free_rpminspect(struct rpminspect *);
 void free_deprules(deprule_list_t *list);
 
 /* pairfuncs.c */
+bool pair_contains_key(const pair_list_t *list, const char *key);
 void free_pair(pair_list_t *list);
 
 /* listfuncs.c */

--- a/lib/pairfuncs.c
+++ b/lib/pairfuncs.c
@@ -8,6 +8,31 @@
 #include "rpminspect.h"
 
 /**
+ * @brief Check if a pair list has a key.
+ * @param The pair_list_t to check.
+ * @param The key to look for.
+ * @returns True if the pair list contains the key.
+ */
+bool pair_contains_key(const pair_list_t *list, const char *key)
+{
+    pair_entry_t *pair = NULL;
+
+    if (list == NULL) {
+        return false;
+    }
+
+    TAILQ_FOREACH(pair, list, items) {
+        if (key == NULL && pair->key == key) {
+            return true;
+        } else if (!strcmp(key, pair->key)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * @brief Free a pair_list_t and all member data.
  * @param The pair_list_t to free.
  */


### PR DESCRIPTION
Change the way the header dir arguments are constructed to avoid generating really long command lines with duplicate directories.

Signed-off-by: David Cantrell <dcantrell@redhat.com>