### PR TITLE
[lib] Support initialization from YAML, JSON, or DSON files

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -625,13 +625,6 @@
  */
 #define ELF_LIB_EXTENSION ".so."
 
-/**
- * @def YAML_FILENAME_EXTENSION
- *
- * YAML filename extension
- */
-#define YAML_FILENAME_EXTENSION ".yaml"
-
 /** @} */
 
 /**


### PR DESCRIPTION
rpminspect starts by reading in a main configuration file.  That file provides the vendor data directory which is key to finding the second [optional] configuration file, the profile.  Lastly, rpminspect looks for an 'rpminspect.yaml' file in the current working directory.  Each read in overlays and modifies the configuration data already read in.

This patch extends the init_rpminspect() functionality to try reading in profile configuration files by *.yaml, *.json, and *.dson.  Any one by that name will fulfill the -p or --profile argument.  Like before, if you specify a profile and rpminspect cannot find it, the program exits with an error reported.

The functionality is further extended to support looking for a local rpminspect.yaml, rpminspect.json, or rpminspect.dson file in the current working directory.  This file is optional, like before.

A limitation is the order the files are read in.  It first checks for a file by the *.yaml file, then *.json, then *.dson.  The first one found will be used and any potential remaining will be ignored.  So if you have rpminspect.yaml and rpminspect.dson in the current directory, the *.yaml one is used.  I thought about adjusting it based on file mtime and taking the most recently touched file, but that felt like it would lead to all sorts of unexpected behavior.  An order to try reading must be declared and this is the order: YAML, JSON, DSON.  I am open to other suggestions.

Signed-off-by: David Cantrell <dcantrell@redhat.com>