### PR TITLE
[fix] Use json_object_object_get_ex() in parse_json.c

### DIFF
--- a/lib/parse_json.c
+++ b/lib/parse_json.c
@@ -85,9 +85,7 @@ static json_object *getobj(json_object *jo, const char *key1, const char *key2)
         return NULL;
     }
 
-    cont = json_object_object_get(jo, key1);
-
-    if (cont == NULL) {
+    if (!json_object_object_get_ex(jo, key1, &cont)) {
         return NULL;
     }
 


### PR DESCRIPTION
The json_object_object_get() function is deprecated in favor of the json_object_object_get_ex() function.

Signed-off-by: David Cantrell <dcantrell@redhat.com>