### PR TITLE
Fix tests for virus inspection

### DIFF
--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -564,14 +564,9 @@ class TestRPMs(RequiresRpminspect):
                 self.dumpResults()
 
             self.assertEqual(self.p.returncode, self.exitcode)
-            self.assertEqual(
-                self.results[self.result_inspection][0]["result"], self.result
+            check_results(
+                self.results, self.result_inspection, self.result, self.waiver_auth
             )
-            if "waiver authorization" in self.results[self.result_inspection][0]:
-                self.assertEqual(
-                    self.results[self.result_inspection][0]["waiver authorization"],
-                    self.waiver_auth,
-                )
 
     def tearDown(self):
         super().tearDown()

--- a/test/test_virus.py
+++ b/test/test_virus.py
@@ -10,7 +10,6 @@ from baseclass import TestCompareSRPM, TestCompareRPMs, TestCompareKoji
 
 
 # package that does not contain a virus (OK)
-@timeout_decorator.timeout(500)
 class HasNoVirusSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
@@ -22,8 +21,11 @@ class HasNoVirusSRPM(TestSRPM):
         self.inspection = "virus"
         self.result = "OK"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasNoVirusRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
@@ -35,8 +37,11 @@ class HasNoVirusRPMs(TestRPMs):
         self.inspection = "virus"
         self.result = "OK"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasNoVirusKoji(TestKoji):
     def setUp(self):
         super().setUp()
@@ -48,8 +53,11 @@ class HasNoVirusKoji(TestKoji):
         self.inspection = "virus"
         self.result = "OK"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasNoVirusCompareSRPM(TestCompareSRPM):
     def setUp(self):
         super().setUp()
@@ -64,8 +72,11 @@ class HasNoVirusCompareSRPM(TestCompareSRPM):
         self.inspection = "virus"
         self.result = "OK"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasNoVirusCompareRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
@@ -80,8 +91,11 @@ class HasNoVirusCompareRPMs(TestCompareRPMs):
         self.inspection = "virus"
         self.result = "OK"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasNoVirusCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
@@ -96,9 +110,12 @@ class HasNoVirusCompareKoji(TestCompareKoji):
         self.inspection = "virus"
         self.result = "OK"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
+
 
 # package that contains a virus (BAD)
-@timeout_decorator.timeout(500)
 class HasVirusSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
@@ -109,8 +126,11 @@ class HasVirusSRPM(TestSRPM):
         self.result = "BAD"
         self.waiver_auth = "Security"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasVirusRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
@@ -121,8 +141,11 @@ class HasVirusRPMs(TestRPMs):
         self.result = "BAD"
         self.waiver_auth = "Security"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasVirusKoji(TestKoji):
     def setUp(self):
         super().setUp()
@@ -133,8 +156,11 @@ class HasVirusKoji(TestKoji):
         self.result = "BAD"
         self.waiver_auth = "Security"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasVirusCompareSRPM(TestCompareSRPM):
     def setUp(self):
         super().setUp()
@@ -150,8 +176,11 @@ class HasVirusCompareSRPM(TestCompareSRPM):
         self.result = "BAD"
         self.waiver_auth = "Security"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasVirusCompareRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
@@ -167,8 +196,11 @@ class HasVirusCompareRPMs(TestCompareRPMs):
         self.result = "BAD"
         self.waiver_auth = "Security"
 
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()
 
-@timeout_decorator.timeout(500)
+
 class HasVirusCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
@@ -183,3 +215,7 @@ class HasVirusCompareKoji(TestCompareKoji):
         self.inspection = "virus"
         self.result = "BAD"
         self.waiver_auth = "Security"
+
+    @timeout_decorator.timeout(500)
+    def runTest(self):
+        super().runTest()


### PR DESCRIPTION
2 changes:

- virus tests are currently not recognized as tests due to the timeout decorator being used on the whole class
  - decorating method instead fixes this problem
- switch to `check_results()` in `TestRPMs` as virus inspection results starts with information about the database and not actual virus scan result