### PR TITLE
[fix] Nullify result params after they were freed

### DIFF
--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -171,7 +171,9 @@ bool inspect_virus(struct rpminspect *ri)
     params.arch = NULL;
     add_result(ri, &params);
     free(params.msg);
+    params.msg = NULL;
     free(params.details);
+    params.details = NULL;
 
     /* run the virus check on each file */
     params.severity = RESULT_BAD;


### PR DESCRIPTION
`add_result_entry()` is reading non-NULL params and thus we might end up with random garbage in the final output. Virus inspection tests are currently failing on unicode decoding errors because of this.

Signed-off-by: Michal Srb <michal@redhat.com>