### PR TITLE
[ci] Install cdson on various CI jobs

### DIFF
--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -70,6 +70,20 @@ autoreconf -f -i -v
 make V=1
 make install
 
+# cdson is not [yet] in Alpine
+cd "${CWD}" || exit 1
+git clone https://github.com/frozencemetery/cdson.git
+cd cdson || exit 1
+TAG="$(git tag -l | sort -n | tail -n 1)"
+git checkout -b "${TAG}" "${TAG}"
+cd "${TAG}" || exit 1
+meson setup build
+ninja -C build -v
+meson -C build test
+meson -C build install
+cd "${CWD}" || exit 1
+rm -rf cdson
+
 # Avoid getting %{_arch} in filenames from rpmbuild
 echo "%_arch %(/bin/arch)" > ~/.rpmmacros
 

--- a/osdeps/amzn2/reqs.txt
+++ b/osdeps/amzn2/reqs.txt
@@ -22,6 +22,7 @@ libabigail
 libarchive-devel
 libcap-devel
 libcurl-devel
+libdson-devel
 libffi-devel
 libicu-devel
 libmandoc-devel

--- a/osdeps/arch/post.sh
+++ b/osdeps/arch/post.sh
@@ -52,5 +52,19 @@ autoreconf -f -i -v
 make
 make install
 
+# cdson is not [yet] in Arch
+cd "${CWD}" || exit 1
+git clone https://github.com/frozencemetery/cdson.git
+cd cdson || exit 1
+TAG="$(git tag -l | sort -n | tail -n 1)"
+git checkout -b "${TAG}" "${TAG}"
+cd "${TAG}" || exit 1
+meson setup build
+ninja -C build -v
+meson -C build test
+meson -C build install
+cd "${CWD}" || exit 1
+rm -rf cdson
+
 # Update the clamav database
 freshclam

--- a/osdeps/mageia/post.sh
+++ b/osdeps/mageia/post.sh
@@ -51,5 +51,19 @@ autoreconf -f -i -v
 make
 make install
 
+# cdson is not [yet] in Mageia
+cd "${CWD}" || exit 1
+git clone https://github.com/frozencemetery/cdson.git
+cd cdson || exit 1
+TAG="$(git tag -l | sort -n | tail -n 1)"
+git checkout -b "${TAG}" "${TAG}"
+cd "${TAG}" || exit 1
+meson setup build
+ninja -C build -v
+meson -C build test
+meson -C build install
+cd "${CWD}" || exit 1
+rm -rf cdson
+
 # Update the clamav database
 freshclam

--- a/osdeps/opensuse-leap/post.sh
+++ b/osdeps/opensuse-leap/post.sh
@@ -39,5 +39,19 @@ make install
 cd "${CWD}" || exit 1
 rm -rf rc
 
+# cdson is not [yet] in OpenSUSE Leap
+cd "${CWD}" || exit 1
+git clone https://github.com/frozencemetery/cdson.git
+cd cdson || exit 1
+TAG="$(git tag -l | sort -n | tail -n 1)"
+git checkout -b "${TAG}" "${TAG}"
+cd "${TAG}" || exit 1
+meson setup build
+ninja -C build -v
+meson -C build test
+meson -C build install
+cd "${CWD}" || exit 1
+rm -rf cdson
+
 # Update the clamav database
 freshclam


### PR DESCRIPTION
Install cdson on Alpine Linux, Amazon Linux 2, Arch Linux, Mageia Linux, and OpenSUSE Leap.  Install from git because none of these distributions offers cdson as a package.

Signed-off-by: David Cantrell <dcantrell@redhat.com>