### PR TITLE
[fix] Set CURLOPT_FOLLOWLOCATION in curl_get_size()

### DIFF
--- a/lib/curl.c
+++ b/lib/curl.c
@@ -244,11 +244,13 @@ curl_off_t curl_get_size(const char *src)
 
     /* get the size */
     curl_easy_setopt(c, CURLOPT_URL, src);
-    curl_easy_setopt(c, CURLOPT_NOBODY, 1);
+    curl_easy_setopt(c, CURLOPT_NOBODY, 1L);
     curl_easy_setopt(c, CURLOPT_FAILONERROR, true);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
 #ifdef CURLOPT_TCP_FASTOPEN /* not available on all versions of libcurl (e.g., <= 7.29) */
     curl_easy_setopt(c, CURLOPT_TCP_FASTOPEN, 1);
 #endif
+
     cc = curl_easy_perform(c);
 
     if (cc != CURLE_OK) {
@@ -262,8 +264,8 @@ curl_off_t curl_get_size(const char *src)
     curl_easy_getinfo(c, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &len);
     r = (curl_off_t) len;
 #endif
-    curl_easy_cleanup(c);
 
+    curl_easy_cleanup(c);
     return r;
 }
 


### PR DESCRIPTION
For redirects, make sure curl follows along in order to get the size of the file we're trying to download.

Fixes: #1059

Signed-off-by: David Cantrell <dcantrell@redhat.com>