### PR TITLE
[lib] Set CURLOPT_MAXREDIRS to prevent unlimited URL redirections

### DIFF
--- a/lib/curl.c
+++ b/lib/curl.c
@@ -178,6 +178,7 @@ void curl_get_file(const bool verbose, const char *src, const char *dst)
 
     curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, NULL);
     curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(c, CURLOPT_MAXREDIRS, 10L);
 
     if (verbose) {
 #if LIBCURL_VERSION_NUM >= 0x072000
@@ -247,6 +248,7 @@ curl_off_t curl_get_size(const char *src)
     curl_easy_setopt(c, CURLOPT_NOBODY, 1L);
     curl_easy_setopt(c, CURLOPT_FAILONERROR, true);
     curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(c, CURLOPT_MAXREDIRS, 10L);
 #ifdef CURLOPT_TCP_FASTOPEN /* not available on all versions of libcurl (e.g., <= 7.29) */
     curl_easy_setopt(c, CURLOPT_TCP_FASTOPEN, 1);
 #endif


### PR DESCRIPTION
Pick 10 which seems more than reasonable (start the timer on when that is not reasonable).  The default is unlimited, which could result in improperly configured servers causing rpminspect to just sit and spin indefinitely if they bounce around each other.

Signed-off-by: David Cantrell <dcantrell@redhat.com>