### PR TITLE
[lib] Adjust indentation when dumping config data

### DIFF
--- a/lib/debug.c
+++ b/lib/debug.c
@@ -464,7 +464,7 @@ void dump_cfg(const struct rpminspect *ri)
         printf("    jobs:\n");
 
         HASH_ITER(hh, ri->annocheck, hentry, tmp_hentry) {
-            printf("    %s: %s\n", hentry->key, hentry->value);
+            printf("        %s: %s\n", hentry->key, hentry->value);
         }
 
         dump_inspection_ignores(ri->inspection_ignores, NAME_ANNOCHECK);


### PR DESCRIPTION
The job definition list for the annocheck block was missing a level of indentation.

Signed-off-by: David Cantrell <dcantrell@redhat.com>