### PR TITLE
[cmd] Do not crash when user tries to compare two incompatible builds

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -154,7 +154,9 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
     char *after_product = NULL;
     bool matched = false;
 
-    assert(after != NULL);
+    if (after == NULL) {
+        return NULL;
+    }
 
     /* skip up to the dist tag */
     while (*after != '.' && *after != '\0') {


### PR DESCRIPTION
If a user tries to compare a build of zsh with gcc, the function that determines the product release substring will crash.  Let's not do that.  The user was just confused probably.

Signed-off-by: David Cantrell <dcantrell@redhat.com>