### PR TITLE
[fix] Check return value of cl_cvdhead() in virus inspection

### DIFF
--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -145,6 +145,16 @@ bool inspect_virus(struct rpminspect *ri)
         assert(cvdpath != NULL);
         cvd = cl_cvdhead(cvdpath);
 
+        if (cvd == NULL) {
+            free(cvdpath);
+
+            if (closedir(d) == -1) {
+                warn("closedir");
+            }
+
+            return false;
+        }
+
         xasprintf(&dbver, _("%s version %u (%s)"), cvdpath, cvd->version, cvd->time);
         assert(dbver != NULL);
 


### PR DESCRIPTION
cl_cvdhead() can return NULL, in which case we want to stop the virus inspection and let the user program consider that an error.

Fixes: #1088