### PR TITLE
[fix] Do not infinite loop on an empty rpminspect.yaml file

### DIFF
--- a/lib/parse_yaml.c
+++ b/lib/parse_yaml.c
@@ -299,6 +299,9 @@ static y_value *p_value(context *context)
             goto done;
         } else {
             warnx("skipping token type %s", tokname(token.type));
+            free(ret);
+            ret = NULL;
+            goto done;
         }
 
         yaml_token_delete(&token);
@@ -318,13 +321,13 @@ static bool yaml_parse_file(parser_context **context_out, const char *filename)
     y_value *value = NULL;
 
     if (filename == NULL) {
-        return NULL;
+        return true;
     }
 
     /* prepare a YAML parser */
     if (!yaml_parser_initialize(&parser)) {
         warnx("yaml_parser_initialize");
-        return NULL;
+        return true;
     }
 
     context.parser = &parser;
@@ -332,7 +335,7 @@ static bool yaml_parse_file(parser_context **context_out, const char *filename)
 
     if (fp == NULL) {
         warn("fopen");
-        return NULL;
+        return true;
     }
 
     yaml_parser_set_input_file(&parser, fp);


### PR DESCRIPTION
If a YAML config file is empty, rpminspect will get stuck in an infinite loop.  Make sure that doesn't happen.

Fixes: #1087