### PR TITLE
Initialize a dictionary on an empty flow YAML mapping

### DIFF
--- a/lib/parse_yaml.c
+++ b/lib/parse_yaml.c
@@ -198,6 +198,8 @@ static y_value *p_value(context *context)
                    || token.type == YAML_FLOW_MAPPING_START_TOKEN) {
             ret = xalloc(sizeof(*ret));
             ret->type = Y_DICT;
+            ret->v.dict.keys = xalloc(sizeof(ret->v.dict.keys));
+            ret->v.dict.values = xalloc(sizeof(ret->v.dict.values));
 
             while (1) {
                 yaml_token_delete(&token);


### PR DESCRIPTION
Previously empty flow mappings in modulemd.txt files as found in flatpack modules:

    buildopts:
	rpms: {}
	arches: [x86_64]

triggered a crash in y_free_tree():

    $ /tmp/build/src/rpminspect -c /usr/share/rpminspect/redhat.yaml --debug --verbose --arches=x86_64 --keep --build-type=module --tests=modularity --format=summary firefox-flatpak-9020020230217074331.9bc4ec6c
    Downloading module firefox-flatpak-9020020230217074331.9bc4ec6c
    debug: curl_get_file (169): src=|https://download.devel.redhat.com/brewroot/packages/firefox/flatpak/9020020230217074331.9bc4ec6c/files/module/modulemd.txt|
    dst=|/var/tmp/rpminspect/firefox-flatpak.lIwCPW/after/files/modulemd.txt|
    => modulemd.txt                                                                                        [#######################################################################################################]
    Segmentation fault (core dumped)

That was caused by a missing initialiation of v.dict.keys and v.dict.values arrays:

    Thread 1 "rpminspect" received signal SIGSEGV, Segmentation fault.
    0x00007ffff7f5e1c3 in y_free_tree (v=0x521180) at ../rpminspect/lib/parse_yaml.c:374
    374             for (i = 0; v->v.dict.keys[i] != NULL; i++) {
    (gdb) p *v
    $1 = {type = Y_DICT, v = {string = 0x0, array = 0x0, dict = {keys = 0x0, values = 0x0}}}

Because all functions accessing these arrays expect them to be allocated, this patch corrects p_value() contructor to allocate them.

https://github.com/rpminspect/rpminspect/issues/1093