### PR TITLE
[ci] Install rpm4 from source on FreeBSD CI job

### DIFF
--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -19,7 +19,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     char *digest = NULL;
     bool matched = false;
     bool allowed = false;
-    int flags = FNM_NOESCAPE | FNM_PERIOD;
+    int flags = FNM_PERIOD;
     const char *name = NULL;
     struct result_params params;
 

--- a/osdeps/freebsd/post.sh
+++ b/osdeps/freebsd/post.sh
@@ -2,6 +2,15 @@
 PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 CWD="$(pwd)"
 
+# Sync ports tree from git
+rm -rf /usr/ports || :
+git clone https://git.freebsd.org/ports.git /usr/ports
+echo "DEFAULT_VERSIONS+=ssl=openssl" >> /etc/make.conf
+
+# Build rpm4 from ports since the binary package lacks 'elfdeps'
+cd /usr/ports/archivers/rpm4
+make BATCH=yes install
+
 # Hostname to make sure rpmbuild works (this is gross)
 echo "$(ifconfig | grep "inet " | grep -v "inet 127" | awk '{ print $2; }') $(hostname)" >> /etc/hosts
 

--- a/osdeps/freebsd/post.sh
+++ b/osdeps/freebsd/post.sh
@@ -8,7 +8,7 @@ git clone https://git.freebsd.org/ports.git /usr/ports
 echo "DEFAULT_VERSIONS+=ssl=openssl" >> /etc/make.conf
 
 # Build rpm4 from ports since the binary package lacks 'elfdeps'
-cd /usr/ports/archivers/rpm4
+cd /usr/ports/archivers/rpm4 || exit 1
 make BATCH=yes install
 
 # Hostname to make sure rpmbuild works (this is gross)

--- a/osdeps/freebsd/reqs.txt
+++ b/osdeps/freebsd/reqs.txt
@@ -31,7 +31,6 @@ patchelf
 pkgconf
 python3
 rc
-rpm4
 rust
 valgrind
 xhtml

--- a/test/test_debuginfo.py
+++ b/test/test_debuginfo.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+import os
+import unittest
+
 from baseclass import (
     TestSRPM,
     TestCompareSRPM,
@@ -53,6 +56,9 @@ class MissingSectionsInDebuginfoPkgCompareSRPM(TestCompareSRPM):
 
 
 class MissingSectionsInDebuginfoPkgRPMs(TestRPMs):
+    @unittest.skipIf(
+        os.uname().sysname == "FreeBSD", "FreeBSD lacks find-debuginfo from debugedit"
+    )
     def setUp(self):
         super().setUp()
 
@@ -66,6 +72,9 @@ class MissingSectionsInDebuginfoPkgRPMs(TestRPMs):
 
 
 class MissingSectionsInDebuginfoPkgCompareRPMs(TestCompareRPMs):
+    @unittest.skipIf(
+        os.uname().sysname == "FreeBSD", "FreeBSD lacks find-debuginfo from debugedit"
+    )
     def setUp(self):
         super().setUp()
 
@@ -83,6 +92,9 @@ class MissingSectionsInDebuginfoPkgCompareRPMs(TestCompareRPMs):
 
 
 class MissingSectionsInDebuginfoPkgKoji(TestKoji):
+    @unittest.skipIf(
+        os.uname().sysname == "FreeBSD", "FreeBSD lacks find-debuginfo from debugedit"
+    )
     def setUp(self):
         super().setUp()
 
@@ -96,6 +108,9 @@ class MissingSectionsInDebuginfoPkgKoji(TestKoji):
 
 
 class MissingSectionsInDebuginfoPkgCompareKoji(TestCompareKoji):
+    @unittest.skipIf(
+        os.uname().sysname == "FreeBSD", "FreeBSD lacks find-debuginfo from debugedit"
+    )
     def setUp(self):
         super().setUp()
 
@@ -199,6 +214,9 @@ class HaveDebuggingSectionsInRegularPkgCompareKoji(TestCompareKoji):
 
 # Before build is stripped but now not stripped in the after build
 class BeforeStrippedAfterNotStrippedCompareKoji(TestCompareKoji):
+    @unittest.skipIf(
+        os.uname().sysname == "FreeBSD", "FreeBSD lacks find-debuginfo from debugedit"
+    )
     def setUp(self):
         super().setUp()
 
@@ -216,6 +234,9 @@ class BeforeStrippedAfterNotStrippedCompareKoji(TestCompareKoji):
 
 # Before build is not stripped, but the after build is
 class BeforeNotStrippedAfterStrippedCompareKoji(TestCompareKoji):
+    @unittest.skipIf(
+        os.uname().sysname == "FreeBSD", "FreeBSD lacks find-debuginfo from debugedit"
+    )
     def setUp(self):
         super().setUp()
 


### PR DESCRIPTION
The rpm4 prebuilt port is old at this point and the ports tree was updated a few weeks ago to fix the missing /usr/local/lib/rpm/elfdeps problem.  So install this port from source rather than the prebuilt package.  At some point we can probably go back to the prebuilt package.