### PR TITLE
[fix] elf_getscn() can return NULL in get_elf_section_names()

### DIFF
--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -237,7 +237,10 @@ string_list_t *get_elf_section_names(Elf *elf, size_t start)
 
     /* get the starting section */
     scn = elf_getscn(elf, start);
-    assert(scn != NULL);
+
+    if (scn == NULL) {
+        return NULL;
+    }
 
     /* iterate over the sections collecting the names */
     while ((scn = elf_nextscn(elf, scn)) != NULL) {


### PR DESCRIPTION
If elf_getscn() returns NULL, that's fine.  Just return NULL from this function.

Fixes: #1099