### PR TITLE
[ci] Fix Debian CI job and pip module installation

### DIFF
--- a/osdeps/debian/defs.mk
+++ b/osdeps/debian/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = env DEBIAN_FRONTEND=noninteractive apt-get -y install
-PIP_CMD = pip install -I
+PIP_CMD = pip install --break-system-packages

--- a/osdeps/debian/pre.sh
+++ b/osdeps/debian/pre.sh
@@ -11,4 +11,3 @@ apt-get update
 
 # install and update pip and setuptools
 apt-get -y install python3-pip python3-setuptools
-pip3 install --upgrade pip setuptools


### PR DESCRIPTION
Debian seems to have gotten a bit more picky about letting you install Python modules with pip.  Find the "push harder" command line option and run with that.