### PR TITLE
[ci] Add 'debug' and 'setup-debug' targets to Makefile

### DIFF
--- a/.github/workflows/almalinux.yml
+++ b/.github/workflows/almalinux.yml
@@ -62,7 +62,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/alpinelinux.yml
+++ b/.github/workflows/alpinelinux.yml
@@ -59,7 +59,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/amazonlinux.yml
+++ b/.github/workflows/amazonlinux.yml
@@ -57,7 +57,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -58,7 +58,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -58,7 +58,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/fedora-aarch64.yml
+++ b/.github/workflows/fedora-aarch64.yml
@@ -76,5 +76,4 @@ jobs:
                   #
                   run: |
                       make instreqs
-                      meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                      ninja -C build -v
+                      make debug

--- a/.github/workflows/fedora-ppc64le.yml
+++ b/.github/workflows/fedora-ppc64le.yml
@@ -76,5 +76,4 @@ jobs:
                   #
                   run: |
                       make instreqs
-                      meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                      ninja -C build -v
+                      make debug

--- a/.github/workflows/fedora-s390x.yml
+++ b/.github/workflows/fedora-s390x.yml
@@ -76,5 +76,4 @@ jobs:
                   #
                   run: |
                       make instreqs
-                      meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                      ninja -C build -v
+                      make debug

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -73,9 +73,8 @@ jobs:
               run: |
                   dnf install -y make
                   make instreqs
-                  meson setup build --werror -Db_buildtype=debug -Db_coverage=true
-                  ninja -C build -v
-                  meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :
 
     # Fedora on i386
@@ -110,7 +109,6 @@ jobs:
                   dnf remove -y fedora-repos-modular
                   dnf install -y make
                   make instreqs OSDEPS_ARCH=i686
-                  env CFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig meson setup build --werror -Db_buildtype=debug -Db_coverage=true
-                  ninja -C build -v
-                  meson test -C build -v
+                  env CFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/gentoo.yml
+++ b/.github/workflows/gentoo.yml
@@ -54,7 +54,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/mageia.yml
+++ b/.github/workflows/mageia.yml
@@ -56,7 +56,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -61,7 +61,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/oraclelinux.yml
+++ b/.github/workflows/oraclelinux.yml
@@ -68,7 +68,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/rockylinux.yml
+++ b/.github/workflows/rockylinux.yml
@@ -62,7 +62,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/slackware.yml
+++ b/.github/workflows/slackware.yml
@@ -74,7 +74,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -57,7 +57,6 @@ jobs:
                   make instreqs
 
                   # Build the software and run the test suite
-                  meson setup build --werror -D b_buildtype=debug -D b_coverage=true
-                  ninja -C build -v
-                  env LANG=en_US.UTF-8 meson test -C build -v
+                  make debug
+                  make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,14 @@ RELEASED_TARBALL_ASC = $(RELEASED_TARBALL).asc
 all: setup
 	$(NINJA) -C $(MESON_BUILD_DIR) -v
 
+debug: setup-debug
+	$(NINJA) -C $(MESON_BUILD_DIR) -v
+
 setup:
 	meson setup $(MESON_BUILD_DIR)
+
+setup-debug:
+	meson setup $(MESON_BUILD_DIR) --werror -Db_buildtype=debug -Db_coverage=true
 
 # NOTE: Set QA_RPATHS=63 so that check-rpaths is disabled during the
 # rpmfluff rpmbuild operations.  We want to let bad DT_RPATH values

--- a/osdeps/fedora-rawhide.i686/defs.mk
+++ b/osdeps/fedora-rawhide.i686/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install
+PIP_CMD = pip-3 install

--- a/osdeps/fedora-rawhide/defs.mk
+++ b/osdeps/fedora-rawhide/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install
+PIP_CMD = pip-3 install

--- a/osdeps/fedora.i686/defs.mk
+++ b/osdeps/fedora.i686/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip-3 install
+PIP_CMD = pip-3 install


### PR DESCRIPTION
These are for the CI jobs.  For the test suite, I want the CI jobs to run "make check" rather than using meson.  The reason is the Makefile target sets up the test environment and that's what I use to test things.

I have converted most workflows over to running "make debug" and "make check" in the GitHub workflow file, but I still have CentOS and FreeBSD to update.  Need to make sure these work first.