### PR TITLE
Handle 32-bit x86 architecture naming inconsistencies and patch file names with RPM macros

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -402,6 +402,14 @@
 #define RPM_NOARCH_NAME "noarch"
 
 /**
+ * @def RPM_X86_ARCH_PATTERN
+ *
+ * An fnmatch(3) pattern for 32-bit x86 because Koji, rpm, and the
+ * toolchain cannot agree on what to call this architecture.
+ */
+#define RPM_X86_ARCH_PATTERN "i?86"
+
+/**
  * @def BIN_OWNER
  *
  * Default executable file owner.

--- a/include/results.h
+++ b/include/results.h
@@ -684,6 +684,8 @@
 
 #define REMEDY_PATCHES_MISMATCHED_MACRO _("The named patch is defined but is mismatched by number with the %patch macro.  Make sure all numbered patches have corresponding %patch macros.  For example, Patch47 needs to have a %patch47 macro.")
 
+#define REMEDY_PATCHES_UNHANDLED_PATCH _("The defined patch file is not something rpminspect can handle.  This is likely a bug and should be reported to the upstream rpminspect project.")
+
 /** @} */
 
 /**

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -358,7 +358,7 @@ bool find_all(Elf *elf, string_list_t **user_data);
 
 /* paths.c */
 /**
- * @brief Return the before build debuginfo package path where the
+ * @brief Return the selected build debuginfo package path where the
  * package was extracted for rpminspect.  The path must match the
  * architecture provided.
  *
@@ -367,25 +367,10 @@ bool find_all(Elf *elf, string_list_t **user_data);
  * @param ri The struct rpminspect for the program.
  * @param file The file we are looking for debuginfo for.
  * @param binarch The required debuginfo architecture.
- * @return Full path to the extract before build debuginfo package, or
- * NULL if not found.
+ * @return Full path to the extracted debuginfo package, or
+ *         NULL if not found.
  */
-const char *get_before_debuginfo_path(struct rpminspect *ri, const rpmfile_entry_t *file, const char *binarch);
-
-/**
- * @brief Return the after build debuginfo package path where the
- * package was extracted for rpminspect.  The path must match the
- * architecture provided.
- *
- * IMPORTANT: Do not free the returned string.
- *
- * @param ri The struct rpminspect for the program.
- * @param file The file we are looking for debuginfo for.
- * @param binarch The required debuginfo architecture.
- * @return Full path to the extract after build debuginfo package, or
- * NULL if not found.
- */
-const char *get_after_debuginfo_path(struct rpminspect *ri, const rpmfile_entry_t *file, const char *binarch);
+const char *get_debuginfo_path(struct rpminspect *ri, const rpmfile_entry_t *file, const char *binarch, int build);
 
 bool usable_path(const char *path);
 bool match_path(const char *pattern, const char *root, const char *path);

--- a/lib/files.c
+++ b/lib/files.c
@@ -159,7 +159,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
 {
     rpmtd td = NULL;
 
-    const char *rpm_path;
+    const char *rpm_path = NULL;
     struct file_data *path_table = NULL;
     struct file_data *path_entry = NULL;
     struct file_data *tmp_entry = NULL;
@@ -168,12 +168,12 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
     char *hardlinkpath = NULL;
     struct archive *archive = NULL;
     struct archive_entry *entry = NULL;
-    const char *archive_path;
-    mode_t archive_perm;
-    int archive_result;
+    const char *archive_path = NULL;
+    mode_t archive_perm = 0;
+    int archive_result = 0;
 
-    int i;
-    rpmfile_entry_t *file_entry;
+    int i = 0;
+    rpmfile_entry_t *file_entry = NULL;
     rpmfile_t *file_list = NULL;
 
     const int archive_flags = ARCHIVE_EXTRACT_SECURE_NODOTDOT | ARCHIVE_EXTRACT_SECURE_SYMLINKS;
@@ -305,7 +305,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         }
 
         /* Prepend output_dir to the path name */
-        xasprintf(&file_entry->fullpath, "%s/%s", *output_dir, archive_path);
+        xasprintf(&file_entry->fullpath, "%s%s%s", *output_dir, (strsuffix(*output_dir, "/") && strprefix(archive_path, "/")) ? "" : "/", archive_path);
         archive_entry_set_pathname(entry, file_entry->fullpath);
 
         /* Ensure the resulting file is user-rw and global-unwritable */

--- a/lib/files.c
+++ b/lib/files.c
@@ -173,6 +173,8 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
     int archive_result = 0;
 
     int i = 0;
+    const char *tmp = NULL;
+    const char *div = NULL;
     rpmfile_entry_t *file_entry = NULL;
     rpmfile_t *file_list = NULL;
 
@@ -305,7 +307,27 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         }
 
         /* Prepend output_dir to the path name */
-        xasprintf(&file_entry->fullpath, "%s%s%s", *output_dir, (strsuffix(*output_dir, "/") && strprefix(archive_path, "/")) ? "" : "/", archive_path);
+        tmp = archive_path;
+
+        if (strsuffix(*output_dir, "/")) {
+            if (strprefix(archive_path, "/")) {
+                div = "";
+
+                while (*tmp == '/' && *tmp != '\0') {
+                    tmp++;
+                }
+            } else {
+                div = "/";
+            }
+        } else {
+            if (strprefix(archive_path, "/")) {
+                div = "";
+            } else {
+                div = "/";
+            }
+        }
+
+        xasprintf(&file_entry->fullpath, "%s%s%s", *output_dir, div, tmp);
         archive_entry_set_pathname(entry, file_entry->fullpath);
 
         /* Ensure the resulting file is user-rw and global-unwritable */

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <err.h>
 #include <limits.h>
+#include <fnmatch.h>
 #include <xmlrpc-c/client.h>
 #include <xmlrpc-c/client_global.h>
 #include "queue.h"
@@ -1359,8 +1360,17 @@ string_list_t *get_all_arches(const struct rpminspect *ri)
             continue;
         }
 
-        /* add this architecture to the list */
-        arches = list_add(arches, element);
+        /*
+         * If the architecture is something like i386 or i686, add a
+         * pattern instead to cover the range which built RPMs may
+         * report.  Otherwise add the architecture as-is to the list.
+         */
+        if (!fnmatch(RPM_X86_ARCH_PATTERN, element, 0)) {
+            arches = list_add(arches, RPM_X86_ARCH_PATTERN);
+        } else {
+            arches = list_add(arches, element);
+        }
+
         free(element);
     }
 

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -226,7 +226,7 @@ string_list_t *get_macros(const char *s)
 
     /* collect all the macro names */
     TAILQ_FOREACH(entry, fields, items) {
-        if (!strcmp(entry->data, "%")) {
+        if (!strcmp(entry->data, "%") || strsuffix(entry->data, "%")) {
             found = true;
             continue;
         }

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -18,6 +18,7 @@
 #include <limits.h>
 #include <wordexp.h>
 #include <regex.h>
+#include <fnmatch.h>
 #include <zlib.h>
 #include <magic.h>
 #include <clamav.h>
@@ -759,7 +760,7 @@ int main(int argc, char **argv)
             found = false;
 
             TAILQ_FOREACH(arch, valid_arches, items) {
-                if (!strcmp(token, arch->data)) {
+                if (!fnmatch(arch->data, token, 0)) {
                     found = true;
                     break;
                 }


### PR DESCRIPTION
A lot in here, but it all started with fixing the annocheck inspection and it not finding the debuginfo path for i686 packages.  That began the yak shaving.