### PR TITLE
[fix] Handle patch files with spec file macros in the name

### DIFF
--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -482,3 +482,48 @@ class PatchDefinedWithoutFieldSpaceCompareSRPM(TestCompareSRPM):
         self.inspection = "patches"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
+
+
+# patch filename has a spec file macro in it
+class PatchFilenameWithMacroSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # define a macro
+        self.rpm.header += "\n%define super_patch_number 47\n"
+
+        # add a patch using a macro in a filename
+        self.rpm.add_patch(
+            rpmfluff.SourceFile("some-47.patch", patch_file),
+            True,
+            patchUrl="some-%{super_patch_number}.patch",
+        )
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class PatchFilenameWithMacroCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # define a macro
+        self.before_rpm.header += "\n%define super_patch_number 47\n"
+        self.after_rpm.header += "\n%define super_patch_number 47\n"
+
+        # add a patch using a macro in a filename
+        self.before_rpm.add_patch(
+            rpmfluff.SourceFile("some-47.patch", patch_file),
+            True,
+            patchUrl="some-%{super_patch_number}.patch",
+        )
+        self.after_rpm.add_patch(
+            rpmfluff.SourceFile("some-47.patch", patch_file),
+            True,
+            patchUrl="some-%{super_patch_number}.patch",
+        )
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
Patches can use spec file macros in their name definitions.  Support that as best as possible in the patches inspection.  Handles things like "patch-%{rpmversion}-vendor.patch"

Fixes: #1114