### PR TITLE
Fix leaking file descriptors which cause cascading failures through other inspections

### DIFF
--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -192,6 +192,11 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
             warn("read");
+
+            if (close(fd) == -1) {
+                warn("close");
+            }
+
             return true;
         }
 

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -128,6 +128,9 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     int macrocount = 0;
     struct result_params params;
 
+    assert(ri != NULL);
+    assert(file != NULL);
+
     /* Read in spec file macros */
     macrocount = get_specfile_macros(ri, file->fullpath);
 

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -868,11 +868,19 @@ static bool elf_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     /* Skip kernel modules */
     after_elf = get_elf(after->fullpath, &after_elf_fd);
 
-    if (after_elf != NULL && get_elf_type(after_elf) == ET_REL && have_elf_section(after_elf, SHT_PROGBITS, ".modinfo")
+    if (after_elf != NULL
+        && get_elf_type(after_elf) == ET_REL
+        && have_elf_section(after_elf, SHT_PROGBITS, ".modinfo")
         && strsuffix(after->localpath, KERNEL_MODULE_FILENAME_EXTENSION)) {
-        close(after_elf_fd);
         elf_end(after_elf);
+        close(after_elf_fd);
         return true;
+    }
+
+    /* close this handle so the test can start over for .a vs .so */
+    if (after_elf) {
+        elf_end(after_elf);
+        close(after_elf_fd);
     }
 
     arch = get_rpm_header_arch(after->rpm_header);

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -70,6 +70,11 @@ static short get_jvm_major(const char *filename, const char *localpath, const ch
 
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
             warn("read");
+
+            if (close(fd) == -1) {
+                warn("close");
+            }
+
             return -1;
         }
 

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -83,7 +83,10 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
 
     /* Read in the spec file first */
     spec = read_file(specfile);
-    assert(spec != NULL);
+
+    if (spec == NULL) {
+        return 0;
+    }
 
     /* Use a regular expression to match macro lines we will break down */
     xasprintf(&buf, "(%s|%s)", SPEC_MACRO_DEFINE, SPEC_MACRO_GLOBAL);


### PR DESCRIPTION
The elf inspection had a file descriptor leak which, when comparing builds with many many many files, would hit the open file descriptor limit for the process.  This led to problems with a number of other inspections.  This PR addresses that whole chain of problems I found.