### PR TITLE
[ci] clamav-update.i686 -> clamav-update on Fedora i386 jobs

### DIFF
--- a/osdeps/fedora-rawhide.i686/reqs.txt
+++ b/osdeps/fedora-rawhide.i686/reqs.txt
@@ -3,7 +3,7 @@ bash
 binutils-devel.i686
 clamav-data
 clamav-devel.i686
-clamav-update.i686
+clamav-update
 CUnit.i686
 CUnit-devel.i686
 dash

--- a/osdeps/fedora.i686/reqs.txt
+++ b/osdeps/fedora.i686/reqs.txt
@@ -4,7 +4,7 @@ binutils-devel.i686
 cargo
 clamav-data
 clamav-devel.i686
-clamav-update.i686
+clamav-update
 CUnit.i686
 CUnit-devel.i686
 dash


### PR DESCRIPTION
The clamav-update.i686 package does not exist anymore, so just install clamav-update.