### PR TITLE
Fix modularity test when forbidden static_context field is actually missing

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -183,7 +183,7 @@ vendor:
     # And rpminspect will match the longer ones to fc31.  By default
     # there is no product release regexp mapping enabled.
     #
-    # fc31: ^\.fc31.*$
+    #fc31: ^\.fc31.*$
 
 macrofiles:
     # Paths to all RPM macro definitions that rpminspect should use.

--- a/include/types.h
+++ b/include/types.h
@@ -469,6 +469,9 @@ struct rpminspect {
     /* Commands */
     struct command_paths commands;
 
+    /* environment section present? */
+    bool have_environment;
+
     /* Vendor data */
     char *vendor_data_dir;     /* main vendor data directory */
     string_list_t *licensedb;  /* names of files under licenses/ to use */

--- a/lib/init.c
+++ b/lib/init.c
@@ -474,7 +474,7 @@ static bool annocheck_cb(const char *key, const char *value, void *cb_data)
 {
     tabledict_cb_data *data = cb_data;
 
-    if (!strcasecmp(key, "failure_severity") || !strcasecmp(key, "extra_opts") || !strcasecmp(key, "ignore") || !strcasecmp(key, "ignore")) {
+    if (!strcasecmp(key, "failure_severity") || !strcasecmp(key, "extra_opts") || !strcasecmp(key, "ignore")) {
         return false;
     }
 
@@ -602,7 +602,6 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
     /* Processing order doesn't matter, so match data/generic.yaml. */
     strget(p, ctx, "common", "workdir", &ri->workdir);
     strget(p, ctx, "common", "profiledir", &ri->profiledir);
-    strget(p, ctx, "environment", "product_release", &ri->product_release);
     strget(p, ctx, "koji", "hub", &ri->kojihub);
     strget(p, ctx, "koji", "download_ursine", &ri->kojiursine);
     strget(p, ctx, "koji", "download_mbs", &ri->kojimbs);
@@ -612,6 +611,15 @@ static int read_cfgfile(struct rpminspect *ri, const char *filename)
     strget(p, ctx, "commands", "kmidiff", &ri->commands.kmidiff);
     strget(p, ctx, "vendor", "vendor_data_dir", &ri->vendor_data_dir);
     array(p, ctx, "vendor", "licensedb", &ri->licensedb);
+
+    s = p->getstr(ctx, "environment", "product_release");
+
+    if (s != NULL) {
+        ri->have_environment = true;
+        free(ri->product_release);
+        ri->product_release = s;
+        s = NULL;
+    }
 
     s = p->getstr(ctx, "vendor", "favor_release");
 

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -118,7 +118,7 @@ static bool check_static_context(struct rpminspect *ri)
         /* comparing builds, verify after build is correct, but report changes */
         bsc = get_static_context(ri->worksubdir, BEFORE_SUBDIR);
 
-        if (bsc == asc) {
+        if (bsc && asc) {
             if (ri->modularity_static_context == STATIC_CONTEXT_FORBIDDEN) {
                 xasprintf(&params.msg, _("The /data/static_context value in %s matches the value in %s, but the product release rules forbid the presence of /data/static_context in the module metadata."), ri->before, ri->after);
                 params.severity = RESULT_VERIFY;


### PR DESCRIPTION
Also there is a commit that cleans up the dump_cfg() output.