### PR TITLE
[fix] Call cap_free() on any allocations made by cap_from_text()

### DIFF
--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -109,7 +109,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     pkg = headerGetString(file->rpm_header, RPMTAG_NAME);
     flcaps = get_caps_entry(ri, pkg, file->localpath);
 
-    if (!flcaps) {
+    if (!aftercap && !flcaps) {
         free(after);
         free(before);
 

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
+#include <err.h>
 #include <sys/capability.h>
 
 #include "rpminspect.h"
@@ -108,9 +109,18 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     pkg = headerGetString(file->rpm_header, RPMTAG_NAME);
     flcaps = get_caps_entry(ri, pkg, file->localpath);
 
-    if (!aftercap && !flcaps) {
+    if (!flcaps) {
         free(after);
         free(before);
+
+        if (cap_free(aftercap) == -1) {
+            warn("cap_free");
+        }
+
+        if (cap_free(beforecap) == -1) {
+            warn("cap_free");
+        }
+
         return true;
     }
 
@@ -189,6 +199,18 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     free(before);
     free(after);
+
+    if (cap_free(aftercap) == -1) {
+        warn("cap_free");
+    }
+
+    if (cap_free(beforecap) == -1) {
+        warn("cap_free");
+    }
+
+    if (cap_free(expected) == -1) {
+        warn("cap_free");
+    }
 
     return result;
 }

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -133,6 +133,10 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                         warnx("cap_get_flag");
                         have_setuid = CAP_CLEAR;
                     }
+
+                    if (cap_free(cap) == -1) {
+                        warn("cap_free");
+                    }
                 }
 
                 /* Handle if CAP_SETUID is present or not */


### PR DESCRIPTION
I was not calling cap_free() on anything created with cap_from_text(). All I'll say is "instructions unclear".  But it seems a cap_t is a pointer and allocations are made and you need to call cap_free() when you're done.  Fine.