### PR TITLE
[ci] Get rpminspect building with clang on FreeBSD 13.1

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -65,7 +65,7 @@ jobs:
                       echo $? > exitcodes/instreqs
 
                       # Build the software and run the test suite
-                      env CC=gcc CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib gmake debug
+                      gmake debug
                       echo $? > exitcodes/build
                       gmake check
                       echo $? > exitcodes/test

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,13 @@ RELEASED_TARBALL_ASC = $(RELEASED_TARBALL).asc
 # The python executable to use for the debug build and tests
 PYTHON ?= python3
 
+# FreeBSD installs ports to /usr/local, so make sure we pick up
+# libraries and headers correctly.
+ifeq ($(OS),freebsd)
+export CFLAGS=-I/usr/local/include
+export LDFLAGS=-L/usr/local/lib
+endif
+
 all: setup
 	$(NINJA) -C $(MESON_BUILD_DIR) -v
 
@@ -65,6 +72,12 @@ setup-debug:
 # environment variable -or- remove the script(s) from /usr/lib/rpm.
 # The environment variable is easier.
 export QA_RPATHS = 63
+
+# Make sure rpmfluff has a usable compiler.  gcc is not on default
+# FreeBSD installs anymore, so have it use 'cc'.
+ifeq ($(OS),freebsd)
+export CC = clang
+endif
 
 # To keep intermediate files and results files for each test case, set
 # KEEP=y (or to any value) in the calling environment when you run

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -236,6 +236,7 @@ void dump_cfg(const struct rpminspect *ri)
         }
     }
 
+#ifdef _HAVE_MODULARITYLABEL
     /* modularity */
 
     if (ri->modularity_static_context != STATIC_CONTEXT_NULL) {
@@ -252,6 +253,7 @@ void dump_cfg(const struct rpminspect *ri)
 
         printf("\n");
     }
+#endif
 
     /* elf */
 
@@ -825,6 +827,7 @@ void dump_cfg(const struct rpminspect *ri)
         dump_inspection_ignores(ri->inspection_ignores, NAME_VIRUS);
     }
 
+#ifdef _WITH_LIBCAP
     /* capabilities */
 
     HASH_FIND_STR(ri->inspection_ignores, NAME_CAPABILITIES, mapentry);
@@ -833,6 +836,7 @@ void dump_cfg(const struct rpminspect *ri)
         printf("capabilities:\n");
         dump_inspection_ignores(ri->inspection_ignores, NAME_CAPABILITIES);
     }
+#endif
 
     /* config */
 
@@ -852,6 +856,7 @@ void dump_cfg(const struct rpminspect *ri)
         dump_inspection_ignores(ri->inspection_ignores, NAME_DOC);
     }
 
+#ifdef _WITH_LIBKMOD
     /* kmod */
 
     HASH_FIND_STR(ri->inspection_ignores, NAME_KMOD, mapentry);
@@ -860,6 +865,7 @@ void dump_cfg(const struct rpminspect *ri)
         printf("kmod:\n");
         dump_inspection_ignores(ri->inspection_ignores, NAME_KMOD);
     }
+#endif
 
     /* permissions */
 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,6 @@ project('rpminspect',
         'c',
         version : '1.12',
         default_options : [
-            'c_std=c99',
             'warning_level=3',
             'werror=true',
             'buildtype=debugoptimized'
@@ -16,6 +15,9 @@ add_global_arguments('-DPACKAGE_VERSION="@0@"'.format(meson.project_version()), 
 
 # Always add _GNU_SOURCE because some other libraries rely on this macro
 add_global_arguments('-D_GNU_SOURCE', language : 'c')
+
+# Define this to get around a problematic json_object.h macro
+add_global_arguments('-D__STRICT_ANSI__', language : 'c')
 
 # Library search dirs
 search_dirs = [ '/usr/local/lib', '/usr/lib64', '/usr/lib' ]

--- a/osdeps/freebsd/post.sh
+++ b/osdeps/freebsd/post.sh
@@ -11,6 +11,13 @@ echo "DEFAULT_VERSIONS+=ssl=openssl" >> /etc/make.conf
 cd /usr/ports/archivers/rpm4 || exit 1
 make BATCH=yes install
 
+# https://github.com/rpm-software-management/rpm/pull/2459
+grep RPM_MASK_RETURN_TYPE /usr/include/rpm/rpmtag.h 2>/dev/null | grep -q 0xffff0000 >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+    sed -i -e 's|^.*RPM_MASK_RETURN_TYPE.*=.*0xffff0000$|#define RPM_MASK_RETURN_TYPE 0xffff0000|g' /usr/include/rpm/rpmtag.h
+    sed -i -e '/RPM_MAPPING_RETURN_TYPE/ s/\,$//' /usr/include/rpm/rpmtag.h
+fi
+
 # Hostname to make sure rpmbuild works (this is gross)
 echo "$(ifconfig | grep "inet " | grep -v "inet 127" | awk '{ print $2; }') $(hostname)" >> /etc/hosts
 
@@ -47,7 +54,7 @@ tar -xf mandoc.tar.gz
 ( cd "${SUBDIR}" && ./configure && gmake && gmake lib-install )
 rm -rf mandoc.tar.gz "${SUBDIR}"
 
-# cdson is not [yet] in Debian
+# cdson is not [yet] in FreeBSD
 cd "${CWD}" || exit 1
 git clone https://github.com/frozencemetery/cdson.git
 cd cdson || exit 1

--- a/osdeps/freebsd/reqs.txt
+++ b/osdeps/freebsd/reqs.txt
@@ -9,7 +9,6 @@ curl
 debugedit
 desktop-file-utils
 elfutils
-gcc
 gettext
 git
 gmake

--- a/test/test_elf.py
+++ b/test/test_elf.py
@@ -31,8 +31,8 @@ double exponent(double x, double y)
 """
 
 # Figure out if the system is 32-bit capable or not
-have_gcc_multilib = False
-args = ["gcc", "-print-multi-lib"]
+have_multilib = False
+args = ["cc", "-print-multi-lib"]
 proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 (out, err) = proc.communicate()
 
@@ -41,7 +41,7 @@ if (
     and str(out).find("@m32") != -1
     and os.path.isfile("/usr/include/gnu/stubs-32.h")
 ):
-    have_gcc_multilib = True
+    have_multilib = True
 
 
 # Simple way to figure out if we are musl or glibc
@@ -600,14 +600,14 @@ class SecurityFAILFulltoPartialRELROCompareKoji(TestCompareKoji):
 
 # Program lost -fPIC in after (BAD, WAIVABLE_BY_SECURITY)
 class LostPICCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
         installPath = "usr/lib/libsimple.a"
 
         self.before_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
-        self.before_rpm.section_build += "gcc -m32 -fPIC -c simple.c\n"
+        self.before_rpm.section_build += "cc -m32 -fPIC -c simple.c\n"
         self.before_rpm.section_build += "ar -crs libsimple.a simple.o\n"
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -619,7 +619,7 @@ class LostPICCompareRPMs(TestCompareRPMs):
 
         self.after_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
         self.after_rpm.section_build += (
-            "gcc -m32 -shared -fno-PIC -o simple.o simple.c\n"
+            "cc -m32 -shared -fno-PIC -o simple.o simple.c\n"
         )
         self.after_rpm.section_build += "chmod 0644 simple.o\n"
         self.after_rpm.section_build += "ar -crs libsimple.a simple.o\n"
@@ -637,14 +637,14 @@ class LostPICCompareRPMs(TestCompareRPMs):
 
 
 class SecuritySKIPLostPICCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
         installPath = "usr/lib/libskip.a"
 
         self.before_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
-        self.before_rpm.section_build += "gcc -m32 -fPIC -c simple.c\n"
+        self.before_rpm.section_build += "cc -m32 -fPIC -c simple.c\n"
         self.before_rpm.section_build += "ar -crs libsimple.a simple.o\n"
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -656,7 +656,7 @@ class SecuritySKIPLostPICCompareRPMs(TestCompareRPMs):
 
         self.after_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
         self.after_rpm.section_build += (
-            "gcc -m32 -shared -fno-PIC -o simple.o simple.c\n"
+            "cc -m32 -shared -fno-PIC -o simple.o simple.c\n"
         )
         self.after_rpm.section_build += "chmod 0644 simple.o\n"
         self.after_rpm.section_build += "ar -crs libsimple.a simple.o\n"
@@ -673,14 +673,14 @@ class SecuritySKIPLostPICCompareRPMs(TestCompareRPMs):
 
 
 class SecurityINFORMLostPICCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
         installPath = "usr/lib/libinform.a"
 
         self.before_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
-        self.before_rpm.section_build += "gcc -m32 -fPIC -c simple.c\n"
+        self.before_rpm.section_build += "cc -m32 -fPIC -c simple.c\n"
         self.before_rpm.section_build += "ar -crs libsimple.a simple.o\n"
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -692,7 +692,7 @@ class SecurityINFORMLostPICCompareRPMs(TestCompareRPMs):
 
         self.after_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
         self.after_rpm.section_build += (
-            "gcc -m32 -shared -fno-PIC -o simple.o simple.c\n"
+            "cc -m32 -shared -fno-PIC -o simple.o simple.c\n"
         )
         self.after_rpm.section_build += "chmod 0644 simple.o\n"
         self.after_rpm.section_build += "ar -crs libsimple.a simple.o\n"
@@ -710,14 +710,14 @@ class SecurityINFORMLostPICCompareRPMs(TestCompareRPMs):
 
 
 class SecurityVERIFYLostPICCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
         installPath = "usr/lib/libverify.a"
 
         self.before_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
-        self.before_rpm.section_build += "gcc -m32 -fPIC -c simple.c\n"
+        self.before_rpm.section_build += "cc -m32 -fPIC -c simple.c\n"
         self.before_rpm.section_build += "ar -crs libsimple.a simple.o\n"
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -729,7 +729,7 @@ class SecurityVERIFYLostPICCompareRPMs(TestCompareRPMs):
 
         self.after_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
         self.after_rpm.section_build += (
-            "gcc -m32 -shared -fno-PIC -o simple.o simple.c\n"
+            "cc -m32 -shared -fno-PIC -o simple.o simple.c\n"
         )
         self.after_rpm.section_build += "chmod 0644 simple.o\n"
         self.after_rpm.section_build += "ar -crs libsimple.a simple.o\n"
@@ -747,14 +747,14 @@ class SecurityVERIFYLostPICCompareRPMs(TestCompareRPMs):
 
 
 class SecurityFAILLostPICCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
         installPath = "usr/lib/libfail.a"
 
         self.before_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
-        self.before_rpm.section_build += "gcc -m32 -fPIC -c simple.c\n"
+        self.before_rpm.section_build += "cc -m32 -fPIC -c simple.c\n"
         self.before_rpm.section_build += "ar -crs libsimple.a simple.o\n"
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -766,7 +766,7 @@ class SecurityFAILLostPICCompareRPMs(TestCompareRPMs):
 
         self.after_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
         self.after_rpm.section_build += (
-            "gcc -m32 -shared -fno-PIC -o simple.o simple.c\n"
+            "cc -m32 -shared -fno-PIC -o simple.o simple.c\n"
         )
         self.after_rpm.section_build += "chmod 0644 simple.o\n"
         self.after_rpm.section_build += "ar -crs libsimple.a simple.o\n"
@@ -784,14 +784,14 @@ class SecurityFAILLostPICCompareRPMs(TestCompareRPMs):
 
 
 class LostPICCompareKoji(TestCompareKoji):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
         installPath = "usr/lib/libsimple.a"
 
         self.before_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
-        self.before_rpm.section_build += "gcc -m32 -fPIC -c simple.c\n"
+        self.before_rpm.section_build += "cc -m32 -fPIC -c simple.c\n"
         self.before_rpm.section_build += "ar -crs libsimple.a simple.o\n"
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -803,7 +803,7 @@ class LostPICCompareKoji(TestCompareKoji):
 
         self.after_rpm.add_source(rpmfluff.SourceFile("simple.c", test_library_source))
         self.after_rpm.section_build += (
-            "gcc -m32 -shared -fno-PIC -o simple.o simple.c\n"
+            "cc -m32 -shared -fno-PIC -o simple.o simple.c\n"
         )
         self.after_rpm.section_build += "chmod 0644 simple.o\n"
         self.after_rpm.section_build += "ar -crs libsimple.a simple.o\n"
@@ -822,7 +822,7 @@ class LostPICCompareKoji(TestCompareKoji):
 
 # Program has or gained TEXTREL relocations (32-bit arches only)
 class HasTEXTRELRPMs(TestRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -831,7 +831,7 @@ class HasTEXTRELRPMs(TestRPMs):
         # Can't use rpmfluff here because it always adds -fPIC
         self.rpm.add_source(rpmfluff.SourceFile("simple.c", simple_library_source))
         self.rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.rpm.create_parent_dirs(installPath)
         self.rpm.section_install += "cp libsimple.so $RPM_BUILD_ROOT/%s\n" % installPath
@@ -845,7 +845,7 @@ class HasTEXTRELRPMs(TestRPMs):
 
 
 class SecuritySKIPHasTEXTRELRPMs(TestRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -854,7 +854,7 @@ class SecuritySKIPHasTEXTRELRPMs(TestRPMs):
         # Can't use rpmfluff here because it always adds -fPIC
         self.rpm.add_source(rpmfluff.SourceFile("simple.c", simple_library_source))
         self.rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.rpm.create_parent_dirs(installPath)
         self.rpm.section_install += "cp libsimple.so $RPM_BUILD_ROOT/%s\n" % installPath
@@ -867,7 +867,7 @@ class SecuritySKIPHasTEXTRELRPMs(TestRPMs):
 
 
 class SecurityINFORMHasTEXTRELRPMs(TestRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -876,7 +876,7 @@ class SecurityINFORMHasTEXTRELRPMs(TestRPMs):
         # Can't use rpmfluff here because it always adds -fPIC
         self.rpm.add_source(rpmfluff.SourceFile("simple.c", simple_library_source))
         self.rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.rpm.create_parent_dirs(installPath)
         self.rpm.section_install += "cp libsimple.so $RPM_BUILD_ROOT/%s\n" % installPath
@@ -890,7 +890,7 @@ class SecurityINFORMHasTEXTRELRPMs(TestRPMs):
 
 
 class SecurityVERIFYHasTEXTRELRPMs(TestRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -899,7 +899,7 @@ class SecurityVERIFYHasTEXTRELRPMs(TestRPMs):
         # Can't use rpmfluff here because it always adds -fPIC
         self.rpm.add_source(rpmfluff.SourceFile("simple.c", simple_library_source))
         self.rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.rpm.create_parent_dirs(installPath)
         self.rpm.section_install += "cp libsimple.so $RPM_BUILD_ROOT/%s\n" % installPath
@@ -913,7 +913,7 @@ class SecurityVERIFYHasTEXTRELRPMs(TestRPMs):
 
 
 class SecurityFAILHasTEXTRELRPMs(TestRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -922,7 +922,7 @@ class SecurityFAILHasTEXTRELRPMs(TestRPMs):
         # Can't use rpmfluff here because it always adds -fPIC
         self.rpm.add_source(rpmfluff.SourceFile("simple.c", simple_library_source))
         self.rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.rpm.create_parent_dirs(installPath)
         self.rpm.section_install += "cp libsimple.so $RPM_BUILD_ROOT/%s\n" % installPath
@@ -936,7 +936,7 @@ class SecurityFAILHasTEXTRELRPMs(TestRPMs):
 
 
 class HasTEXTRELCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -947,7 +947,7 @@ class HasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -961,7 +961,7 @@ class HasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (
@@ -977,7 +977,7 @@ class HasTEXTRELCompareRPMs(TestCompareRPMs):
 
 
 class SecuritySKIPHasTEXTRELCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -988,7 +988,7 @@ class SecuritySKIPHasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -1002,7 +1002,7 @@ class SecuritySKIPHasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (
@@ -1017,7 +1017,7 @@ class SecuritySKIPHasTEXTRELCompareRPMs(TestCompareRPMs):
 
 
 class SecurityINFORMHasTEXTRELCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -1028,7 +1028,7 @@ class SecurityINFORMHasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -1042,7 +1042,7 @@ class SecurityINFORMHasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (
@@ -1058,7 +1058,7 @@ class SecurityINFORMHasTEXTRELCompareRPMs(TestCompareRPMs):
 
 
 class SecurityVERIFYHasTEXTRELCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -1069,7 +1069,7 @@ class SecurityVERIFYHasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -1083,7 +1083,7 @@ class SecurityVERIFYHasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (
@@ -1099,7 +1099,7 @@ class SecurityVERIFYHasTEXTRELCompareRPMs(TestCompareRPMs):
 
 
 class SecurityFAILHasTEXTRELCompareRPMs(TestCompareRPMs):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -1110,7 +1110,7 @@ class SecurityFAILHasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -1124,7 +1124,7 @@ class SecurityFAILHasTEXTRELCompareRPMs(TestCompareRPMs):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (
@@ -1140,7 +1140,7 @@ class SecurityFAILHasTEXTRELCompareRPMs(TestCompareRPMs):
 
 
 class HasTEXTRELCompareKoji(TestCompareKoji):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -1151,7 +1151,7 @@ class HasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -1165,7 +1165,7 @@ class HasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (
@@ -1181,7 +1181,7 @@ class HasTEXTRELCompareKoji(TestCompareKoji):
 
 
 class SecuritySKIPHasTEXTRELCompareKoji(TestCompareKoji):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -1192,7 +1192,7 @@ class SecuritySKIPHasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -1206,7 +1206,7 @@ class SecuritySKIPHasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (
@@ -1221,7 +1221,7 @@ class SecuritySKIPHasTEXTRELCompareKoji(TestCompareKoji):
 
 
 class SecurityINFORMHasTEXTRELCompareKoji(TestCompareKoji):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -1232,7 +1232,7 @@ class SecurityINFORMHasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -1246,7 +1246,7 @@ class SecurityINFORMHasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (
@@ -1262,7 +1262,7 @@ class SecurityINFORMHasTEXTRELCompareKoji(TestCompareKoji):
 
 
 class SecurityVERIFYHasTEXTRELCompareKoji(TestCompareKoji):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -1273,7 +1273,7 @@ class SecurityVERIFYHasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -1287,7 +1287,7 @@ class SecurityVERIFYHasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (
@@ -1303,7 +1303,7 @@ class SecurityVERIFYHasTEXTRELCompareKoji(TestCompareKoji):
 
 
 class SecurityFAILHasTEXTRELCompareKoji(TestCompareKoji):
-    @unittest.skipUnless(have_gcc_multilib, "gcc lacks multilib (-m32) support")
+    @unittest.skipUnless(have_multilib, "cc lacks multilib (-m32) support")
     def setUp(self):
         super().setUp()
 
@@ -1314,7 +1314,7 @@ class SecurityFAILHasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.before_rpm.section_build += (
-            "gcc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fPIC -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.before_rpm.create_parent_dirs(installPath)
         self.before_rpm.section_install += (
@@ -1328,7 +1328,7 @@ class SecurityFAILHasTEXTRELCompareKoji(TestCompareKoji):
             rpmfluff.SourceFile("simple.c", simple_library_source)
         )
         self.after_rpm.section_build += (
-            "gcc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
+            "cc -m32 -fno-pic -shared -Wl,-z,noexecstack -o libsimple.so simple.c\n"
         )
         self.after_rpm.create_parent_dirs(installPath)
         self.after_rpm.section_install += (

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -21,7 +21,7 @@ class ValidFilesSectionSRPM(TestSRPM):
         libraryName = "libfoo.so"
         sourceFileName = "foo.c"
         self.rpm.add_source(rpmfluff.SourceFile(sourceFileName, simple_library_source))
-        self.rpm.section_build += "gcc --shared -fPIC -o %s %s %s\n" % (
+        self.rpm.section_build += "cc --shared -fPIC -o %s %s %s\n" % (
             libraryName,
             "",
             sourceFileName,
@@ -47,7 +47,7 @@ class ValidFilesSectionKoji(TestKoji):
         libraryName = "libfoo.so"
         sourceFileName = "foo.c"
         self.rpm.add_source(rpmfluff.SourceFile(sourceFileName, simple_library_source))
-        self.rpm.section_build += "gcc --shared -fPIC -o %s %s %s\n" % (
+        self.rpm.section_build += "cc --shared -fPIC -o %s %s %s\n" % (
             libraryName,
             "",
             sourceFileName,
@@ -75,7 +75,7 @@ class ValidFilesSectionCompareSRPM(TestCompareSRPM):
         self.after_rpm.add_source(
             rpmfluff.SourceFile(sourceFileName, simple_library_source)
         )
-        self.after_rpm.section_build += "gcc --shared -fPIC -o %s %s %s\n" % (
+        self.after_rpm.section_build += "cc --shared -fPIC -o %s %s %s\n" % (
             libraryName,
             "",
             sourceFileName,
@@ -103,7 +103,7 @@ class ValidFilesSectionCompareKoji(TestCompareKoji):
         self.after_rpm.add_source(
             rpmfluff.SourceFile(sourceFileName, simple_library_source)
         )
-        self.after_rpm.section_build += "gcc --shared -fPIC -o %s %s %s\n" % (
+        self.after_rpm.section_build += "cc --shared -fPIC -o %s %s %s\n" % (
             libraryName,
             "",
             sourceFileName,

--- a/test/test_lto.py
+++ b/test/test_lto.py
@@ -14,8 +14,8 @@ lto_src = open(datadir + "/mathlib.c").read()
 
 # NOTE: The add_simple_compilation() calls to rpmfluff use '-o a.out' in
 # the compileFlags due to a limitation in rpmfluff.  It always tries to
-# copy a compiled file by the name of 'a.out' so if you are invoking gcc
-# to compile a .o, you need to tell gcc to name the output a.out otherwise
+# copy a compiled file by the name of 'a.out' so if you are invoking cc
+# to compile a .o, you need to tell cc to name the output a.out otherwise
 # rpmfluff will fail.  This does not impact ELF executables which is the
 # more common use.
 


### PR DESCRIPTION
Drop the requirement for gcc on FreeBSD.  This required an upstream patch to rpm:

    https://github.com/rpm-software-management/rpm/pull/2459

And also modification of librpminspect, the build scripts, and some test scripts.