### PR TITLE
Implement the 'virus' security rule type

### DIFF
--- a/data/security/GENERIC
+++ b/data/security/GENERIC
@@ -39,6 +39,7 @@
 #     securitypath   Check for loss of file(s) that belong in a security
 #                    path prefix.
 #     modes          Check for expected file ownership and permissions.
+#     virus          Check for libclamav finding a virus signature.
 #
 # Available ACTIONS (case-insensitive in the config file):
 #

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -425,6 +425,8 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 /* secrule.c */
 security_entry_t *get_secrule_by_path(struct rpminspect *ri, const rpmfile_entry_t *file);
 severity_t get_secrule_result_severity(struct rpminspect *ri, const rpmfile_entry_t *file, const int type);
+secrule_type_t get_secrule_type(const char *s);
+severity_t get_secrule_severity(const char *s);
 
 /* deprules.c */
 deprule_list_t *gather_deprules(Header hdr, deprule_ignore_map_t *ignores);

--- a/include/secrules.h
+++ b/include/secrules.h
@@ -77,7 +77,13 @@ typedef enum _secrule_type_t {
      * modes
      * File mode does not match expected mode from the fileinfo rules.
      */
-    SECRULE_MODES = 10
+    SECRULE_MODES = 10,
+
+    /*
+     * virus
+     * File contains a virus found by libclamav.
+     */
+    SECRULE_VIRUS = 11
 } secrule_type_t;
 
 #endif

--- a/include/secrules.h
+++ b/include/secrules.h
@@ -13,69 +13,71 @@
  * rule type (e.g., "caps" or "fortifysource").
  */
 
-/* only used to indicate an unknown rule */
-#define SECRULE_NULL 0
+typedef enum _secrule_type_t {
+    /* only used to indicate an unknown rule */
+    SECRULE_NULL = 0,
 
-/*
- * caps
- * Any inspection that looks at capabilities(7) values.
- */
-#define SECRULE_CAPS 1
+    /*
+     * caps
+     * Any inspection that looks at capabilities(7) values.
+     */
+    SECRULE_CAPS = 1,
 
-/*
- * execstack
- * ELF object contains an executable stack or built without
- * GNU_STACK.
- */
-#define SECRULE_EXECSTACK 2
+    /*
+     * execstack
+     * ELF object contains an executable stack or built without
+     * GNU_STACK.
+     */
+    SECRULE_EXECSTACK = 2,
 
-/*
- * relro
- * ELF object loses partial or full GNU_RELRO protection.
- */
-#define SECRULE_RELRO 3
+    /*
+     * relro
+     * ELF object loses partial or full GNU_RELRO protection.
+     */
+    SECRULE_RELRO = 3,
 
-/*
- * fortifysource
- * ELF object loses -D_FORTIFY_SOURCE protection.
- */
-#define SECRULE_FORTIFYSOURCE 4
+    /*
+     * fortifysource
+     * ELF object loses -D_FORTIFY_SOURCE protection.
+     */
+    SECRULE_FORTIFYSOURCE = 4,
 
-/*
- * pic
- * ELF objects in static libraries built without -fPIC
- */
-#define SECRULE_PIC 5
+    /*
+     * pic
+     * ELF objects in static libraries built without -fPIC
+     */
+    SECRULE_PIC = 5,
 
-/*
- * textrel
- * ELF object has TEXTREL relocations.
- */
-#define SECRULE_TEXTREL 6
+    /*
+     * textrel
+     * ELF object has TEXTREL relocations.
+     */
+    SECRULE_TEXTREL = 6,
 
-/*
- * setuid
- * File has CAP_SETUID but is group writable.
- */
-#define SECRULE_SETUID 7
+    /*
+     * setuid
+     * File has CAP_SETUID but is group writable.
+     */
+    SECRULE_SETUID = 7,
 
-/*
- * worldwritable
- * File or directory is world writable.
- */
-#define SECRULE_WORLDWRITABLE 8
+    /*
+     * worldwritable
+     * File or directory is world writable.
+     */
+    SECRULE_WORLDWRITABLE = 8,
 
-/*
- * securitypath
- * File is removed but belonged in a security path prefix as
- * defined in the configuration file.
- */
-#define SECRULE_SECURITYPATH 9
+    /*
+     * securitypath
+     * File is removed but belonged in a security path prefix as
+     * defined in the configuration file.
+     */
+    SECRULE_SECURITYPATH = 9,
 
-/*
- * modes
- * File mode does not match expected mode from the fileinfo rules.
- */
-#define SECRULE_MODES 10
+    /*
+     * modes
+     * File mode does not match expected mode from the fileinfo rules.
+     */
+    SECRULE_MODES = 10
+} secrule_type_t;
 
 #endif

--- a/lib/init.c
+++ b/lib/init.c
@@ -1327,8 +1327,8 @@ bool init_security(struct rpminspect *ri)
     string_list_t *kv = NULL;
     string_entry_t *key = NULL;
     string_entry_t *value = NULL;
-    int stype;
-    severity_t severity;
+    secrule_type_t stype = SECRULE_NULL;
+    severity_t severity = RESULT_NULL;
     security_entry_t *sentry = NULL;
     secrule_t *rule_entry = NULL;
 
@@ -1428,29 +1428,7 @@ bool init_security(struct rpminspect *ri)
                 value = TAILQ_LAST(kv, string_entry_s);
 
                 /* find the rule */
-                if (!strcasecmp(key->data, "caps")) {
-                    stype = SECRULE_CAPS;
-                } else if (!strcasecmp(key->data, "execstack")) {
-                    stype = SECRULE_EXECSTACK;
-                } else if (!strcasecmp(key->data, "relro")) {
-                    stype = SECRULE_RELRO;
-                } else if (!strcasecmp(key->data, "fortifysource")) {
-                    stype = SECRULE_FORTIFYSOURCE;
-                } else if (!strcasecmp(key->data, "pic")) {
-                    stype = SECRULE_PIC;
-                } else if (!strcasecmp(key->data, "textrel")) {
-                    stype = SECRULE_TEXTREL;
-                } else if (!strcasecmp(key->data, "setuid")) {
-                    stype = SECRULE_SETUID;
-                } else if (!strcasecmp(key->data, "worldwritable")) {
-                    stype = SECRULE_WORLDWRITABLE;
-                } else if (!strcasecmp(key->data, "securitypath")) {
-                    stype = SECRULE_SECURITYPATH;
-                } else if (!strcasecmp(key->data, "modes")) {
-                    stype = SECRULE_MODES;
-                } else {
-                    stype = SECRULE_NULL;
-                }
+                stype = get_secrule_type(key->data);
 
                 if (stype == SECRULE_NULL) {
                     warnx(_("*** unknown security rule: %s"), key->data);
@@ -1459,18 +1437,7 @@ bool init_security(struct rpminspect *ri)
                 }
 
                 /* find the action */
-                if (!strcasecmp(value->data, "skip")) {
-                    severity = RESULT_SKIP;
-                } else if (!strcasecmp(value->data, "inform")) {
-                    severity = RESULT_INFO;
-                } else if (!strcasecmp(value->data, "verify")) {
-                    severity = RESULT_VERIFY;
-                } else if (!strcasecmp(value->data, "fail")) {
-                    severity = RESULT_BAD;
-                } else {
-                    /* unknown text was present */
-                    severity = RESULT_NULL;
-                }
+                severity = get_secrule_severity(value->data);
 
                 if (severity == RESULT_NULL) {
                     warnx(_("*** unknown security action: %s"), value->data);

--- a/lib/secrule.c
+++ b/lib/secrule.c
@@ -123,6 +123,8 @@ secrule_type_t get_secrule_type(const char *s)
         return SECRULE_SECURITYPATH;
     } else if (!strcasecmp(s, "modes")) {
         return SECRULE_MODES;
+    } else if (!strcasecmp(s, "virus")) {
+        return SECRULE_VIRUS;
     } else {
         return SECRULE_NULL;
     }

--- a/lib/secrule.c
+++ b/lib/secrule.c
@@ -92,3 +92,60 @@ severity_t get_secrule_result_severity(struct rpminspect *ri, const rpmfile_entr
     /* nothing found for this type, default result */
     return RESULT_BAD;
 }
+
+/*
+ * Given a secrule name from a configuration file, return the
+ * secrule_type_t value.
+ */
+secrule_type_t get_secrule_type(const char *s)
+{
+    if (s == NULL) {
+        return SECRULE_NULL;
+    }
+
+    if (!strcasecmp(s, "caps")) {
+        return SECRULE_CAPS;
+    } else if (!strcasecmp(s, "execstack")) {
+        return SECRULE_EXECSTACK;
+    } else if (!strcasecmp(s, "relro")) {
+        return SECRULE_RELRO;
+    } else if (!strcasecmp(s, "fortifysource")) {
+        return SECRULE_FORTIFYSOURCE;
+    } else if (!strcasecmp(s, "pic")) {
+        return SECRULE_PIC;
+    } else if (!strcasecmp(s, "textrel")) {
+        return SECRULE_TEXTREL;
+    } else if (!strcasecmp(s, "setuid")) {
+        return SECRULE_SETUID;
+    } else if (!strcasecmp(s, "worldwritable")) {
+        return SECRULE_WORLDWRITABLE;
+    } else if (!strcasecmp(s, "securitypath")) {
+        return SECRULE_SECURITYPATH;
+    } else if (!strcasecmp(s, "modes")) {
+        return SECRULE_MODES;
+    } else {
+        return SECRULE_NULL;
+    }
+}
+
+/*
+ * Like getseverity(), but for the security rules.
+ */
+severity_t get_secrule_severity(const char *s)
+{
+    if (s == NULL) {
+        return RESULT_NULL;
+    }
+
+    if (!strcasecmp(s, "skip")) {
+        return RESULT_SKIP;
+    } else if (!strcasecmp(s, "inform")) {
+        return RESULT_INFO;
+    } else if (!strcasecmp(s, "verify")) {
+        return RESULT_VERIFY;
+    } else if (!strcasecmp(s, "fail")) {
+        return RESULT_BAD;
+    } else {
+        return RESULT_NULL;
+    }
+}

--- a/test/data/security/GENERIC
+++ b/test/data/security/GENERIC
@@ -47,3 +47,13 @@
 
 # ignore everything about the build-id files
 /usr/lib/.build-id     *           *           *           caps=SKIP,execstack=SKIP,relro=SKIP,fortifysource=SKIP,pic=SKIP,textrel=SKIP,setuid=SKIP,worldwritable=SKIP,securitypath=SKIP,modes=SKIP
+
+# for virus tests
+/usr/lib/wrskip.o      vaporware   *           *           virus=SKIP
+wrskip.pas             vaporware   *           *           virus=SKIP
+/usr/lib/wrinform.o    vaporware   *           *           virus=INFORM
+wrinform.pas           vaporware   *           *           virus=INFORM
+/usr/lib/wrverify.o    vaporware   *           *           virus=VERIFY
+wrverify.pas           vaporware   *           *           virus=VERIFY
+/usr/lib/wrfail.o      vaporware   *           *           virus=FAIL
+wrfail.pas             vaporware   *           *           virus=FAIL

--- a/test/test_virus.py
+++ b/test/test_virus.py
@@ -205,3 +205,159 @@ class HasVirusCompareKoji(TestCompareKoji):
 
     def runTest(self):
         super().runTest()
+
+
+class HasKnownVirusSkipRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_fake_virus("usr/lib/wrskip.o", "wrskip.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "OK"
+
+
+class HasKnownVirusSkipCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_fake_virus("usr/lib/wrskip.o", "wrskip.pas", mode="0755")
+        self.after_rpm.add_fake_virus("usr/lib/wrskip.o", "wrskip.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "OK"
+
+
+class HasKnownVirusSkipKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_fake_virus("usr/lib/wrskip.o", "wrskip.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "OK"
+
+
+class HasKnownVirusSkipCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_fake_virus("usr/lib/wrskip.o", "wrskip.pas", mode="0755")
+        self.after_rpm.add_fake_virus("usr/lib/wrskip.o", "wrskip.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "OK"
+
+
+class HasKnownVirusInformRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_fake_virus("usr/lib/wrinform.o", "wrinform.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class HasKnownVirusInformCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_fake_virus(
+            "usr/lib/wrinform.o", "wrinform.pas", mode="0755"
+        )
+        self.after_rpm.add_fake_virus("usr/lib/wrinform.o", "wrinform.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class HasKnownVirusInformKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_fake_virus("usr/lib/wrinform.o", "wrinform.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class HasKnownVirusInformCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_fake_virus(
+            "usr/lib/wrinform.o", "wrinform.pas", mode="0755"
+        )
+        self.after_rpm.add_fake_virus("usr/lib/wrinform.o", "wrinform.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class HasKnownVirusVerifyRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_fake_virus("usr/lib/wrverify.o", "wrverify.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "VERIFY"
+        self.waiver_auth = "Security"
+
+
+class HasKnownVirusVerifyCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_fake_virus(
+            "usr/lib/wrverify.o", "wrverify.pas", mode="0755"
+        )
+        self.after_rpm.add_fake_virus("usr/lib/wrverify.o", "wrverify.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "VERIFY"
+        self.waiver_auth = "Security"
+
+
+class HasKnownVirusVerifyKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_fake_virus("usr/lib/wrverify.o", "wrverify.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "VERIFY"
+        self.waiver_auth = "Security"
+
+
+class HasKnownVirusVerifyCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_fake_virus(
+            "usr/lib/wrverify.o", "wrverify.pas", mode="0755"
+        )
+        self.after_rpm.add_fake_virus("usr/lib/wrverify.o", "wrverify.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "VERIFY"
+        self.waiver_auth = "Security"
+
+
+class HasKnownVirusFailRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_fake_virus("usr/lib/wrfail.o", "wrfail.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class HasKnownVirusFailCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_fake_virus("usr/lib/wrfail.o", "wrfail.pas", mode="0755")
+        self.after_rpm.add_fake_virus("usr/lib/wrfail.o", "wrfail.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class HasKnownVirusFailKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_fake_virus("usr/lib/wrfail.o", "wrfail.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class HasKnownVirusFailCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_fake_virus("usr/lib/wrfail.o", "wrfail.pas", mode="0755")
+        self.after_rpm.add_fake_virus("usr/lib/wrfail.o", "wrfail.pas", mode="0755")
+        self.inspection = "virus"
+        self.result = "BAD"
+        self.waiver_auth = "Security"


### PR DESCRIPTION
As described in #1026, this implements a 'virus' security rule type that can be SKIP, INFORM, VERIFY, or FAIL per file or path glob pattern.  This works for source and binary packages.