### PR TITLE
Add support for the "unicode" security rule type

### DIFF
--- a/data/security/GENERIC
+++ b/data/security/GENERIC
@@ -40,6 +40,7 @@
 #                    path prefix.
 #     modes          Check for expected file ownership and permissions.
 #     virus          Check for libclamav finding a virus signature.
+#     unicode        Check for forbidden Unicode code points in source files.
 #
 # Available ACTIONS (case-insensitive in the config file):
 #

--- a/include/secrules.h
+++ b/include/secrules.h
@@ -83,7 +83,14 @@ typedef enum _secrule_type_t {
      * virus
      * File contains a virus found by libclamav.
      */
-    SECRULE_VIRUS = 11
+    SECRULE_VIRUS = 11,
+
+    /*
+     * unicode
+     * File contains a forbidden Unicode code point as defined in the
+     * configuration file.
+     */
+    SECRULE_UNICODE = 12
 } secrule_type_t;
 
 #endif

--- a/lib/secrule.c
+++ b/lib/secrule.c
@@ -125,6 +125,8 @@ secrule_type_t get_secrule_type(const char *s)
         return SECRULE_MODES;
     } else if (!strcasecmp(s, "virus")) {
         return SECRULE_VIRUS;
+    } else if (!strcasecmp(s, "unicode")) {
+        return SECRULE_UNICODE;
     } else {
         return SECRULE_NULL;
     }

--- a/test/data/security/GENERIC
+++ b/test/data/security/GENERIC
@@ -57,3 +57,9 @@ wrinform.pas           vaporware   *           *           virus=INFORM
 wrverify.pas           vaporware   *           *           virus=VERIFY
 /usr/lib/wrfail.o      vaporware   *           *           virus=FAIL
 wrfail.pas             vaporware   *           *           virus=FAIL
+
+# for unicode tests
+badskip.c              vaporware   *           *           unicode=SKIP
+badinform.c            vaporware   *           *           unicode=INFORM
+badverify.c            vaporware   *           *           unicode=VERIFY
+badfail.c              vaporware   *           *           unicode=FAIL

--- a/test/test_unicode.py
+++ b/test/test_unicode.py
@@ -3351,3 +3351,452 @@ class UnicodeBadStretchStringSourceArchiveCompareBadPrepSRPM(TestCompareSRPM):
         self.inspection = "unicode"
         self.waiver_auth = "Security"
         self.result = "BAD"
+
+
+# The following tests handle the unicode= security rules that may be present
+class UnicodeBadCSourceSkipSecRuleSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(
+            ProvidedSourceFile("badskip.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        # the known bad file is skipped here, so unicode result should be 'OK'
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeBadCSourceSkipSecRuleKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(
+            ProvidedSourceFile("badskip.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        # the known bad file is skipped here, so unicode result should be 'OK'
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeBadCSourceCompareSkipSecRuleSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            ProvidedSourceFile("badskip.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+        self.after_rpm.add_source(
+            ProvidedSourceFile("badskip.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        # the known bad file is skipped here, so unicode result should be 'OK'
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeBadCSourceCompareSkipSecRuleKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            ProvidedSourceFile("badskip.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+        self.after_rpm.add_source(
+            ProvidedSourceFile("badskip.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        # the known bad file is skipped here, so unicode result should be 'OK'
+        self.inspection = "unicode"
+        self.result = "OK"
+
+
+class UnicodeBadCSourceInformSecRuleSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(
+            ProvidedSourceFile("badinform.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Not Waivable"
+        self.result = "INFO"
+
+
+class UnicodeBadCSourceInformSecRuleKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(
+            ProvidedSourceFile("badinform.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Not Waivable"
+        self.result = "INFO"
+
+
+class UnicodeBadCSourceCompareInformSecRuleSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            ProvidedSourceFile("badinform.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+        self.after_rpm.add_source(
+            ProvidedSourceFile("badinform.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Not Waivable"
+        self.result = "INFO"
+
+
+class UnicodeBadCSourceCompareInformSecRuleKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            ProvidedSourceFile("badinform.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+        self.after_rpm.add_source(
+            ProvidedSourceFile("badinform.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Not Waivable"
+        self.result = "INFO"
+
+
+class UnicodeBadCSourceVerifySecRuleSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(
+            ProvidedSourceFile("badverify.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "VERIFY"
+
+
+class UnicodeBadCSourceVerifySecRuleKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(
+            ProvidedSourceFile("badverify.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "VERIFY"
+
+
+class UnicodeBadCSourceCompareVerifySecRuleSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            ProvidedSourceFile("badverify.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+        self.after_rpm.add_source(
+            ProvidedSourceFile("badverify.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "VERIFY"
+
+
+class UnicodeBadCSourceCompareVerifySecRuleKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            ProvidedSourceFile("badverify.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+        self.after_rpm.add_source(
+            ProvidedSourceFile("badverify.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "VERIFY"
+
+
+class UnicodeBadCSourceFailSecRuleSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(
+            ProvidedSourceFile("badfail.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCSourceFailSecRuleKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.rpm.add_source(
+            ProvidedSourceFile("badfail.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCSourceCompareFailSecRuleSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            ProvidedSourceFile("badfail.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+        self.after_rpm.add_source(
+            ProvidedSourceFile("badfail.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"
+
+
+class UnicodeBadCSourceCompareFailSecRuleKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # this creates enough of a spec file to appease rpmbuild
+        self.before_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/status",
+            ProvidedSourceFile(
+                "status.sh", os.path.join(datadir, "unicode", "status.sh")
+            ),
+            mode=755,
+        )
+
+        # drop our known bad source files directly in the SRPM
+        self.before_rpm.add_source(
+            ProvidedSourceFile("badfail.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+        self.after_rpm.add_source(
+            ProvidedSourceFile("badfail.c", os.path.join(datadir, "unicode", "bad.c"))
+        )
+
+        self.inspection = "unicode"
+        self.waiver_auth = "Security"
+        self.result = "BAD"


### PR DESCRIPTION
Notes in the individual commits.  This is similar to the PR that I did yesterday to add a virus security rule type.

Fixes: #996