### PR TITLE
[lib] Show local rpminspect config file in diagnostics output

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -462,6 +462,8 @@ typedef struct _applied_patches_t {
 struct rpminspect {
     char *progname;            /* Full path to the program */
     string_list_t *cfgfiles;   /* list of full path config files read (in order) */
+    char *localcfg;            /* Name of the optional local config file */
+    string_list_t *locallines; /* Contents of optional local config file */
     char *workdir;             /* full path to working directory */
     char *profiledir;          /* full path to profiles directory */
     char *worksubdir;          /* within workdir, where these builds go */

--- a/lib/free.c
+++ b/lib/free.c
@@ -97,6 +97,8 @@ void free_rpminspect(struct rpminspect *ri)
 
     free(ri->progname);
     list_free(ri->cfgfiles, free);
+    free(ri->localcfg);
+    list_free(ri->locallines, free);
     free(ri->workdir);
     free(ri->kojihub);
     free(ri->kojiursine);

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -896,6 +896,15 @@ int main(int argc, char **argv)
     free(params.msg);
     free(params.details);
 
+    /* report optional local configuration file */
+    if (ri->localcfg && ri->locallines && !TAILQ_EMPTY(ri->locallines)) {
+        xasprintf(&params.msg, _("Local configuration file: %s"), ri->localcfg);
+        params.details = list_to_string(ri->locallines, "\n");
+        add_result_entry(&ri->results, &params);
+        free(params.msg);
+        free(params.details);
+    }
+
     /* make sure the worst result is set before running inspections */
     ri->worst_result = params.severity;
 


### PR DESCRIPTION
If a local rpminspect.yaml (or json or dson) file is present, add that to the DIAGNOSTICS reporting output so that users can see that rpminspect read in those settings.  The -D option dumps the effective configuration at runtime, which is the result of reading the main config file, optional profile, and optional local config file in that order.

Fixes: #925