### PR TITLE
[fix] General memory management cleanups in librpminspect

### DIFF
--- a/lib/inspect_debuginfo.c
+++ b/lib/inspect_debuginfo.c
@@ -329,10 +329,10 @@ static bool debuginfo_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             add_result(ri, &params);
             free(params.msg);
-
-            close(fd);
-            elf_end(elf);
         }
+
+        close(fd);
+        elf_end(elf);
     }
 
     free(nvr);

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -10,6 +10,7 @@
 #include <rpm/rpmlib.h>
 #include <rpm/rpmts.h>
 #include <rpm/header.h>
+#include <rpm/rpmmacro.h>
 #include <archive.h>
 #include <archive_entry.h>
 
@@ -26,6 +27,8 @@ int init_librpm(struct rpminspect *ri)
         return RPMRC_OK;
     }
 
+    rpmFreeMacros(NULL);
+    rpmFreeRpmrc();
     result = rpmReadConfigFiles(NULL, NULL);
     ri->librpm_initialized = true;
 


### PR DESCRIPTION
These are focused around forking and execing subprocesses and using librpm.