### PR TITLE
[fix] Include libgen.h in init.c (for basename)

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+#include <libgen.h>
 #include <regex.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Implicit definition is forbidden by C99.