### PR TITLE
[PATCH] [fix] Drop duplicate fileinfo checks from 'addedfiles'

### DIFF
--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -221,12 +221,6 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
     }
 
-    /* Check for any new setuid or setgid files */
-    if (!S_ISDIR(file->st.st_mode) && (file->st.st_mode & (S_ISUID|S_ISGID))) {
-        match_fileinfo_mode(ri, file, NAME_ADDEDFILES, remedy_addedfiles, &result, &reported);
-        goto done;
-    }
-
     /*
      * Report that a new file has been added in a build comparison.
      */

--- a/test/test_addedfiles.py
+++ b/test/test_addedfiles.py
@@ -168,65 +168,6 @@ class ForbiddenDirectoryCompareKoji(TestCompareKoji):
         self.waiver_auth = "Anyone"
 
 
-# Expected security mode as defined in fileinfo -> INFO
-class ExpectedSecurityModeRPMs(TestRPMs):
-    def setUp(self):
-        super().setUp()
-
-        self.rpm.add_installed_file(
-            "usr/bin/mount", rpmfluff.SourceFile("mount.bin", ri_bytes), mode="4755"
-        )
-
-        self.inspection = "addedfiles"
-        self.result = "INFO"
-        self.waiver_auth = "Not Waivable"
-
-
-class ExpectedSecurityModeKoji(TestKoji):
-    def setUp(self):
-        super().setUp()
-
-        self.rpm.add_installed_file(
-            "usr/bin/mount", rpmfluff.SourceFile("mount.bin", ri_bytes), mode="4755"
-        )
-
-        self.inspection = "addedfiles"
-        self.result = "INFO"
-        self.waiver_auth = "Not Waivable"
-
-
-class ExpectedSecurityModeCompareRPMs(TestCompareRPMs):
-    def setUp(self):
-        super().setUp()
-
-        self.before_rpm.add_installed_file(
-            "usr/bin/mount", rpmfluff.SourceFile("mount.bin", ri_bytes), mode="4755"
-        )
-        self.after_rpm.add_installed_file(
-            "usr/bin/mount", rpmfluff.SourceFile("mount.bin", ri_bytes), mode="4755"
-        )
-
-        self.inspection = "addedfiles"
-        self.result = "INFO"
-        self.waiver_auth = "Not Waivable"
-
-
-class ExpectedSecurityModeCompareKoji(TestCompareKoji):
-    def setUp(self):
-        super().setUp()
-
-        self.before_rpm.add_installed_file(
-            "usr/bin/mount", rpmfluff.SourceFile("mount.bin", ri_bytes), mode="4755"
-        )
-        self.after_rpm.add_installed_file(
-            "usr/bin/mount", rpmfluff.SourceFile("mount.bin", ri_bytes), mode="4755"
-        )
-
-        self.inspection = "addedfiles"
-        self.result = "INFO"
-        self.waiver_auth = "Not Waivable"
-
-
 # Unexpected security file (not defined in fileinfo) -> BAD
 # This check only happens for comparison runs because rpminspect needs a
 # before build to know that something new was added.

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -31,6 +31,7 @@ class ExecutableWithSetUIDSRPM(TestSRPM):
         )
 
         self.inspection = "permissions"
+        # SRPM is a no-op
         self.result = "OK"
 
 
@@ -84,6 +85,7 @@ class ExecutableWithSetUIDCompareSRPM(TestCompareSRPM):
         )
 
         self.inspection = "permissions"
+        # SRPM is a no-op
         self.result = "OK"
 
 


### PR DESCRIPTION
The fileinfo permissions checks were in both the permissions and addedfiles inspections.  We only need them in the permissions inspection.

Fixes: #1105