### PR TITLE
[tst] Add unit test for humansize.c

### DIFF
--- a/test/lib/test-humansize.c
+++ b/test/lib/test-humansize.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <CUnit/Basic.h>
+#include "rpminspect.h"
+
+#include "test-main.h"
+
+
+int init_test_humansize(void) {
+    return 0;
+}
+
+int clean_test_humansize(void) {
+    return 0;
+}
+
+void test_humansize(void) {
+    RI_ASSERT_EQUAL(strncmp(human_size(12), "12 B", 4), 0);
+    RI_ASSERT_EQUAL(strncmp(human_size(12288), "12 KiB", 6), 0);
+    RI_ASSERT_EQUAL(strncmp(human_size(12582912), "12 MiB", 6), 0);
+    RI_ASSERT_EQUAL(strncmp(human_size(3221225472), "3 GiB", 5), 0);
+    RI_ASSERT_NOT_EQUAL(strncmp(human_size(13), "12 B", 4), 0);
+    RI_ASSERT_NOT_EQUAL(strncmp(human_size(13288), "12 KiB", 6), 0);
+    RI_ASSERT_NOT_EQUAL(strncmp(human_size(13582912), "12 MiB", 6), 0);
+    RI_ASSERT_NOT_EQUAL(strncmp(human_size(2147483648), "3 GiB", 5), 0);
+}
+
+CU_pSuite get_suite(void) {
+    CU_pSuite pSuite = NULL;
+
+    /* add a suite to the registry */
+    pSuite = CU_add_suite("humansize", init_test_humansize, clean_test_humansize);
+    if (pSuite == NULL) {
+        return NULL;
+    }
+
+    /* add tests to the suite */
+    if (CU_add_test(pSuite, "test human_size()", test_humansize) == NULL) {
+        return NULL;
+    }
+
+    return pSuite;
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -79,6 +79,16 @@ if cunit.found()
         link_with : [ librpminspect ],
     )
 
+    test_humansize = executable(
+        'test-humansize',
+        ['lib/test-humansize.c',
+         'lib/test-main.c'],
+        include_directories : inc,
+        dependencies : [ cunit, libkmod ],
+        c_args : '-D_BUILDDIR_="@0@"'.format(meson.current_build_dir()),
+        link_with : [ librpminspect ],
+    )
+
     # Support program used by test-inspect-elf
     execstack_prog = executable(
         'execstack',
@@ -103,6 +113,7 @@ if cunit.found()
          depends : [execstack_prog, noexecstack_prog]
     )
     test('test-abspath', test_abspath)
+    test('test-humansize', test_humansize)
 else
     warning('CUnit not found, skipping unit test suite')
 endif


### PR DESCRIPTION
The TODO list mentions that one type of possible contributions are unit tests.
This PR introduces unit test for `human_size()` function.

I have purposely chosen the easiest possible C file to write unit tests to, to learn how unit tests work in rpminspect.

The test checks if conversion from bytes to human readable format is correct.