### PR TITLE
[lib] Load *.cld files in addition to *.cvd files for virus scans

### DIFF
--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -148,7 +148,7 @@ bool inspect_virus(struct rpminspect *ri)
     errno = 0;
 
     while ((de = readdir(d)) != NULL) {
-        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..") || !strsuffix(de->d_name, ".cvd")) {
+        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..") || !strsuffix(de->d_name, ".cvd") || !strsuffix(de->d_name, ".cld")) {
             continue;
         }
 


### PR DESCRIPTION
clamav databases are either *.cvd files or *.cld files so make sure to load both if we find them.

Fixes: #1155