### PR TITLE
[fix] Load both *.cld and *.cvd virus database files, if they exist

### DIFF
--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -148,7 +148,7 @@ bool inspect_virus(struct rpminspect *ri)
     errno = 0;
 
     while ((de = readdir(d)) != NULL) {
-        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..") || !strsuffix(de->d_name, ".cvd") || !strsuffix(de->d_name, ".cld")) {
+        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..") || (!strsuffix(de->d_name, ".cvd") && !strsuffix(de->d_name, ".cld"))) {
             continue;
         }
 


### PR DESCRIPTION
This just fixes a logical error that was accidentally introduced in 66b0953.