### PR TITLE
[fix] Handle manually unpacked source archives in unicode inspection

### DIFF
--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -219,6 +219,16 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
             warn("close");
         }
 
+        if (close(STDOUT_FILENO)) {
+            warn("close");
+            _exit(EXIT_FAILURE);
+        }
+
+        if (close(STDERR_FILENO)) {
+            warn("close");
+            _exit(EXIT_FAILURE);
+        }
+
         _exit(status);
     } else if (proc == -1) {
         /* failure */
@@ -262,7 +272,7 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
 
         /* wipe the working directory if %prep failed */
         if (WEXITSTATUS(status) == 2) {
-            rmtree(build, true, true);
+            (void) rmtree(build, true, true);
             free(build);
             build = NULL;
         }

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -626,7 +626,11 @@ static bool unicode_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             free(params.details);
 
             seen = true;
+            (void) rmtree(build, true, false);
+
+            free(build);
             free(globalfile);
+
             return false;
         }
 
@@ -640,7 +644,10 @@ static bool unicode_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
 
         seen = true;
+        (void) rmtree(build, true, false);
+
         free(params.details);
+        free(build);
     }
 
     /* check the individual file */
@@ -736,6 +743,5 @@ bool inspect_unicode(struct rpminspect *ri)
         result = true;
     }
 
-    free(build);
     return result;
 }


### PR DESCRIPTION
The unicode inspection works on SRPMs and needs to both look at the files in the SRPM itself as well as unpacked and patched source trees. Archives are unpacked to temporary directories and the code was not properly trimming this leading path so that matching against security/PRODUCT_RELEASE rules in the vendor data package would work.

Fixes: #1157