### PR TITLE
[lib] Do not display curl progress bar on non-tty output

### DIFF
--- a/lib/curl.c
+++ b/lib/curl.c
@@ -160,6 +160,7 @@ static int legacy_download_progress(void *p, double dltotal, double dlnow, doubl
 void curl_get_file(const bool verbose, const char *src, const char *dst)
 {
     FILE *fp = NULL;
+    char *archive = NULL;
     CURL *c = NULL;
     CURLcode cc;
 
@@ -181,13 +182,19 @@ void curl_get_file(const bool verbose, const char *src, const char *dst)
     curl_easy_setopt(c, CURLOPT_MAXREDIRS, 10L);
 
     if (verbose) {
+        if (isatty(STDOUT_FILENO) == 1) {
 #if LIBCURL_VERSION_NUM >= 0x072000
-        curl_easy_setopt(c, CURLOPT_XFERINFOFUNCTION, download_progress);
+            curl_easy_setopt(c, CURLOPT_XFERINFOFUNCTION, download_progress);
 #else
-        curl_easy_setopt(c, CURLOPT_PROGRESSFUNCTION, legacy_download_progress);
+            curl_easy_setopt(c, CURLOPT_PROGRESSFUNCTION, legacy_download_progress);
 #endif
-        curl_easy_setopt(c, CURLOPT_NOPROGRESS, 0L);
-        setup_progress_bar(src);
+            curl_easy_setopt(c, CURLOPT_NOPROGRESS, 0L);
+            setup_progress_bar(src);
+        } else {
+            archive = rindex(src, '/') + 1;
+            assert(archive != NULL);
+            printf(">>> %s", archive);
+        }
     }
 
     /* perform the download */

--- a/lib/curl.c
+++ b/lib/curl.c
@@ -6,6 +6,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <libgen.h>
 #include <string.h>
 #include <stdbool.h>


### PR DESCRIPTION
It is common to capture rpminspect output to log files.  In those cases, do not output curl progress bars since that makes the log files more difficult to read.

Fixes: #1162