### PR TITLE
Check file owner and group for setuid/setgid files in the ownership inspection

### DIFF
--- a/include/results.h
+++ b/include/results.h
@@ -401,6 +401,13 @@
  */
 #define REMEDY_OWNERSHIP_CHANGED _("Verify the ownership changes are expected. If not, adjust the package build process to set correct owner and group information. If expected, update %s and send a patch to the project that owns it.")
 
+/**
+ * @def REMEDY_FILEINFO_RULE
+ *
+ * How to handle a missing fileinfo rule.
+ */
+#define REMEDY_FILEINFO_RULE _("rpminspect is expecting a fileinfo rule from the vendor data package for this file. Usually this means the file carries a non-standard set of permissions (e.g., setuid) which is a condition where rpminspect would check the fileinfo list to ensure the package conforms to the vendor rules. To remedy, add a fileinfo rule for this file to the vendor data package under the appropriate product release file.")
+
 /** @} */
 
 /**

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -47,7 +47,12 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         return true;
     }
 
-    /* We will skip checks for ignored files */
+    /* Ignore debuginfo and debugsource packages */
+    if (strprefix(file->localpath, DEBUG_PATH) || strprefix(file->localpath, DEBUG_SRC_PATH)) {
+        return true;
+    }
+
+    /* We will skip checks for ignored files for non-security checks */
     ignore = ignore_rpmfile_entry(ri, NAME_OWNERSHIP, file);
 
     /* Get the arch, we'll use that */
@@ -96,6 +101,10 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         result = false;
         reported = true;
     }
+
+    /* fileinfo expected owner and group */
+    (void) match_fileinfo_owner(ri, file, owner, NAME_OWNERSHIP, NULL, NULL, &result, &reported);
+    (void) match_fileinfo_group(ri, file, group, NAME_OWNERSHIP, NULL, NULL, &result, &reported);
 
     /* Report files in bin paths not under the bin owner or group */
     TAILQ_FOREACH(entry, ri->bin_paths, items) {

--- a/test/data/fileinfo/GENERIC
+++ b/test/data/fileinfo/GENERIC
@@ -1,2 +1,4 @@
 -rwsr-xr-x          root       root       /usr/bin/mount
 -rwsr-xr-x          root       root       /usr/bin/umount
+-rwsr-xr-x          bin        bin        /usr/ucb/sowner
+-rwxr-sr-x          bin        bin        /usr/ucb/sgroup

--- a/test/test_ownership.py
+++ b/test/test_ownership.py
@@ -3016,3 +3016,559 @@ class FileGroupChangedCompareKoji(TestCompareKoji):
         self.inspection = "ownership"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
+
+
+#######################################
+# Unexpected ownership on setuid file #
+#######################################
+
+
+class ExpectedSetuidOwnerRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class UnexpectedSetuidOwnerRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetuidOwnerKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetuidOwnerCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="4755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetuidOwnerCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="4755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+###################################
+# Unexpected group on setuid file #
+###################################
+
+
+class ExpectedSetuidGroupRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class UnexpectedSetuidGroupRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetuidGroupKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetuidGroupCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="4755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetuidGroupCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="4755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/sowner",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+#######################################
+# Unexpected ownership on setgid file #
+#######################################
+
+
+class ExpectedSetgidOwnerRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class UnexpectedSetgidOwnerRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetgidOwnerKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetgidOwnerCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="2755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetgidOwnerCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="2755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="root",
+            group="bin",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+###################################
+# Unexpected group on setgid file #
+###################################
+
+
+class ExpectedSetgidGroupRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class UnexpectedSetgidGroupRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetgidGroupKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetgidGroupCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="2755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class UnexpectedSetgidGroupCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="2755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/sgroup",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="root",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+#####################################
+# setuid file missing fileinfo rule #
+#####################################
+
+
+class MissingFileinfoRuleSetuidRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class MissingFileinfoRuleSetuidCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="4755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class MissingFileinfoRuleSetuidCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="4755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="4755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+#####################################
+# setgid file missing fileinfo rule #
+#####################################
+
+
+class MissingFileinfoRuleSetgidRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class MissingFileinfoRuleSetgidCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="2755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
+
+
+class MissingFileinfoRuleSetgidCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        self.before_rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="2755",
+        )
+        self.after_rpm.add_installed_file(
+            installPath="usr/ucb/smissing",
+            sourceFile=rpmfluff.SourceFile("rpminspect", ri_bytes),
+            owner="bin",
+            group="bin",
+            mode="2755",
+        )
+
+        self.inspection = "ownership"
+        self.result = "BAD"
+        self.waiver_auth = "Security"


### PR DESCRIPTION
In the ownership inspection, do two new things:

* Any fileinfo rules that exist for a package are validated against what is found in the package.  Fileinfo rules do not have to be used for setuid or setgid files, so if any exist that cover non-standard owner and group info, check here.
* For setuid and setgid files, check the found owner and group against the fileinfo rule.
* I lied, there are three things.  For any setuid or setgid file, if the file lacks a fileinfo rule, report that as a security problem.  All of these types of files need a corresponding fileinfo rule.