### PR TITLE
[tst] Add unit test for arches.c

### DIFF
--- a/test/lib/test-arches.c
+++ b/test/lib/test-arches.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <CUnit/Basic.h>
+#include "rpminspect.h"
+#include "test-main.h"
+
+struct rpminspect *ri = NULL;
+
+int init_test_arches(void) {
+    ri = init_rpminspect(ri, NULL, NULL);
+    ri->arches = list_add(ri->arches, "x86_64");
+    return 0;
+}
+
+int clean_test_arches(void) {
+    free_rpminspect(ri);
+    return 0;
+}
+
+void test_allowed_arch(void) {
+    RI_ASSERT_TRUE(allowed_arch(ri, "x86_64"));
+    RI_ASSERT_FALSE(allowed_arch(ri, "RISC-V"));
+}
+
+CU_pSuite get_suite(void) {
+    CU_pSuite pSuite = NULL;
+
+    /* add a suite to the registry */
+    pSuite = CU_add_suite("arches", init_test_arches, clean_test_arches);
+    if (pSuite == NULL) {
+        return NULL;
+    }
+
+    /* add tests to the suite */
+    if (CU_add_test(pSuite, "test allowed_arch()", test_allowed_arch) == NULL) {
+        return NULL;
+    }
+
+    return pSuite;
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -88,6 +88,15 @@ if cunit.found()
         c_args : '-D_BUILDDIR_="@0@"'.format(meson.current_build_dir()),
         link_with : [ librpminspect ],
     )
+    test_arches = executable(
+        'test-arches',
+        ['lib/test-arches.c',
+         'lib/test-main.c'],
+        include_directories : inc,
+        dependencies : [ cunit, libkmod ],
+        c_args : '-D_BUILDDIR_="@0@"'.format(meson.current_build_dir()),
+        link_with : [ librpminspect ],
+    )
 
     # Support program used by test-inspect-elf
     execstack_prog = executable(
@@ -114,6 +123,7 @@ if cunit.found()
     )
     test('test-abspath', test_abspath)
     test('test-humansize', test_humansize)
+    test('test-arches', test_arches)
 else
     warning('CUnit not found, skipping unit test suite')
 endif


### PR DESCRIPTION
The unit test in this PR in the end covers only `allowed_arch()`.

The allowed arches unit test adds one allowed arch and then checks if the added arch is indeed among allowed arches. It also checks, that a random not-allowed arch is indeed not allowed.
