### PR TITLE
[fix] Honor additional %patch macro syntax in the patches inspection

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -658,10 +658,17 @@
 /**
  * @def SPEC_MACRO_PATCH
  *
- * The %patchN macro used to apply patches.  N corresponds to the
- * patch number defined in the header.
+ * The %patch macro used to apply patches.
  */
 #define SPEC_MACRO_PATCH       "%patch"
+
+/**
+ * @def SPEC_MACRO_PATCH_P_ARG
+ *
+ * The -P argument to the %patch macro.  The -P argument is used to
+ * specify the patch number as defined in the header.
+ */
+#define SPEC_MACRO_PATCH_P_ARG "-P"
 
 /**
  * @def SPEC_SECTION_PREP

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -1548,7 +1548,7 @@ bool inspect_debuginfo(struct rpminspect *ri);
  * @def DESC_PATCHES
  * The description for the 'patches' inspection.
  */
-#define DESC_PATCHES _("Inspects all patches defined in the spec file and reports changes between builds.  At the INFO level, rpminspect reports file count, line count, and patch size changes.  If thresholds are reached regarding a change in the patch size or the number of files the patch touches, rpminspect reports the change at the VERIFY level unless the comparison is for a rebase.  The configuration file can also list patch names that rpminspect should ignore during the inspection.")
+#define DESC_PATCHES _("Inspects all patches defined in the spec file and reports changes between builds.  The functional check here is to ensure all defined patches in the preamble have a corresponding application macro in the spec file.  At the INFO level, rpminspect reports file count, line count, and patch size changes.  If thresholds are reached regarding a change in the patch size or the number of files the patch touches, rpminspect reports the change at the VERIFY level unless the comparison is for a rebase.  The configuration file can also list patch names that rpminspect should ignore during the inspection.")
 
 /**
  * @def DESC_VIRUS

--- a/include/results.h
+++ b/include/results.h
@@ -687,9 +687,9 @@
 
 #define REMEDY_PATCHES_CORRUPT _("An invalid patch file was found.  This is usually the result of generating a collection of patches by comparing two trees.  When files disappear that can lead to zero length patches in the resulting collection.  Check to see if the source package has any zero length or otherwise invalid patches and correct the problem.")
 
-#define REMEDY_PATCHES_MISSING_MACRO _("The named patch is defined in the source RPM header (this means it has a PatchN: definition in the spec file) but is not applied anywhere in the spec file.  It is missing a corresponding %patch macro and the spec file lacks the %autosetup or %autopatch macros.  You can fix this by adding the appropriate %patch macro in the spec file (usually in the %prep section).  The number specified with the %patch macro corresponds to the number used to define the patch at the top of the spec file.  So Patch47 is applied with a %patch47 macro.")
+#define REMEDY_PATCHES_MISSING_MACRO _("The named patch is defined in the source RPM header (this means it has a PatchN: definition in the spec file) but is not applied anywhere in the spec file.  It is missing a corresponding %patch macro and the spec file lacks the %autosetup or %autopatch macros.  You can fix this by adding the appropriate %patch macro in the spec file (usually in the %prep section).  The number specified with the %patch macro corresponds to the number used to define the patch at the top of the spec file.  So Patch47 is applied with either a '%patch 47', '%patch -P 47', '%patch -P47', or '%patch47' macro.")
 
-#define REMEDY_PATCHES_MISMATCHED_MACRO _("The named patch is defined but is mismatched by number with the %patch macro.  Make sure all numbered patches have corresponding %patch macros.  For example, Patch47 needs to have a %patch47 macro.")
+#define REMEDY_PATCHES_MISMATCHED_MACRO _("The named patch is defined but is mismatched by number with the %patch macro.  Make sure all numbered patches have corresponding %patch macros.  For example, Patch47 needs to have either a '%patch 47', '%patch -P 47', '%patch -P47', or '%patch47' macro.")
 
 #define REMEDY_PATCHES_UNHANDLED_PATCH _("The defined patch file is not something rpminspect can handle.  This is likely a bug and should be reported to the upstream rpminspect project.")
 

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -527,3 +527,153 @@ class PatchFilenameWithMacroCompareSRPM(TestCompareSRPM):
         self.inspection = "patches"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
+
+
+# '%patch N' syntax used to apply patch
+class PatchNMacroSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add the patch with '%patch N' syntax
+        patch = rpmfluff.SourceFile("some.patch", patch_file)
+        patchIndex = len(self.rpm.patches)
+        self.rpm.patches[patchIndex] = patch
+
+        self.rpm.section_patches += "Patch%i: %s\n" % (patchIndex, patch.sourceName)
+        self.rpm.add_check(rpmfluff.check.CheckSourceFile(patch.sourceName))
+
+        self.rpm.section_prep += "%%patch %i\n" % patchIndex
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class PatchNMacroCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add the patch with '%patch N' syntax
+        patch = rpmfluff.SourceFile("some.patch", patch_file)
+
+        beforePatchIndex = len(self.before_rpm.patches)
+        self.before_rpm.patches[beforePatchIndex] = patch
+        self.before_rpm.section_patches += "Patch%i: %s\n" % (
+            beforePatchIndex,
+            patch.sourceName,
+        )
+        self.before_rpm.add_check(rpmfluff.check.CheckSourceFile(patch.sourceName))
+        self.before_rpm.section_prep += "%%patch %i\n" % beforePatchIndex
+
+        afterPatchIndex = len(self.after_rpm.patches)
+        self.after_rpm.patches[afterPatchIndex] = patch
+        self.after_rpm.section_patches += "Patch%i: %s\n" % (
+            afterPatchIndex,
+            patch.sourceName,
+        )
+        self.after_rpm.add_check(rpmfluff.check.CheckSourceFile(patch.sourceName))
+        self.after_rpm.section_prep += "%%patch %i\n" % afterPatchIndex
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# '%patch -P N' syntax used to apply patch
+class PatchP_NMacroSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add the patch with '%patch -P N' syntax
+        patch = rpmfluff.SourceFile("some.patch", patch_file)
+        patchIndex = len(self.rpm.patches)
+        self.rpm.patches[patchIndex] = patch
+
+        self.rpm.section_patches += "Patch%i: %s\n" % (patchIndex, patch.sourceName)
+        self.rpm.add_check(rpmfluff.check.CheckSourceFile(patch.sourceName))
+
+        self.rpm.section_prep += "%%patch -P %i\n" % patchIndex
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class PatchP_NMacroCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add the patch with '%patch -P N' syntax
+        patch = rpmfluff.SourceFile("some.patch", patch_file)
+
+        beforePatchIndex = len(self.before_rpm.patches)
+        self.before_rpm.patches[beforePatchIndex] = patch
+        self.before_rpm.section_patches += "Patch%i: %s\n" % (
+            beforePatchIndex,
+            patch.sourceName,
+        )
+        self.before_rpm.add_check(rpmfluff.check.CheckSourceFile(patch.sourceName))
+        self.before_rpm.section_prep += "%%patch -P %i\n" % beforePatchIndex
+
+        afterPatchIndex = len(self.after_rpm.patches)
+        self.after_rpm.patches[afterPatchIndex] = patch
+        self.after_rpm.section_patches += "Patch%i: %s\n" % (
+            afterPatchIndex,
+            patch.sourceName,
+        )
+        self.after_rpm.add_check(rpmfluff.check.CheckSourceFile(patch.sourceName))
+        self.after_rpm.section_prep += "%%patch -P %i\n" % afterPatchIndex
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# '%patch -PN' syntax used to apply patch
+class PatchPNMacroSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add the patch with '%patch -PN' syntax
+        patch = rpmfluff.SourceFile("some.patch", patch_file)
+        patchIndex = len(self.rpm.patches)
+        self.rpm.patches[patchIndex] = patch
+
+        self.rpm.section_patches += "Patch%i: %s\n" % (patchIndex, patch.sourceName)
+        self.rpm.add_check(rpmfluff.check.CheckSourceFile(patch.sourceName))
+
+        self.rpm.section_prep += "%%patch -P%i\n" % patchIndex
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class PatchPNMacroCompareSRPM(TestCompareSRPM):
+    def setUp(self):
+        super().setUp()
+
+        # add the patch with '%patch -PN' syntax
+        patch = rpmfluff.SourceFile("some.patch", patch_file)
+
+        beforePatchIndex = len(self.before_rpm.patches)
+        self.before_rpm.patches[beforePatchIndex] = patch
+        self.before_rpm.section_patches += "Patch%i: %s\n" % (
+            beforePatchIndex,
+            patch.sourceName,
+        )
+        self.before_rpm.add_check(rpmfluff.check.CheckSourceFile(patch.sourceName))
+        self.before_rpm.section_prep += "%%patch -P%i\n" % beforePatchIndex
+
+        afterPatchIndex = len(self.after_rpm.patches)
+        self.after_rpm.patches[afterPatchIndex] = patch
+        self.after_rpm.section_patches += "Patch%i: %s\n" % (
+            afterPatchIndex,
+            patch.sourceName,
+        )
+        self.after_rpm.add_check(rpmfluff.check.CheckSourceFile(patch.sourceName))
+        self.after_rpm.section_prep += "%%patch -P%i\n" % afterPatchIndex
+
+        self.inspection = "patches"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
The %patchN macro has been deprecated by rpm, so many maintainers are switching to alternate syntax.  The preferred syntax is:

    %patch -P N

Where N corresponds to the patch number as defined in the preamble. However, other syntax is supported.  rpminspect can now work with the following syntax:

    %patchN
    %patch -P N
    %patch -PN
    %patch N

Fixes: #1166