### PR TITLE
[fix] Fix a memory bug in the unicode inspection

### DIFF
--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -499,7 +499,7 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
         for (i = 0; (line[i] = u_fgetcx(src)) != U_EOF && !end_of_line(line[i]); i++) {
             /* increase the buffer size if necessary */
             if (i >= sz) {
-                sz += (i - sz);
+                sz *= 2;
                 errno = 0;
                 line_new = reallocarray(line, sz, sizeof(*line));
 


### PR DESCRIPTION
Double the line buffer, if needed.

rpminspect started freezing in RHEL CI with the following error in logs:
"corrupted size vs. prev_size"

Doing just "sz += (i - sz);" is problematic as we would initially not increase the size of the buffer at all ("sz += 0").