### PR TITLE
Introduce 'udevrules' inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ there are a number of userspace programs used:
     /usr/bin/msgunfmt
     /usr/bin/abidiff [optional]
     /usr/bin/kmidiff [optional]
+    /usr/bin/udevadm [optional]
 
 The provided spec file template uses the Fedora locations for these
 files, but in the program, they must be on the runtime system.

--- a/data/generic.json
+++ b/data/generic.json
@@ -252,5 +252,11 @@
       "/usr/lib/grub/*"
     ],
     "debuginfo_sections": ".symtab .debug_info"
+  },
+  "udevrules": {
+    "udev_rules_dirs": [
+      "/etc/udev/rules.d/",
+      "/usr/lib/udev/rules.d/"
+    ]
   }
 }

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -61,6 +61,9 @@ commands:
     #abidiff: /usr/bin/abidiff
     #kmidiff: /usr/bin/kmidiff
 
+    # udevadm from the systemd project
+    #udevadm: udevadm
+
 vendor:
     # Where the vendor data files can be found.  The
     # rpminspect-data-generic package provides a template of where
@@ -158,6 +161,7 @@ vendor:
     #upstream: off
     #virus: off
     #xml: off
+    #udevrules: off
 
 #products:
     # Product release string matches.  rpminspect uses product release
@@ -1039,3 +1043,9 @@ debuginfo:
     # instance, some systems add a .gdb_index section to debuginfo
     # file.  This is a space-delimited string of section names.
     debuginfo_sections: .symtab .debug_info
+
+udevrules:
+    # Directories where udev rules live.
+    #udev_rules_dirs:
+    #    - /etc/udev/rules.d/
+    #    - /usr/lib/udev/rules.d/

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -424,6 +424,10 @@ program.
     dependency metadata when inspecting a single build and report
     findings.
 
+- **udevrules**
+
+    Perform syntax check on udev rules files using udevadm verify.
+
 **Comparison Mode**
 
 These inspections run when a before and after build are specified as

--- a/include/constants.h
+++ b/include/constants.h
@@ -378,6 +378,13 @@
  */
 #define KMIDIFF_KMI_WHITELIST "--kmi-whitelist"
 
+/**
+ * @def UDEVADM_CMD
+ *
+ * Executable providing udevadm verify.
+ */
+#define UDEVADM_CMD "udevadm"
+
 /** @} */
 
 /**
@@ -639,6 +646,13 @@
  * this extension ends with a period.
  */
 #define ELF_LIB_EXTENSION ".so."
+
+/**
+ * @def UDEV_RULES_FILENAME_EXTENSION
+ *
+ * udev rules filename extension
+ */
+#define UDEV_RULES_FILENAME_EXTENSION ".rules"
 
 /** @} */
 

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -712,6 +712,16 @@ bool inspect_rpmdeps(struct rpminspect *ri);
  */
 bool inspect_debuginfo(struct rpminspect *ri);
 
+/**
+ * @brief Perform the 'udevrules' inspection.
+ *
+ * Perform syntax check on udev rules files using udevadm verify.
+ *
+ * @param ri Pointer to the struct rpminspect for the program.
+ * @return True if the inspection passed, false otherwise.
+ */
+bool inspect_udevrules(struct rpminspect *ri);
+
 /** @} */
 
 /**
@@ -1010,6 +1020,12 @@ bool inspect_debuginfo(struct rpminspect *ri);
  */
 #define INSPECT_DEBUGINFO                   (((uint64_t) 1) << 45)
 
+/**
+ * @def INSPECT_UDEVRULES
+ * 'udevrules' inspection ID.
+ */
+#define INSPECT_UDEVRULES                   (((uint64_t) 1) << 46)
+
 /** @} */
 
 /**
@@ -1304,6 +1320,12 @@ bool inspect_debuginfo(struct rpminspect *ri);
  */
 #define NAME_DEBUGINFO                      "debuginfo"
 
+/**
+ * @def NAME_UDEVRULES
+ * The string "udevrules"
+ */
+#define NAME_UDEVRULES                      "udevrules"
+
 /** @} */
 
 /**
@@ -1591,6 +1613,12 @@ bool inspect_debuginfo(struct rpminspect *ri);
  * The description for the 'debuginfo' inspection.
  */
 #define DESC_DEBUGINFO _("Checks that files in RPM packages have their debugging symbols stripped and files in debuginfo packages carry debugging symbols.  When comparing builds, report where symbols unexpectedly appear or disappear and what corrective action is needed.")
+
+/**
+ * @def DESC_UDEVRULES
+ * The description for the 'udevrules' inspection.
+ */
+#define DESC_UDEVRULES _("Perform syntax check on udev rules files using udevadm verify.")
 
 /** @} */
 

--- a/include/results.h
+++ b/include/results.h
@@ -773,6 +773,15 @@
 
 /** @} */
 
+/**
+ * @def REMEDY_UDEVRULES
+ *
+ * How to address syntax check issues in udev rules files.
+ */
+#define REMEDY_UDEVRULES _("Refer to the udev documentation at https://www.freedesktop.org/software/systemd/man/udev.html for help correcting the errors and warnings.")
+
+/** @} */
+
 /** @} */
 
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -389,6 +389,7 @@ struct command_paths {
 #ifdef _WITH_ANNOCHECK
     char *annocheck;
 #endif
+    char *udevadm;
 };
 
 /* Hash table used for key/value situations where each is a string. */
@@ -684,6 +685,9 @@ struct rpminspect {
 
     /* debuginfo ELF section name(s) when checking for debugging symbols */
     char *debuginfo_sections;
+
+    /* Directories where udev rules live */
+    string_list_t *udev_rules_dirs;
 
     /* Options specified by the user */
     char *before;              /* before build ID arg given on cmdline */

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -142,6 +142,10 @@ void dump_cfg(const struct rpminspect *ri)
     }
 #endif
 
+    if (ri->commands.udevadm) {
+        printf("    udevadm: %s\n", ri->commands.udevadm);
+    }
+
     /* vendor */
 
     printf("vendor:\n");
@@ -906,6 +910,25 @@ void dump_cfg(const struct rpminspect *ri)
         }
 
         dump_inspection_ignores(ri->inspection_ignores, NAME_DEBUGINFO);
+    }
+
+    /* udevrules */
+
+    HASH_FIND_STR(ri->inspection_ignores, NAME_UDEVRULES, mapentry);
+
+    if ((ri->udev_rules_dirs && !TAILQ_EMPTY(ri->udev_rules_dirs))
+        || mapentry != NULL) {
+        printf("udevrules:\n");
+
+        if (ri->udev_rules_dirs && !TAILQ_EMPTY(ri->udev_rules_dirs)) {
+            printf("    udev_rules_dirs:\n");
+
+            TAILQ_FOREACH(entry, ri->udev_rules_dirs, items) {
+                printf("        - %s\n", entry->data);
+            }
+        }
+
+        dump_inspection_ignores(ri->inspection_ignores, NAME_UDEVRULES);
     }
 
     printf("\n\n");

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -256,5 +256,21 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     free(ver);
 
+    /* udevadm */
+    tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.udevadm, "--version", NULL);
+    details = strsplit(tmp, "\n");
+    free(tmp);
+
+    entry = TAILQ_FIRST(details);
+    ver = strdup(entry->data);
+    list_free(details, free);
+
+    entry = calloc(1, sizeof(*entry));
+    assert(entry != NULL);
+    xasprintf(&entry->data, "udevadm version %s", ver);
+    TAILQ_INSERT_TAIL(list, entry, items);
+
+    free(ver);
+
     return list;
 }

--- a/lib/free.c
+++ b/lib/free.c
@@ -223,6 +223,7 @@ void free_rpminspect(struct rpminspect *ri)
 #ifdef _WITH_ANNOCHECK
     free(ri->commands.annocheck);
 #endif
+    free(ri->commands.udevadm);
 
     list_free(ri->buildhost_subdomain, free, true);
     list_free(ri->macrofiles, free, true);
@@ -270,6 +271,7 @@ void free_rpminspect(struct rpminspect *ri)
     list_free(ri->unicode_forbidden_codepoints, free, true);
     free_deprule_ignore_map(ri->deprules_ignore);
     free(ri->debuginfo_sections);
+    list_free(ri->udev_rules_dirs, free);
 
     free_peers(ri->peers);
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -49,6 +49,13 @@ static const char *SHELLS[] = {"sh", "ksh", "zsh", "csh", "tcsh", "rc", "bash", 
 /* Supported config filename endings (we assume type by this) */
 static const char *CFG_FILENAME_EXTENSIONS[] = {"yaml", "json", "dson", NULL};
 
+/**
+ * @def UDEV_RULES_DIRS
+ * NULL terminated array of strings of directories where udev rules files
+ * may reside.
+ */
+static const char *UDEV_RULES_DIRS[] = {"/etc/udev/rules.d/", "/usr/lib/udev/rules.d/", NULL};
+
 static int add_regex(const char *pattern, regex_t **regex_out)
 {
     int reg_result;
@@ -595,6 +602,7 @@ static void read_cfgfile(struct rpminspect *ri, const char *filename)
     strget(p, ctx, "commands", "desktop-file-validate", &ri->commands.desktop_file_validate);
     strget(p, ctx, "commands", "abidiff", &ri->commands.abidiff);
     strget(p, ctx, "commands", "kmidiff", &ri->commands.kmidiff);
+    strget(p, ctx, "commands", "udevadm", &ri->commands.udevadm);
     strget(p, ctx, "vendor", "vendor_data_dir", &ri->vendor_data_dir);
     array(p, ctx, "vendor", "licensedb", &ri->licensedb);
 
@@ -834,6 +842,9 @@ static void read_cfgfile(struct rpminspect *ri, const char *filename)
     add_ignores(ri, p, ctx, "upstream");
     add_ignores(ri, p, ctx, "debuginfo");
     strget(p, ctx, "debuginfo", "debuginfo_sections", &ri->debuginfo_sections);
+
+    array(p, ctx, "udevrules", "udev_rules_dirs", &ri->udev_rules_dirs);
+    add_ignores(ri, p, ctx, "udevrules");
 
     p->fini(ctx);
     return;
@@ -1555,6 +1566,7 @@ struct rpminspect *calloc_rpminspect(struct rpminspect *ri)
     ri->annocheck_failure_severity = RESULT_VERIFY;
     ri->size_threshold = -1;
     ri->debuginfo_sections = strdup(ELF_SYMTAB" "ELF_DEBUG_INFO);
+    ri->udev_rules_dirs = list_from_array(UDEV_RULES_DIRS);
 
     /* Initialize commands */
     ri->commands.msgunfmt = strdup(MSGUNFMT_CMD);
@@ -1564,6 +1576,7 @@ struct rpminspect *calloc_rpminspect(struct rpminspect *ri)
 #ifdef _WITH_ANNOCHECK
     ri->commands.annocheck = strdup(ANNOCHECK_CMD);
 #endif
+    ri->commands.udevadm = strdup(UDEVADM_CMD);
 
     /* Store full paths to all config files read */
     if (ri->cfgfiles == NULL) {

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -78,6 +78,7 @@ struct inspect inspections[] = {
     { INSPECT_SUBPACKAGES,   "subpackages",   false, false, &inspect_subpackages },
     { INSPECT_SYMLINKS,      "symlinks",      false, true,  &inspect_symlinks },
     { INSPECT_TYPES,         "types",         false, false, &inspect_types },
+    { INSPECT_UDEVRULES,     "udevrules",     false, true,  &inspect_udevrules },
     { INSPECT_UNICODE,       "unicode",       true,  true,  &inspect_unicode },
     { INSPECT_UPSTREAM,      "upstream",      false, false, &inspect_upstream },
     { INSPECT_VIRUS,         "virus",         true,  true,  &inspect_virus },
@@ -252,6 +253,8 @@ uint64_t inspection_id(const char *name)
         return INSPECT_RPMDEPS;
     } else if (!strcmp(name, NAME_DEBUGINFO)) {
         return INSPECT_DEBUGINFO;
+    } else if (!strcmp(name, NAME_UDEVRULES)) {
+        return INSPECT_UDEVRULES;
     } else {
         return INSPECT_NULL;
     }
@@ -361,6 +364,8 @@ const char *inspection_desc(const uint64_t inspection)
             return DESC_RPMDEPS;
         case INSPECT_DEBUGINFO:
             return DESC_DEBUGINFO;
+        case INSPECT_UDEVRULES:
+            return DESC_UDEVRULES;
         default:
             return NULL;
     }
@@ -471,6 +476,8 @@ const char *inspection_header_to_desc(const char *header)
         i = INSPECT_RPMDEPS;
     } else if (!strcmp(header, NAME_DEBUGINFO)) {
         i = INSPECT_DEBUGINFO;
+    } else if (!strcmp(header, NAME_UDEVRULES)) {
+        i = INSPECT_UDEVRULES;
     }
 
     return inspection_desc(i);

--- a/lib/inspect_udevrules.c
+++ b/lib/inspect_udevrules.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <libgen.h>
+#include <string.h>
+#include <errno.h>
+#include <err.h>
+#include <libgen.h>
+#include <ftw.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <dirent.h>
+
+#include "rpminspect.h"
+
+/*
+ * Called by udevrules_driver() to determine if a found file is one
+ * we want to look at.  Returns true if it is, false otherwise.
+ */
+static bool is_udev_rules_file(struct rpminspect *ri, const rpmfile_entry_t *file)
+{
+    string_entry_t *entry = NULL;
+
+    assert(ri != NULL);
+    assert(file != NULL);
+
+    /* Skip source packages */
+    if (headerIsSource(file->rpm_header)) {
+        return false;
+    }
+
+    /* Is this a regular file? */
+    if (!file->fullpath || !S_ISREG(file->st.st_mode)) {
+        return false;
+    }
+
+    /* Make sure we are looking at a udev rules file */
+
+    if (!strsuffix(file->localpath, UDEV_RULES_FILENAME_EXTENSION)) {
+        return false;
+    }
+
+    TAILQ_FOREACH(entry, ri->udev_rules_dirs, items) {
+        if (strprefix(file->localpath, entry->data)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/*
+ * A trivial wrapper called by udevrules_driver() and inspect_udevrules()
+ * to invoke udevadm verify.
+ */
+static char *run_udevadm_verify(int *exitcode, const struct rpminspect *ri, const char *arg)
+{
+    return run_cmd(exitcode, ri->worksubdir, ri->commands.udevadm, "verify",
+                   "--no-summary", "--resolve-names=never", arg, NULL);
+}
+
+static bool udevrules_driver(struct rpminspect *ri, rpmfile_entry_t *file)
+{
+    bool result = true;
+    const char *arch = NULL;
+    int before_rc = 0;
+    int after_rc = 0;
+    char *details = NULL;
+    char *tmpbuf;
+    struct result_params params;
+
+    /*
+     * Is this a file we should look at?
+     * NOTE: Returning 'true' here is like 'continue' in the calling loop.
+     */
+    if (!is_udev_rules_file(ri, file)) {
+        return true;
+    }
+
+    /* We need the architecture for reporting */
+    arch = get_rpm_header_arch(file->rpm_header);
+
+    /* Set up the result parameters */
+    init_result_params(&params);
+    params.header = NAME_UDEVRULES;
+    params.verb = VERB_OK;
+    params.arch = arch;
+    params.file = file->localpath;
+
+    /* Validate the udev rules file */
+    tmpbuf = run_udevadm_verify(&after_rc, ri, file->fullpath);
+    details = strreplace(tmpbuf, file->fullpath, file->localpath);
+    free(tmpbuf);
+
+    /* If we have a before peer, validate the corresponding udev rules file */
+    if (file->peer_file && is_udev_rules_file(ri, file->peer_file)) {
+        tmpbuf = run_udevadm_verify(&before_rc, ri, file->peer_file->fullpath);
+        free(tmpbuf);
+
+        if (before_rc == 0 && after_rc == 0) {
+            xasprintf(&params.msg, _("%s is a valid udev rules file on %s"), file->localpath, arch);
+        } else if (before_rc && after_rc == 0) {
+            xasprintf(&params.msg, _("%s is now a valid udev rules file on %s"), file->localpath, arch);
+            params.verb = VERB_CHANGED;
+        } else if (before_rc == 0 && after_rc) {
+            xasprintf(&params.msg, _("%s is no longer a valid udev rules file on %s"), file->localpath, arch);
+            params.verb = VERB_CHANGED;
+        } else {
+            xasprintf(&params.msg, _("%s is not a valid udev rules file on %s"), file->localpath, arch);
+        }
+    } else {
+        if (after_rc == 0) {
+            xasprintf(&params.msg, _("%s is a valid udev rules file on %s"), file->localpath, arch);
+        } else {
+            xasprintf(&params.msg, _("%s is not a valid udev rules file on %s"), file->localpath, arch);
+        }
+    }
+
+    if (after_rc == 0) {
+        params.severity = RESULT_INFO;
+        params.waiverauth = NOT_WAIVABLE;
+    } else {
+        params.severity = RESULT_BAD;
+        params.waiverauth = WAIVABLE_BY_ANYONE;
+        params.remedy = REMEDY_UDEVRULES;
+        params.details = details;
+        result = false;
+    }
+
+    if (params.msg) {
+        add_result(ri, &params);
+        free(params.msg);
+    }
+
+    free(details);
+
+    return result;
+}
+
+/*
+ * Main driver for the 'udevrules' inspection.
+ */
+bool inspect_udevrules(struct rpminspect *ri)
+{
+    char *details;
+    int rc = 0;
+    bool result;
+    struct result_params params;
+
+    assert(ri != NULL);
+    assert(ri->peers != NULL);
+
+    /* Check whether udevadm verify is available. */
+    details = run_udevadm_verify(&rc, ri, NULL);
+
+    /* Skip the inspection if udevadm verify is not available. */
+    if (rc != 0) {
+        init_result_params(&params);
+        params.header = NAME_UDEVRULES;
+        params.severity = RESULT_SKIP;
+        params.verb = VERB_SKIP;
+        params.details = details;
+        add_result(ri, &params);
+        free(details);
+        return true;
+    }
+
+    free(details);
+
+    /* Perform syntax check on udev rules files using udevadm verify. */
+    result = foreach_peer_file(ri, NAME_UDEVRULES, udevrules_driver);
+
+    if (result) {
+        init_result_params(&params);
+        params.header = NAME_UDEVRULES;
+        params.severity = RESULT_OK;
+        params.verb = VERB_OK;
+        add_result(ri, &params);
+    }
+
+    return result;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -71,6 +71,7 @@ librpminspect_sources = [
     'inspect_subpackages.c',
     'inspect_symlinks.c',
     'inspect_types.c',
+    'inspect_udevrules.c',
     'inspect_unicode.c',
     'inspect_upstream.c',
     'inspect_virus.c',

--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -117,6 +117,15 @@ Recommends:     libabigail >= 2.3
 Requires:       libabigail >= 2.3
 %endif
 
+# The udevrules inspection requires an external executable (udevadm verify)
+# provided by systemd-udev.  If the installed udevadm executable does not
+# provide 'verify' command, the udevrules inspection is skipped.
+%if 0%{?rhel} >= 8 || 0%{?epel} >= 8 || 0%{?fedora}
+Recommends:     systemd-udev
+%else
+Requires:       systemd-udev
+%endif
+
 %description -n librpminspect
 The library providing the backend test functionality and API for the
 rpminspect frontend program.  This library can also be used by other

--- a/test/meson.build
+++ b/test/meson.build
@@ -193,6 +193,7 @@ if python.found()
         'test_specname.py',
         'test_symlinks.py',
         'test_types.py',
+        'test_udevrules.py',
         'test_unicode.py',
         'test_upstream.py',
         'test_virus.py',

--- a/test/test_udevrules.py
+++ b/test/test_udevrules.py
@@ -1,0 +1,223 @@
+#
+# Copyright The rpminspect Project Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import os
+import unittest
+from baseclass import TestCompareRPMs, TestCompareKoji, TestRPMs, TestKoji
+import rpmfluff
+
+# This check requires the udevadm verify executable in the PATH
+have_udevadm = True
+
+# As udevadm verify was introduced in systemd v254,
+# skip the udevrules tests if udevadm verify is not available.
+if os.system("udevadm verify --help >/dev/null 2>&1") != 0:
+    have_udevadm = False
+
+
+valid_udev_rules = """
+PROGRAM="a", RESULT=="b", GOTO="c"
+LABEL="c"
+"""
+
+
+invalid_udev_rules = """
+RESULT=="a", PROGRAM="b", GOTO="c"
+LABEL="d"
+"""
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class ValidUdevRulesRPM(TestRPMs):
+    """
+    Valid udev rules file is OK for RPMs
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/valid_udev.rules",
+            rpmfluff.SourceFile("valid_udev.rules", valid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "OK"
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class ShMalformedRPM(TestRPMs):
+    """
+    Invalid udev rules file is BAD for RPMs
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/invalid_udev.rules",
+            rpmfluff.SourceFile("invalid_udev.rules", invalid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class ValidUdevRulesKoji(TestKoji):
+    """
+    Valid udev rules file is OK for Koji build
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/valid_udev.rules",
+            rpmfluff.SourceFile("valid_udev.rules", valid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "OK"
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class ShMalformedKoji(TestKoji):
+    """
+    Invalid udev rules file is BAD for Koji build
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/invalid_udev.rules",
+            rpmfluff.SourceFile("invalid_udev.rules", invalid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class ValidUdevRulesCompareRPMs(TestCompareRPMs):
+    """
+    Valid udev rules file is OK for comparing RPMs
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/valid_udev.rules",
+            rpmfluff.SourceFile("valid_udev.rules", valid_udev_rules),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/valid_udev.rules",
+            rpmfluff.SourceFile("valid_udev.rules", valid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "OK"
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class ShMalformedCompareRPMs(TestCompareRPMs):
+    """
+    Invalid udev rules file is BAD for comparing RPMs
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/invalid_udev.rules",
+            rpmfluff.SourceFile("invalid_udev.rules", invalid_udev_rules),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/invalid_udev.rules",
+            rpmfluff.SourceFile("invalid_udev.rules", invalid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class ValidUdevRulesCompareKoji(TestCompareKoji):
+    """
+    Valid udev rules file is OK for comparing Koji builds
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/valid_udev.rules",
+            rpmfluff.SourceFile("valid_udev.rules", valid_udev_rules),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/valid_udev.rules",
+            rpmfluff.SourceFile("valid_udev.rules", valid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "OK"
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class ShMalformedCompareKoji(TestCompareKoji):
+    """
+    Invalid udev rules file is BAD for comparing Koji builds
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/invalid_udev.rules",
+            rpmfluff.SourceFile("invalid_udev.rules", invalid_udev_rules),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/invalid_udev.rules",
+            rpmfluff.SourceFile("invalid_udev.rules", invalid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class InvalidUdevRulesCompareRPMs(TestCompareRPMs):
+    """
+    Valid udev rules file in before, invalid in after is BAD when comparing RPMs
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/valid_udev.rules",
+            rpmfluff.SourceFile("valid_udev.rules", valid_udev_rules),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/invalid_udev.rules",
+            rpmfluff.SourceFile("invalid_udev.rules", invalid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"
+
+
+@unittest.skipUnless(have_udevadm, "udevadm verify is not available")
+class InvalidUdevRulesCompareKoji(TestCompareKoji):
+    """
+    Valid udev rules file in before, invalid in after is BAD when comparing Koji builds
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/valid_udev.rules",
+            rpmfluff.SourceFile("valid_udev.rules", valid_udev_rules),
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/lib/udev/rules.d/invalid_udev.rules",
+            rpmfluff.SourceFile("invalid_udev.rules", invalid_udev_rules),
+        )
+        self.inspection = "udevrules"
+        self.result = "BAD"
+        self.waiver_auth = "Anyone"


### PR DESCRIPTION
The udevrules inspection checks udev rules files syntax using "udevadm verify".  The latter is a new udevadm tool command introduced in systemd v254.