### PR TITLE
ci: use ShellCheck with SARIF support

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,20 +3,26 @@ name: ShellCheck
 on:
     push:
         branches: [ main ]
-        paths:
-        - '**.sh'
-
     pull_request:
         branches: [ main ]
-        paths:
-        - '**.sh'
+
+permissions:
+    contents: read
 
 jobs:
     shellcheck:
         runs-on: ubuntu-latest
-        # Ubuntu's ShellCheck is old enough to not have --severity
-        container: fedora:latest
+
+        permissions:
+            security-events: write
+
         steps:
-            - uses: actions/checkout@v2
-            - run: dnf install -y ShellCheck xz findutils
-            - run: find . -type f -name "*.sh" -exec shellcheck --severity=warning {} \;
+            - uses: actions/checkout@v3
+              with:
+                fetch-depth: 0
+
+            # https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme
+            - uses: redhat-plumbers-in-action/differential-shellcheck@v4
+              with:
+                severity: warning
+                token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It performs differential and full ShellCheck scans and reports results directly on GitHub.

`differential-shellcheck` Action produce reports in SARIF format. GitHub understands this format and is able to display it nicely as a PR comment, and on the `Files Changed` tab, such a defect is easier to spot and fix.

![image](https://user-images.githubusercontent.com/2879818/183250924-b24fdcf1-c10c-4e7a-b4e5-76f25c1e06a0.png)

![image](https://user-images.githubusercontent.com/2879818/183250933-27cd182f-47f5-42fd-a2e6-1789bf5c3fc3.png)

Documentation is available at [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme). Let me know If you are missing some feature or setting. I'm always happy to extend functionality.