### PR TITLE
[fix] Improve debuginfo and debugsource package detection

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -431,18 +431,25 @@
 #define BUILD_ID_DIR "/.build-id/"
 
 /**
- * @def DEBUGINFO_SUFFIX
+ * @def DEBUGINFO_PROVIDE
  *
- * The debuginfo package name suffix string.
+ * The Provides string in debuginfo packages.
  */
-#define DEBUGINFO_SUFFIX "-debuginfo"
+#define DEBUGINFO_PROVIDE "debuginfo(build-id)"
 
 /**
- * @def DEBUGSOURCE_SUFFIX
+ * @def DEBUGINFO_SUBSTRING
  *
- * The debugsource package name suffix string.
+ * The debuginfo package name substring.
  */
-#define DEBUGSOURCE_SUFFIX "-debugsource"
+#define DEBUGINFO_SUBSTRING "-debuginfo"
+
+/**
+ * @def DEBUGSOURCE_SUBSTRING
+ *
+ * The debugsource package name substring.
+ */
+#define DEBUGSOURCE_SUBSTRING "-debugsource"
 
 /**
  * @def DEBUG_PATH

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -235,6 +235,8 @@ const char *get_rpm_header_arch(Header);
 string_list_t *get_rpm_header_string_array(Header h, rpmTagVal tag);
 char *get_rpm_header_value(const rpmfile_entry_t *file, rpmTag tag);
 char *extract_rpm_payload(const char *rpm);
+bool is_debuginfo_rpm(Header hdr);
+bool is_debugsource_rpm(Header hdr);
 
 /* peers.c */
 rpmpeer_t *init_peers(void);

--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -116,9 +116,9 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
             r = rpmtdGetString(req);
 
             /* skip some rules types */
-            if (!strcmp(r, "debuginfo(build-id)")
-                || strsuffix(r, DEBUGSOURCE_SUFFIX)
-                || strsuffix(r, DEBUGINFO_SUFFIX)
+            if (!strcmp(r, DEBUGINFO_PROVIDE)
+                || strstr(r, DEBUGSOURCE_SUBSTRING)
+                || strstr(r, DEBUGINFO_SUBSTRING)
                 || ((strprefix(r, "rpmlib(") || strprefix(r, "rtld(")) && strsuffix(r, ")"))
                 || ((strprefix(r, "kernel(") || strprefix(r, "modalias(") || strprefix(r, "ksym(") || strprefix(r, "kmod(")) && strsuffix(r, ")"))) {
                 continue;

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -96,7 +96,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Skip debuginfo and debugsource packages */
     name = headerGetString(file->rpm_header, RPMTAG_NAME);
 
-    if (strsuffix(name, DEBUGINFO_SUFFIX) || strsuffix(name, DEBUGSOURCE_SUFFIX)) {
+    if (is_debuginfo_rpm(file->rpm_header) || is_debugsource_rpm(file->rpm_header)) {
         return true;
     }
 

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -34,7 +34,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Skip debuginfo and debugsource packages */
     name = headerGetString(file->rpm_header, RPMTAG_NAME);
 
-    if (strsuffix(name, DEBUGINFO_SUFFIX) || strsuffix(name, DEBUGSOURCE_SUFFIX)) {
+    if (is_debuginfo_rpm(file->rpm_header) || is_debugsource_rpm(file->rpm_header)) {
         return true;
     }
 

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -48,7 +48,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     name = headerGetString(file->rpm_header, RPMTAG_NAME);
 
     /* skip debuginfo and debugsource packages */
-    if (strsuffix(name, DEBUGINFO_SUFFIX) || strsuffix(name, DEBUGSOURCE_SUFFIX)) {
+    if (is_debuginfo_rpm(file->rpm_header) || is_debugsource_rpm(file->rpm_header)) {
         return true;
     }
 

--- a/lib/inspect_debuginfo.c
+++ b/lib/inspect_debuginfo.c
@@ -159,7 +159,6 @@ static bool debuginfo_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool result = true;
     const char *arch = NULL;
-    const char *name = NULL;
     char *nvr = NULL;
     char *tmp = NULL;
     bool debugpkg = false;
@@ -191,12 +190,11 @@ static bool debuginfo_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* the package nvr and arch is used for reporting */
-    name = headerGetString(file->rpm_header, RPMTAG_NAME);
     nvr = get_nevr(file->rpm_header);
     arch = get_rpm_header_arch(file->rpm_header);
 
     /* debuginfo and debugsource packages have special handling */
-    if (strsuffix(name, DEBUGINFO_SUFFIX) || strsuffix(name, DEBUGSOURCE_SUFFIX)) {
+    if (is_debuginfo_rpm(file->rpm_header) || is_debugsource_rpm(file->rpm_header)) {
         debugpkg = true;
     }
 

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -54,7 +54,7 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     name = headerGetString(file->rpm_header, RPMTAG_NAME);
 
     /* skip debuginfo and debugsource packages */
-    if (strsuffix(name, DEBUGINFO_SUFFIX) || strsuffix(name, DEBUGSOURCE_SUFFIX)) {
+    if (is_debuginfo_rpm(file->rpm_header) || is_debugsource_rpm(file->rpm_header)) {
         return true;
     }
 

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -854,7 +854,7 @@ static bool elf_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     }
 
     /* Skip debuginfo packages and debugsource packages */
-    if (strsuffix(name, DEBUGINFO_SUFFIX) || strsuffix(name, DEBUGSOURCE_SUFFIX)) {
+    if (is_debuginfo_rpm(after->rpm_header) || is_debugsource_rpm(after->rpm_header)) {
         return true;
     }
 

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -153,7 +153,7 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     name = headerGetString(file->rpm_header, RPMTAG_NAME);
     assert(name != NULL);
 
-    if (!strsuffix(name, DEBUGINFO_SUFFIX)) {
+    if (!is_debuginfo_rpm(file->rpm_header)) {
         return true;
     }
 

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -84,7 +84,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Skip debuginfo and debugsource packages */
     aftername = headerGetString(file->rpm_header, RPMTAG_NAME);
 
-    if (strsuffix(aftername, DEBUGINFO_SUFFIX) || strsuffix(aftername, DEBUGSOURCE_SUFFIX)) {
+    if (is_debuginfo_rpm(file->rpm_header) || is_debugsource_rpm(file->rpm_header)) {
         return true;
     }
 

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -154,7 +154,6 @@ bool inspect_removedfiles(struct rpminspect *ri)
     bool result = true;
     rpmpeer_entry_t *peer = NULL;
     rpmfile_entry_t *file = NULL;
-    const char *name = NULL;
     struct result_params params;
 
     assert(ri != NULL);
@@ -175,9 +174,7 @@ bool inspect_removedfiles(struct rpminspect *ri)
         }
 
         /* Skip debuginfo and debugsource packages */
-        name = headerGetString(peer->before_hdr, RPMTAG_NAME);
-
-        if (strsuffix(name, DEBUGINFO_SUFFIX) || strsuffix(name, DEBUGSOURCE_SUFFIX)) {
+        if (is_debuginfo_rpm(file->rpm_header) || is_debugsource_rpm(file->rpm_header)) {
             continue;
         }
 

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -97,7 +97,7 @@ const char *get_debuginfo_path(struct rpminspect *ri, const rpmfile_entry_t *fil
         assert(name != NULL);
 
         /* found debuginfo package */
-        if (strsuffix(name, DEBUGINFO_SUFFIX)) {
+        if (is_debuginfo_rpm(file->rpm_header)) {
             count++;
 
             /* used for older systems that generate single debuginfo packages */


### PR DESCRIPTION
Previously librpminspect was checking the RPMTAG_NAME to see if it ended in -debuginfo or -debugsource.  This was done because there was not an obvious RPMTAG_* header tag to indicate if a package was a debuginfo or debugsource package.  This detection method usually works, but some packages change how the construct debuginfo or debugsource package names.

This commit adds two new functions called is_debuginfo_rpm() and is_debugsource_rpm() that inspections can use to determine if the current package is a debuginfo or debugsource package.  The check for debuginfo looks for a Provides rpmdep that says "debuginfo(build-id)" or a Provides name that contains the substring "-debuginfo".  If either condition matches, the package is considered a debuginfo package.  For debugsource detection it just looks for a Provides name that contains the substring "-debugsource".

This may need some additional refinement over time, but it does fix some known problems seen with Fedora builds like the kernel.