### PR TITLE
[fix] Check peer->before_hdr in removedfiles for debuginfo or debugso…

### DIFF
--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -174,7 +174,7 @@ bool inspect_removedfiles(struct rpminspect *ri)
         }
 
         /* Skip debuginfo and debugsource packages */
-        if (is_debuginfo_rpm(file->rpm_header) || is_debugsource_rpm(file->rpm_header)) {
+        if (is_debuginfo_rpm(peer->before_hdr) || is_debugsource_rpm(peer->before_hdr)) {
             continue;
         }
 


### PR DESCRIPTION
…urce

Loop was using file->rpm_header (not defined at this point) rather than peer->before_hdr.

Fixes: #1178