### PR TITLE
[bld] Check for reallocarray() and only use if available

### DIFF
--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -501,7 +501,11 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
             if (i >= sz) {
                 sz *= 2;
                 errno = 0;
+#ifdef _HAVE_REALLOCARRAY
                 line_new = reallocarray(line, sz, sizeof(*line));
+#else
+                line_new = realloc(line, sz * sizeof(*line));
+#endif
 
                 if (errno == ENOMEM) {
                     warn("realloc");

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,11 @@ else
     inc = include_directories( '/usr/local/include', '/usr/include' )
 endif
 
+# See if we have reallocarray in libc
+if cc.has_function('reallocarray')
+    add_global_arguments('-D_HAVE_REALLOCARRAY', language : 'c')
+endif
+
 # On FreeBSD, figure out where strverscmp() is
 libiberty = cc.find_library('iberty',
                             dirs : search_dirs,


### PR DESCRIPTION
If reallocarray() is not available, fall back on realloc().  glibc did not get reallocarray() until 2.26.