### PR TITLE
[fix] Use RPMTAG_NOT_FOUND macro instead of -1

### DIFF
--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -181,7 +181,7 @@ static bool modularity_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Find how to find the header */
     tv = rpmTagGetValue("modularitylabel");
-    if (tv == -1) {
+    if (tv == RPMTAG_NOT_FOUND) {
         add_result(ri, &params);
         free(params.msg);
         return false;


### PR DESCRIPTION
In RPM 4.19, the internal representation of the rpmTagVal type has been changed from signed to unsigned.  That means, a plain check for the value of -1 (tag not found) returned from rpmTagGetValue() now produces a compiler warning.

In order to fix that, we have to either explicitly cast the literal -1 to (uint32_t)-1 or just use the RPMTAG_NOT_FOUND macro readily provided by RPM.

Choose the latter since that's the supported way, really, it's also now documented as such in the API docs for the rpmTagGetValue() function.