### PR TITLE
[ci] Deal with mandoc upstream server being down

### DIFF
--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -3,7 +3,15 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
 # The mandoc package in Alpine Linux lacks the library
-curl -O https://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/arch/post.sh
+++ b/osdeps/arch/post.sh
@@ -3,7 +3,15 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
 # There is no mandoc package in Arch Linux
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/centos7/post.sh
+++ b/osdeps/centos7/post.sh
@@ -47,7 +47,15 @@ pip"${PYTHON_VER}" install cpp-coveralls gcovr PyYAML timeout-decorator rpmfluff
 # Install the latest mandoc package to /usr/local, the official EPEL-7
 # repos may be dated.
 cd "${CWD}" || exit 1
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/debian-stable/post.sh
+++ b/osdeps/debian-stable/post.sh
@@ -14,7 +14,15 @@ esac
 
 # The mandoc package on Debian lacks libmandoc.a and
 # header files, which we need to build rpminspect
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/debian-testing/post.sh
+++ b/osdeps/debian-testing/post.sh
@@ -14,7 +14,15 @@ esac
 
 # The mandoc package on Debian lacks libmandoc.a and
 # header files, which we need to build rpminspect
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/freebsd/post.sh
+++ b/osdeps/freebsd/post.sh
@@ -34,7 +34,15 @@ pip install -q cpp-coveralls gcovr rpmfluff
 
 # libmandoc is missing on FreeBSD
 cd "${CWD}" || exit 1
-curl -O https://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/gentoo/post.sh
+++ b/osdeps/gentoo/post.sh
@@ -4,7 +4,15 @@ CWD="$(pwd)"
 
 # The mandoc package in Gentoo Linux is both masked and does not
 # install the library.
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/mageia/post.sh
+++ b/osdeps/mageia/post.sh
@@ -3,7 +3,15 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
 # Mageia Linux does not have mandoc
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/opensuse-leap/post.sh
+++ b/osdeps/opensuse-leap/post.sh
@@ -7,7 +7,15 @@ sed -i -e '/^%vendor/d' /usr/lib/rpm/macros.d/*
 
 # The mandoc package on OpenSUSE lacks libmandoc.a and
 # header files, which we need to build rpminspect
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/opensuse-tumbleweed/post.sh
+++ b/osdeps/opensuse-tumbleweed/post.sh
@@ -4,7 +4,15 @@ CWD="$(pwd)"
 
 # The mandoc package on OpenSUSE lacks libmandoc.a and
 # header files, which we need to build rpminspect
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | awk '{ print $6; }')"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/slackware/post.sh
+++ b/osdeps/slackware/post.sh
@@ -46,7 +46,15 @@ make install
 cd "${CWD}" || exit 1
 
 # There is no mandoc package, so build from source
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';

--- a/osdeps/ubuntu/post.sh
+++ b/osdeps/ubuntu/post.sh
@@ -4,7 +4,15 @@ CWD="$(pwd)"
 
 # The mandoc package on Ubuntu lacks libmandoc.a and
 # header files, which we need to build rpminspect
-curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
+    curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
+else
+    # failed to connect to upstream host; take Debian's source
+    DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
+    # figure out which one is the latest and get that
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
+fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"
 tar -xf mandoc.tar.gz
 { echo 'PREFIX=/usr/local';


### PR DESCRIPTION
If mandoc.bsd.lv cannot be reached, pull source from the Debian pool. We just need roughly the latest version of mandoc sources to build from.  And surprisingly Debian has that.