### PR TITLE
Handle initGenericErrorDefaultFunc -> xmlSetGenericErrorFunc

### DIFF
--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -17,6 +17,7 @@
 #include "inspect.h"
 #include "rpminspect.h"
 
+#ifndef _HAVE_XMLSETGENERICERRORFUNC
 /*
  * By default, libxml will send error messages to stderr.  Turn that off for
  * our purposes.
@@ -25,6 +26,7 @@ static void xml_silence_errors(void *ctx __attribute__((unused)), const char *ms
 {
     return;
 }
+#endif
 
 /*
  * Return true if the given file is a well-formed XML document, false otherwise.
@@ -34,13 +36,19 @@ static void xml_silence_errors(void *ctx __attribute__((unused)), const char *ms
 static bool is_xml_well_formed(const char *path, char **errors)
 {
     static bool initialized = false;
+#ifndef _HAVE_XMLSETGENERICERRORFUNC
     static xmlGenericErrorFunc silence = xml_silence_errors;
+#endif
     xmlParserCtxtPtr ctxt;
     xmlDocPtr doc;
     bool result = true;
 
     if (!initialized) {
+#ifdef _HAVE_XMLSETGENERICERRORFUNC
+        xmlSetGenericErrorFunc(NULL, NULL);
+#else
         initGenericErrorDefaultFunc(&silence);
+#endif
         LIBXML_TEST_VERSION
         initialized = true;
     }

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,11 @@ clamav = dependency('libclamav', required : true)
 icu_uc = dependency('icu-uc', required : true)
 icu_io = dependency('icu-io', required : true)
 
+# Check for xmlSetGenericErrorFunc in newer releases of libxml
+if cc.has_function('xmlSetGenericErrorFunc', dependencies : [ libxml ])
+    add_project_arguments('-D_HAVE_XMLSETGENERICERRORFUNC', language : 'c')
+endif
+
 # Check for newer CURLcode in libcurl
 curlinfo_src = '''
     #include <curl/curl.h>


### PR DESCRIPTION
Newer releases of libxml have deprecated initGenericErrorDefaultFunc in favor of xmlSetGenericErrorFunc, so make sure we handle building on those systems.