### PR TITLE
Fix up the patches test for currently broken CI jobs

### DIFF
--- a/.github/workflows/almalinux.yml
+++ b/.github/workflows/almalinux.yml
@@ -39,13 +39,7 @@ jobs:
             # Requirements before the git clone can happen
             - name: git clone requirements
               run: |
-                  yum install -y epel-release
-
-                  if [ -d /etc/pki/rpm-gpg ]; then
-                      rpm --import /etc/pki/rpm-gpg/*
-                  fi
-
-                  yum install -y git
+                  yum install -y epel-release git
                   git config --global --add safe.directory /__w/rpminspect/rpminspect
 
             # This means clone the git repo

--- a/.github/workflows/rockylinux.yml
+++ b/.github/workflows/rockylinux.yml
@@ -39,13 +39,7 @@ jobs:
             # Requirements before the git clone can happen
             - name: git clone requirements
               run: |
-                  yum install -y epel-release
-
-                  if [ -d /etc/pki/rpm-gpg ]; then
-                      rpm --import /etc/pki/rpm-gpg/*
-                  fi
-
-                  yum install -y git
+                  yum install -y epel-release git
                   git config --global --add safe.directory /__w/rpminspect/rpminspect
 
             # This means clone the git repo

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,11 +27,17 @@ Contributors
 
 - Jakub Wilk <jwilk@jwilk.net>
 
+- Jan Macku <jamacku@redhat.com>
+
 - Jeremy Cline <jcline@redhat.com>
+
+- Jesus Checa Hidalgo <jchecahi@redhat.com>
 
 - Jim Bair <jbair@redhat.com>
 
 - Martin Pitt <martin@piware.de>
+
+- Michal Domonkos <mdomonko@redhat.com>
 
 - Michal Srb <michal@redhat.com>
 

--- a/osdeps/amzn2/reqs.txt
+++ b/osdeps/amzn2/reqs.txt
@@ -22,7 +22,6 @@ libabigail
 libarchive-devel
 libcap-devel
 libcurl-devel
-libdson-devel
 libffi-devel
 libicu-devel
 libmandoc-devel

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -3,11 +3,21 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+import rpm
 import subprocess
 import rpmfluff
 import unittest
+from distutils.version import LooseVersion
 
 from baseclass import TestSRPM, TestCompareSRPM
+
+# rpm < v4.18 does not support '%patch N' syntax
+rpmver = list(map(lambda x: int(x), rpm.__version__.strip().split("-")[0].split(".")))
+
+if LooseVersion("%d.%d" % (rpmver[0], rpmver[1])) <= LooseVersion("4.18"):
+    patch_N_supported = False
+else:
+    patch_N_supported = True
 
 # Check to see if %autopatch works (requires lua)
 proc = subprocess.Popen(
@@ -531,6 +541,9 @@ class PatchFilenameWithMacroCompareSRPM(TestCompareSRPM):
 
 # '%patch N' syntax used to apply patch
 class PatchNMacroSRPM(TestSRPM):
+    @unittest.skipUnless(
+        patch_N_supported, "rpmbuild v4.14 does not support '%patch N' syntax"
+    )
     def setUp(self):
         super().setUp()
 
@@ -550,6 +563,9 @@ class PatchNMacroSRPM(TestSRPM):
 
 
 class PatchNMacroCompareSRPM(TestCompareSRPM):
+    @unittest.skipUnless(
+        patch_N_supported, "rpmbuild v4.14 does not support '%patch N' syntax"
+    )
     def setUp(self):
         super().setUp()
 


### PR DESCRIPTION
Skip the '%patch N' macro tests for systems with rpm < 4.18.  Also some other cleanups for CI control files.