### PR TITLE
[fix] General cleanups to address static analysis errors

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -140,7 +140,7 @@ string_list_t * list_intersection(const string_list_t *, const string_list_t *);
 string_list_t * list_union(const string_list_t *, const string_list_t *);
 string_list_t * list_symmetric_difference(const string_list_t *, const string_list_t *);
 typedef void (*list_entry_data_free_func)(void *);
-void list_free(string_list_t *, list_entry_data_free_func);
+void list_free(string_list_t *, list_entry_data_free_func, const bool);
 size_t list_len(const string_list_t *);
 string_list_t * list_sort(const string_list_t *);
 string_list_t * list_copy(const string_list_t *);

--- a/lib/abi.c
+++ b/lib/abi.c
@@ -82,7 +82,7 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
 
             if (list_len(linekv) != 2) {
                 warn(_("malformed ABI level entry: %s"), line->data);
-                list_free(linekv, free);
+                list_free(linekv, free, true);
                 continue;
             }
 
@@ -94,7 +94,7 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
 
             if (dsos == NULL) {
                 warn("malformed DSO list: %s", dso->data);
-                list_free(linekv, free);
+                list_free(linekv, free, true);
                 continue;
             }
 
@@ -127,14 +127,14 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
             }
 
             /* clean up */
-            list_free(linekv, free);
-            list_free(dsos, free);
+            list_free(linekv, free, true);
+            list_free(dsos, free, true);
             entry = NULL;          /* for the next loop iteration */
         }
     }
 
     /* clean up */
-    list_free(contents, free);
+    list_free(contents, free, true);
 
     return r;
 }
@@ -152,9 +152,9 @@ void free_abi(abi_t *table)
     }
 
     HASH_ITER(hh, table, entry, tmp_entry) {
-        HASH_DEL(table, entry);
         free(entry->pkg);
-        list_free(entry->dsos, free);
+        list_free(entry->dsos, free, false);
+        HASH_DEL(table, entry);
     }
 
     free(table);

--- a/lib/abspath.c
+++ b/lib/abspath.c
@@ -69,8 +69,8 @@ char *abspath(const char *path)
     }
 
     /* clean up */
-    list_free(tokens, free);
-    list_free(newpath, free);
+    list_free(tokens, free, true);
+    list_free(newpath, free, true);
     free(p);
 
     return r;

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -477,7 +477,7 @@ static int download_build(struct rpminspect *ri, const struct koji_build *build)
             free(pkg);
         }
 
-        list_free(filter, free);
+        list_free(filter, free, true);
         filter = NULL;
     }
 
@@ -596,7 +596,7 @@ static int download_task(struct rpminspect *ri, struct koji_task *task)
                 dst = realloc(dst, len + strlen(pkg) + 2);
                 tail = dst + len;
                 tail = stpcpy(tail, "/");
-                tail = stpcpy(tail, pkg);
+                (void) stpcpy(tail, pkg);
                 assert(dst != NULL);
 
                 xasprintf(&src, "%s/work/%s", workri->kojiursine, entry->data);
@@ -669,10 +669,6 @@ static int download_rpm(struct rpminspect *ri, const char *rpm)
         ri->download_size += rpmsize;
     }
 
-    /* the RPM filename */
-    pkg = strdup(rpm);
-    assert(pkg != NULL);
-
     /* create the destination directory */
     if (fetch_only) {
         dstdir = strdup(workri->worksubdir);
@@ -682,8 +678,13 @@ static int download_rpm(struct rpminspect *ri, const char *rpm)
 
     if (mkdirp(dstdir, mode)) {
         warn("mkdirp");
+        free(dstdir);
         return -1;
     }
+
+    /* the RPM filename */
+    pkg = strdup(rpm);
+    assert(pkg != NULL);
 
     /* set working subdirectory */
     set_worksubdir(workri, LOCAL_WORKDIR, NULL, NULL);

--- a/lib/checksums.c
+++ b/lib/checksums.c
@@ -87,8 +87,7 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
     }
 
     /* don't calculate the checksum of a device node */
-    if (S_ISCHR(*mode) || S_ISBLK(*mode) ||
-        S_ISFIFO(*mode) || S_ISSOCK(*mode)) {
+    if (S_ISCHR(*mode) || S_ISBLK(*mode) || S_ISFIFO(*mode) || S_ISSOCK(*mode)) {
         warnx(_("%s is a FIFO"), filename);
         return NULL;
     }
@@ -112,12 +111,16 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
     }
 
     /* read in the file to generate the requested checksum */
-    if ((input = open(filename, O_RDONLY)) == -1) {
+    input = open(filename, O_RDONLY);
+
+    if (input == -1) {
         warn("open");
         return NULL;
     }
 
-    if ((len = read(input, buf, sizeof(buf))) == -1) {
+    len = read(input, buf, sizeof(buf));
+
+    if (len == -1) {
         warn("read");
         return NULL;
     }
@@ -134,7 +137,9 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
             SHA512_Update(&sha512c, buf, len);
         }
 
-        if ((len = read(input, buf, sizeof(buf))) == -1) {
+        len = read(input, buf, sizeof(buf));
+
+        if (len == -1) {
             warn("read");
             return NULL;
         }
@@ -171,7 +176,9 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
     }
 
     /* this is our human readable digest, caller must free */
-    if ((ret = calloc(len + 1, sizeof(char *))) == NULL) {
+    ret = calloc(len + 1, sizeof(buf));
+
+    if (ret == NULL) {
         warn("calloc");
         return NULL;
     }

--- a/lib/copyfile.c
+++ b/lib/copyfile.c
@@ -85,6 +85,7 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose)
 
     if (mkdirp(destdir, S_IRWXU) == -1) {
         warn("mkdirp");
+        free(destpath);
         return -1;
     }
 

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -146,6 +146,7 @@ char *get_file_delta(const char *a, const char *b)
 
     if (fill_mmfile(&old, a) < 0 || fill_mmfile(&new, b) < 0) {
         warn("fill_mmfile");
+//        free(old.ptr);
         return NULL;
     }
 
@@ -176,7 +177,7 @@ char *get_file_delta(const char *a, const char *b)
     }
 
     r = list_to_string(list, "\n");
-    list_free(list, free);
+    list_free(list, free, true);
     free(old.ptr);
     free(new.ptr);
 

--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -479,11 +479,11 @@ bool deprules_match(const deprule_entry_t *a, const deprule_entry_t *b)
     }
 
     /* trim any leading parens in case of rich deps */
-    while (*ra == '(') {
+    while (ra && *ra == '(') {
         ra++;
     }
 
-    while (*rb == '(') {
+    while (rb && *rb == '(') {
         rb++;
     }
 

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -115,7 +115,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(entry);
 
     tmp = list_to_string(details, " ");                     /* rejoin remaining details */
-    list_free(details, free);
+    list_free(details, free, true);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -138,7 +138,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(entry);
 
     tmp = list_to_string(details, " ");
-    list_free(details, free);
+    list_free(details, free, true);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -197,7 +197,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strdup(entry->data);
-    list_free(details, free);
+    list_free(details, free, true);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -214,7 +214,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strreplace(entry->data, ": Version ", " version ");
-    list_free(details, free);
+    list_free(details, free, true);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -231,7 +231,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strreplace(entry->data, ": ", " version ");
-    list_free(details, free);
+    list_free(details, free, true);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -247,7 +247,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strreplace(entry->data, ": ", " version ");
-    list_free(details, free);
+    list_free(details, free, true);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -66,7 +66,6 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
                     params.waiverauth = NOT_WAIVABLE;
                     add_result(ri, &params);
                     free(params.msg);
-                    free(params.remedy);
                     *reported = true;
                     return true;
                 } else {
@@ -77,7 +76,6 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
                         xasprintf(&params.msg, _("%s in %s on %s carries unexpected mode %04o; expected mode %04o; requires inspection by the Security Team"), file->localpath, pkg, params.arch, perms, fientry->mode);
                         add_result(ri, &params);
                         free(params.msg);
-                        free(params.remedy);
                         *result = false;
                         *reported = true;
                         return true;
@@ -98,12 +96,12 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
             xasprintf(&params.msg, _("%s in %s on %s carries insecure mode %04o, Security Team review may be required"), file->localpath, pkg, params.arch, perms);
             add_result(ri, &params);
             free(params.msg);
-            free(params.remedy);
             *result = false;
             *reported = true;
         }
     }
 
+    free(params.remedy);
     return false;
 }
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -359,9 +359,8 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
 
 cleanup:
     HASH_ITER(hh, path_table, path_entry, tmp_entry) {
-        HASH_DEL(path_table, path_entry);
         free(path_entry->path);
-        free(path_entry);
+        HASH_DEL(path_table, path_entry);
     }
 
     if (archive != NULL) {
@@ -817,7 +816,6 @@ void find_file_peers(rpmfile_t *before, rpmfile_t *after)
     /* Clean up the hash table */
     HASH_ITER(hh, after_table, entry, tmp_entry) {
         HASH_DEL(after_table, entry);
-        free(entry);
     }
 
     return;

--- a/lib/free.c
+++ b/lib/free.c
@@ -18,10 +18,9 @@ static void free_string_list_map(string_list_map_t *table)
     }
 
     HASH_ITER(hh, table, entry, tmp_entry) {
-        HASH_DEL(table, entry);
         free(entry->key);
-        list_free(entry->value, free);
-        free(entry);
+        list_free(entry->value, free, false);
+        HASH_DEL(table, entry);
     }
 
     return;
@@ -66,10 +65,9 @@ void free_string_map(string_map_t *table)
     }
 
     HASH_ITER(hh, table, entry, tmp_entry) {
-        HASH_DEL(table, entry);
         free(entry->key);
         free(entry->value);
-        free(entry);
+        HASH_DEL(table, entry);
     }
 
     return;
@@ -96,9 +94,9 @@ void free_rpminspect(struct rpminspect *ri)
     }
 
     free(ri->progname);
-    list_free(ri->cfgfiles, free);
+    list_free(ri->cfgfiles, free, true);
     free(ri->localcfg);
-    list_free(ri->locallines, free);
+    list_free(ri->locallines, free, true);
     free(ri->workdir);
     free(ri->kojihub);
     free(ri->kojiursine);
@@ -106,7 +104,7 @@ void free_rpminspect(struct rpminspect *ri)
     free(ri->worksubdir);
 
     free(ri->vendor_data_dir);
-    list_free(ri->licensedb, free);
+    list_free(ri->licensedb, free, true);
 
     if (ri->fileinfo) {
         while (!TAILQ_EMPTY(ri->fileinfo)) {
@@ -153,7 +151,7 @@ void free_rpminspect(struct rpminspect *ri)
     }
 
     free(ri->caps_filename);
-    list_free(ri->rebaseable, free);
+    list_free(ri->rebaseable, free, true);
     free(ri->rebaseable_filename);
 
     if (ri->politics) {
@@ -184,7 +182,6 @@ void free_rpminspect(struct rpminspect *ri)
             if (sentry->rules) {
                 HASH_ITER(hh, sentry->rules, srentry, tmp_srentry) {
                     HASH_DEL(sentry->rules, srentry);
-                    free(srentry);
                 }
             }
 
@@ -195,8 +192,8 @@ void free_rpminspect(struct rpminspect *ri)
     }
 
     free(ri->security_filename);
-    list_free(ri->badwords, free);
-    list_free(ri->icons, free);
+    list_free(ri->badwords, free, true);
+    list_free(ri->icons, free, true);
     free(ri->icons_filename);
 
     free_regex(ri->elf_path_include);
@@ -208,8 +205,8 @@ void free_rpminspect(struct rpminspect *ri)
 
     free(ri->elf_path_include_pattern);
     free(ri->elf_path_exclude_pattern);
-    list_free(ri->automacros, free);
-    list_free(ri->bad_functions, free);
+    list_free(ri->automacros, free, true);
+    list_free(ri->bad_functions, free, true);
     free_string_list_map(ri->bad_functions_allowed);
     free(ri->manpage_path_include_pattern);
     free(ri->manpage_path_exclude_pattern);
@@ -227,60 +224,59 @@ void free_rpminspect(struct rpminspect *ri)
     free(ri->commands.annocheck);
 #endif
 
-    list_free(ri->buildhost_subdomain, free);
-    list_free(ri->macrofiles, free);
-    list_free(ri->security_path_prefix, free);
-    list_free(ri->header_file_extensions, free);
-    list_free(ri->forbidden_path_prefixes, free);
-    list_free(ri->forbidden_path_suffixes, free);
-    list_free(ri->forbidden_directories, free);
+    list_free(ri->buildhost_subdomain, free, true);
+    list_free(ri->macrofiles, free, true);
+    list_free(ri->security_path_prefix, free, true);
+    list_free(ri->header_file_extensions, free, true);
+    list_free(ri->forbidden_path_prefixes, free, true);
+    list_free(ri->forbidden_path_suffixes, free, true);
+    list_free(ri->forbidden_directories, free, true);
     free(ri->before);
     free(ri->after);
     free(ri->product_release);
-    list_free(ri->arches, free);
-    list_free(ri->bin_paths, free);
+    list_free(ri->arches, free, true);
+    list_free(ri->bin_paths, free, true);
     free(ri->bin_owner);
     free(ri->bin_group);
-    list_free(ri->forbidden_owners, free);
-    list_free(ri->forbidden_groups, free);
-    list_free(ri->shells, free);
+    list_free(ri->forbidden_owners, free, true);
+    list_free(ri->forbidden_groups, free, true);
+    list_free(ri->shells, free, true);
     free_string_map(ri->jvm);
     free_string_map(ri->annocheck);
     free(ri->annocheck_profile);
     free_string_map(ri->pathmigration);
-    list_free(ri->pathmigration_excluded_paths, free);
+    list_free(ri->pathmigration_excluded_paths, free, true);
     free_string_map(ri->products);
-    list_free(ri->ignores, free);
-    list_free(ri->lto_symbol_name_prefixes, free);
-    list_free(ri->forbidden_paths, free);
+    list_free(ri->ignores, free, true);
+    list_free(ri->lto_symbol_name_prefixes, free, true);
+    list_free(ri->forbidden_paths, free, true);
     free(ri->abidiff_suppression_file);
     free(ri->abidiff_debuginfo_path);
     free(ri->abidiff_extra_args);
     free(ri->kmidiff_suppression_file);
     free(ri->kmidiff_debuginfo_path);
     free(ri->kmidiff_extra_args);
-    list_free(ri->kernel_filenames, free);
+    list_free(ri->kernel_filenames, free, true);
     free(ri->kabi_dir);
     free(ri->kabi_filename);
-    list_free(ri->patch_ignore_list, free);
-    list_free(ri->runpath_allowed_paths, free);
-    list_free(ri->runpath_allowed_origin_paths, free);
-    list_free(ri->runpath_origin_prefix_trim, free);
+    list_free(ri->patch_ignore_list, free, true);
+    list_free(ri->runpath_allowed_paths, free, true);
+    list_free(ri->runpath_allowed_origin_paths, free, true);
+    list_free(ri->runpath_origin_prefix_trim, free, true);
     free_string_list_map(ri->inspection_ignores);
-    list_free(ri->expected_empty_rpms, free);
+    list_free(ri->expected_empty_rpms, free, true);
     free_regex(ri->unicode_exclude);
-    list_free(ri->unicode_excluded_mime_types, free);
-    list_free(ri->unicode_forbidden_codepoints, free);
+    list_free(ri->unicode_excluded_mime_types, free, true);
+    list_free(ri->unicode_forbidden_codepoints, free, true);
     free_deprule_ignore_map(ri->deprules_ignore);
     free(ri->debuginfo_sections);
 
     free_peers(ri->peers);
 
     HASH_ITER(hh, ri->header_cache, hentry, tmp_hentry) {
-        HASH_DEL(ri->header_cache, hentry);
         free(hentry->pkg);
         headerFree(hentry->hdr);
-        free(hentry);
+        HASH_DEL(ri->header_cache, hentry);
     }
 
     free(ri->before_rel);
@@ -308,7 +304,7 @@ void free_deprules(deprule_list_t *list)
         TAILQ_REMOVE(list, entry, items);
         free(entry->requirement);
         free(entry->version);
-        list_free(entry->providers, free);
+        list_free(entry->providers, free, true);
         free(entry);
     }
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -191,7 +191,7 @@ static void process_table(const char *key, const char *value, const bool require
             tokens = list_add(tokens, value);
 
             tmp = list_to_string(tokens, " ");
-            list_free(tokens, free);
+            list_free(tokens, free, true);
         } else {
             tmp = strdup(value);
         }
@@ -981,7 +981,7 @@ bool init_fileinfo(struct rpminspect *ri)
         field = MODE;
     }
 
-    list_free(contents, free);
+    list_free(contents, free, true);
 
     return true;
 }
@@ -1121,7 +1121,7 @@ bool init_caps(struct rpminspect *ri)
         field = PACKAGE;
     }
 
-    list_free(contents, free);
+    list_free(contents, free, true);
 
     return true;
 }
@@ -1183,7 +1183,7 @@ bool init_rebaseable(struct rpminspect *ri)
         ri->rebaseable = list_add(ri->rebaseable, line);
     }
 
-    list_free(contents, free);
+    list_free(contents, free, true);
 
     return true;
 }
@@ -1283,7 +1283,7 @@ bool init_politics(struct rpminspect *ri)
         field = PATTERN;
     }
 
-    list_free(contents, free);
+    list_free(contents, free, true);
 
     return true;
 }
@@ -1401,7 +1401,7 @@ bool init_security(struct rpminspect *ri)
                 /* we must have a rule and action */
                 if (list_len(kv) != 2) {
                     warnx(_("*** invalid security rule: %s"), rentry->data);
-                    list_free(kv, free);
+                    list_free(kv, free, true);
                     continue;
                 }
 
@@ -1413,7 +1413,7 @@ bool init_security(struct rpminspect *ri)
 
                 if (stype == SECRULE_NULL) {
                     warnx(_("*** unknown security rule: %s"), key->data);
-                    list_free(kv, free);
+                    list_free(kv, free, true);
                     continue;
                 }
 
@@ -1422,7 +1422,7 @@ bool init_security(struct rpminspect *ri)
 
                 if (severity == RESULT_NULL) {
                     warnx(_("*** unknown security action: %s"), value->data);
-                    list_free(kv, free);
+                    list_free(kv, free, true);
                     continue;
                 }
 
@@ -1441,7 +1441,7 @@ bool init_security(struct rpminspect *ri)
                 }
 
                 /* clean up */
-                list_free(kv, free);
+                list_free(kv, free, true);
             }
 
             /* add new entry to the security rules list */
@@ -1451,15 +1451,15 @@ bool init_security(struct rpminspect *ri)
         }
 
         /* clean up */
-        free(path);
         free(pkg);
         free(ver);
         free(rel);
-        list_free(rules, free);
+        list_free(rules, free, true);
         pos = 0;
     }
 
-    list_free(contents, free);
+    list_free(contents, free, true);
+    free(path);
 
     return true;
 }
@@ -1517,7 +1517,7 @@ bool init_icons(struct rpminspect *ri)
         ri->icons = list_add(ri->icons, line);
     }
 
-    list_free(contents, free);
+    list_free(contents, free, true);
 
     return true;
 }

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -355,7 +355,7 @@ bool inspect_abidiff(struct rpminspect *ri)
     /* clean up */
     free_abi(abi);
     free(cmdprefix);
-    list_free(suppressions, free);
+    list_free(suppressions, free, true);
     free_pair(before_headers);
     free_pair(after_headers);
 

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -258,7 +258,7 @@ static struct libannocheck_internals *libannocheck_setup(struct rpminspect *ri, 
                     }
                 }
 
-                list_free(args, free);
+                list_free(args, free, true);
             }
         } else {
             annoerr = libannocheck_enable_all_tests(anno);
@@ -512,7 +512,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
             free(params.details);
             free(params.msg);
-            list_free(details, free);
+            list_free(details, free, true);
         }
     }
 
@@ -626,7 +626,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 }
             }
 
-            list_free(slist, free);
+            list_free(slist, free, true);
         }
 
         /* Cleanup */

--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -102,10 +102,10 @@ bool inspect_arch(struct rpminspect *ri)
         result = false;
     }
 
-    list_free(lost, free);
-    list_free(gain, free);
-    list_free(before_arches, free);
-    list_free(after_arches, free);
+    list_free(lost, free, true);
+    list_free(gain, free, true);
+    list_free(before_arches, free, true);
+    list_free(after_arches, free, true);
 
     return result;
 }

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -180,9 +180,9 @@ static bool badfuncs_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     free(output_buffer);
 
 cleanup:
-    list_free(after_symbols, free);
-    list_free(used_symbols, free);
-    list_free(sorted_used, free);
+    list_free(after_symbols, free, true);
+    list_free(used_symbols, free, true);
+    list_free(sorted_used, free, true);
 
     if (after_elf) {
         elf_end(after_elf);

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -297,7 +297,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             }
 
             if (rindex(type, '-')) {
-                comptype = rindex(comptype, '-') + 1;
+                comptype = rindex(type, '-') + 1;
                 assert(comptype != NULL);
             }
 

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -311,8 +311,8 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
         }
     }
 
-    list_free(before_changelog, free);
-    list_free(after_changelog, free);
+    list_free(before_changelog, free, true);
+    list_free(after_changelog, free, true);
     free(before_nevr);
     free(after_nevr);
     free(before_output);
@@ -411,8 +411,8 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     free(before_output);
     free(after_output);
-    list_free(before_changelog, free);
-    list_free(after_changelog, free);
+    list_free(before_changelog, free, true);
+    list_free(after_changelog, free, true);
     free(before_nevr);
     free(after_nevr);
 

--- a/lib/inspect_debuginfo.c
+++ b/lib/inspect_debuginfo.c
@@ -43,7 +43,7 @@ static uint64_t get_flags(const char *s)
         }
     }
 
-    list_free(sections, free);
+    list_free(sections, free, true);
     return r;
 }
 
@@ -111,7 +111,7 @@ static char *strflags(const uint64_t flags)
     }
 
     r = list_to_string(list, " ");
-    list_free(list, free);
+    list_free(list, free, true);
     return r;
 }
 
@@ -151,7 +151,7 @@ static bool is_guile(const char *path)
         }
     }
 
-    list_free(sections, free);
+    list_free(sections, free, true);
     return r;
 }
 

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -81,7 +81,7 @@ static int find_file(const char *fpath, __attribute__((unused)) const struct sta
                 if (strsuffix(fpath, tmp)) {
                     free(file_to_find);
                     file_to_find = strdup(fpath);
-                    list_free(list, free);
+                    list_free(list, free, true);
                     free(tmp);
                     return 1;
                 }
@@ -90,7 +90,7 @@ static int find_file(const char *fpath, __attribute__((unused)) const struct sta
             }
         }
 
-        list_free(list, free);
+        list_free(list, free, true);
     }
 
     /* Might be a base name missing a graphics format ending */
@@ -265,7 +265,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
 
                 if (lstat(file_to_find, &sb) == -1) {
                     warn("stat");
-                    list_free(contents, free);
+                    list_free(contents, free, true);
                     free(file_to_find);
                     return false;
                 }
@@ -344,7 +344,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
 
                 if (lstat(file_to_find, &sb) == -1) {
                     warn("stat");
-                    list_free(contents, free);
+                    list_free(contents, free, true);
                     free(file_to_find);
                     return false;
                 }
@@ -385,7 +385,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
         free(file_to_find);
     }
 
-    list_free(contents, free);
+    list_free(contents, free, true);
 
     return result;
 }

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -74,7 +74,7 @@ static bool check_release_macros(const int macrocount, const pair_list_t *macros
     if (tag_macros == NULL) {
         return false;
     } else if (TAILQ_EMPTY(tag_macros)) {
-        list_free(tag_macros, free);
+        list_free(tag_macros, free, true);
         return false;
     }
 
@@ -112,7 +112,7 @@ static bool check_release_macros(const int macrocount, const pair_list_t *macros
     }
 
     /* clean up */
-    list_free(tag_macros, free);
+    list_free(tag_macros, free, true);
 
     return ret;
 }
@@ -198,7 +198,7 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     free(expanded_release);
     free(params.msg);
-    list_free(contents, free);
+    list_free(contents, free, true);
     return result;
 }
 

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -189,8 +189,8 @@ done:
 
     free(removed);
     free(added);
-    list_free(before_needed, free);
-    list_free(after_needed, free);
+    list_free(before_needed, free, true);
+    list_free(after_needed, free, true);
 
     return result;
 }

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -385,7 +385,7 @@ static void add_execstack_flag_str(string_list_t *list, const char *s)
         return;
     }
 
-    list = list_add(list, s);
+    (void) list_add(list, s);
 
     return;
 }
@@ -496,7 +496,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
             xasprintf(&params.msg, _("File %s has invalid execstack flags (%s) on %s"), file->localpath, fs, arch);
 
             free(fs);
-            list_free(flaglist, free);
+            list_free(flaglist, free, true);
         } else {
             xasprintf(&params.msg, _("File %s has unrecognized GNU_STACK '%s' (expected RW or RWE) on %s"), file->localpath, pflags_to_str(execstack_flags), arch);
         }
@@ -773,11 +773,11 @@ static bool elf_archive_tests(struct rpminspect *ri, Elf *after_elf, int after_e
 
     free(params.msg);
 
-    list_free(after_lost_pic, free);
-    list_free(after_new, free);
-    list_free(after_no_pic, free);
-    list_free(before_pic, free);
-    list_free(before_all, free);
+    list_free(after_lost_pic, free, true);
+    list_free(after_new, free, true);
+    list_free(after_no_pic, free, true);
+    list_free(before_pic, free, true);
+    list_free(before_all, free, true);
 
     free(screendump);
 

--- a/lib/inspect_files.c
+++ b/lib/inspect_files.c
@@ -128,7 +128,7 @@ static bool files_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         valid_macro = false;
     }
 
-    list_free(spec, free);
+    list_free(spec, free, true);
     return result;
 }
 

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -268,9 +268,6 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
     }
 
-    /* check the ABI compat level list */
-    name = headerGetString(file->rpm_header, RPMTAG_NAME);
-
     /* add additional details */
     if (report) {
         params.file = file->localpath;
@@ -345,7 +342,7 @@ bool inspect_kmidiff(struct rpminspect *ri)
 
     /* clean up */
     free(cmdprefix);
-    list_free(suppressions, free);
+    list_free(suppressions, free, true);
     free(kabi_dir);
 
     /* report the inspection results */

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -82,8 +82,6 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Skip debuginfo and debugsource packages */
-    aftername = headerGetString(file->rpm_header, RPMTAG_NAME);
-
     if (is_debuginfo_rpm(file->rpm_header) || is_debugsource_rpm(file->rpm_header)) {
         return true;
     }
@@ -198,7 +196,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
         }
 
-        list_free(lost, free);
+        list_free(lost, free, true);
         lost = NULL;
     }
 
@@ -215,7 +213,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
         }
 
-        list_free(gain, free);
+        list_free(gain, free, true);
         gain = NULL;
     }
 
@@ -236,7 +234,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
         }
 
-        list_free(lost, free);
+        list_free(lost, free, true);
         lost = NULL;
     }
 
@@ -252,7 +250,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
         }
 
-        list_free(gain, free);
+        list_free(gain, free, true);
         gain = NULL;
     }
 

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -411,7 +411,7 @@ static bool is_valid_license(struct rpminspect *ri, struct result_params *params
                 }
             }
 
-            list_free(parenexps, free);
+            list_free(parenexps, free, true);
         }
 
         /* close this db */

--- a/lib/inspect_metadata.c
+++ b/lib/inspect_metadata.c
@@ -152,7 +152,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
             free(params.msg);
         }
 
-        if (strcmp(before_summary, after_summary)) {
+        if (before_summary && after_summary && strcmp(before_summary, after_summary)) {
             xasprintf(&params.msg, _("Package Summary change from \"%s\" to \"%s\" in %s"), before_summary, after_summary, after_name);
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
@@ -165,7 +165,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
             free(params.msg);
         }
 
-        if (strcmp(before_description, after_description)) {
+        if (before_description && after_description && strcmp(before_description, after_description)) {
             xasprintf(&params.msg, _("Package Description changed in %s"), after_name);
             xasprintf(&params.details, _("from:\n\n%s\n\nto:\n\n%s"), before_description, after_description);
             params.severity = RESULT_INFO;

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -51,7 +51,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Skip moved files */
-    if (file->moved_path && file->peer_file->moved_path) {
+    if (file->moved_path && (file->peer_file && file->peer_file->moved_path)) {
         return true;
     }
 

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -423,7 +423,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
             result = false;
         }
 
-        list_free(explicit_requires, free);
+        list_free(explicit_requires, free, true);
     }
 
     return result;
@@ -682,13 +682,13 @@ static bool expected_deprule_change(const bool rebase, const deprule_entry_t *de
             free(vr);
             free(evr);
             free(buf);
-            free(suffix);
         }
     } else if (deprule->version == NULL && found) {
         r = true;
     }
 
     free(req);
+    free(suffix);
     return r;
 }
 

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -196,7 +196,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
             }
         }
 
-        list_free(parts, free);
+        list_free(parts, free, true);
     }
 
     return r;
@@ -292,8 +292,8 @@ cleanup:
         close(fd);
     }
 
-    list_free(rpath, free);
-    list_free(runpath, free);
+    list_free(rpath, free, true);
+    list_free(runpath, free, true);
 
     return result;
 }

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -105,10 +105,10 @@ bool inspect_subpackages(struct rpminspect *ri)
         result = false;
     }
 
-    list_free(lost, free);
-    list_free(gain, free);
-    list_free(before_pkgs, free);
-    list_free(after_pkgs, free);
+    list_free(lost, free, true);
+    list_free(gain, free, true);
+    list_free(before_pkgs, free, true);
+    list_free(after_pkgs, free, true);
 
     /* Sound the everything-is-ok alarm if everything is, in fact, ok */
     if (result) {

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -153,7 +153,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             target++;
         }
 
-        tail = stpcpy(reltarget, target);
+        (void) stpcpy(reltarget, target);
     } else {
         /* link is relative */
         /*

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -117,8 +117,8 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* clean up */
-    list_free(bmt, free);
-    list_free(amt, free);
+    list_free(bmt, free, true);
+    list_free(amt, free, true);
     free(bnevra);
     free(anevra);
 

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -355,7 +355,7 @@ static char *manual_prep_source(struct rpminspect *ri, const rpmfile_entry_t *fi
     }
 
     free(fp);
-    list_free(sources, free);
+    list_free(sources, free, true);
     return build;
 }
 

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -91,6 +91,7 @@ static bool upstream_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("Upstream source file `%s` changed content"), params.file);
             params.verb = VERB_CHANGED;
             params.noun = _("checksum of ${FILE}");
+            params.details = diff_head;
             add_result(ri, &params);
             result = !(params.severity >= RESULT_VERIFY);
             reported = true;
@@ -201,9 +202,9 @@ bool inspect_upstream(struct rpminspect *ri)
             }
         }
 
-        list_free(removed, free);
-        list_free(before_source, free);
-        list_free(source, free);
+        list_free(removed, free, true);
+        list_free(before_source, free, true);
+        list_free(source, free, true);
     }
 
     free(params.remedy);

--- a/lib/joinpath.c
+++ b/lib/joinpath.c
@@ -75,8 +75,6 @@ char *joinpath(const char *path, ...)
         needsep = false;
 
         /* trim any extra trailing slashes */
-        i = strlen(built);
-
         while (*tail == '/') {
             *tail = '\0';
             tail--;

--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -164,11 +164,11 @@ bool compare_module_parameters(const struct kmod_list *before, const struct kmod
         *gain = list_copy(added);
     }
 
-    list_free(added, NULL);
-    list_free(difference, NULL);
-    list_free(before_parm_list, free);
-    list_free(after_parm_list, free);
-    list_free(combined, free);
+    list_free(added, NULL, true);
+    list_free(difference, NULL, true);
+    list_free(before_parm_list, free, true);
+    list_free(after_parm_list, free, true);
+    list_free(combined, free, true);
 
     return result;
 }
@@ -203,16 +203,16 @@ bool compare_module_dependencies(const struct kmod_list *before, const struct km
     if (difference == NULL || TAILQ_EMPTY(difference)) {
         DEBUG_PRINT("no kernel module deps differences\n");
 
-        list_free(difference, NULL);
-        list_free(before_depends_list, free);
-        list_free(after_depends_list, free);
+        list_free(difference, NULL, true);
+        list_free(before_depends_list, free, true);
+        list_free(after_depends_list, free, true);
 
         return true;
     }
 
     /* Otherwise, just free the difference, and return the before and after dependencies */
     DEBUG_PRINT("there are kernel module deps differences\n");
-    list_free(difference, NULL);
+    list_free(difference, NULL, true);
 
     *before_deps = before_depends_list;
     *after_deps = after_depends_list;
@@ -280,10 +280,9 @@ void free_module_aliases(kernel_alias_data_t *data)
     }
 
     HASH_ITER(hh, data, entry, tmp_entry) {
-        HASH_DEL(data, entry);
         free(entry->alias);
-        list_free(entry->modules, free);
-        free(entry);
+        list_free(entry->modules, free, false);
+        HASH_DEL(data, entry);
     }
 
     free(data);
@@ -386,7 +385,7 @@ bool compare_module_aliases(kernel_alias_data_t *before, kernel_alias_data_t *af
                 wildcard_search = true;
             }
 
-            list_free(difference, NULL);
+            list_free(difference, NULL, true);
         }
 
         /* Compare the results */
@@ -399,7 +398,7 @@ bool compare_module_aliases(kernel_alias_data_t *before, kernel_alias_data_t *af
 
         /* If after_modules was created from a wildcard search, free it */
         if (wildcard_search) {
-            list_free(after_modules, NULL);
+            list_free(after_modules, NULL, true);
         }
     }
 

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -550,9 +550,9 @@ void free_koji_task_entry(koji_task_entry_t *entry)
     }
 
     free_koji_task(entry->task);
-    list_free(entry->srpms, free);
-    list_free(entry->rpms, free);
-    list_free(entry->logs, free);
+    list_free(entry->srpms, free, true);
+    list_free(entry->rpms, free, true);
+    list_free(entry->logs, free, true);
     free(entry);
     entry = NULL;
 

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -231,14 +231,14 @@ string_list_t * list_symmetric_difference(const string_list_t *a, const string_l
     b_minus_a = list_difference(b, a);
 
     if (b_minus_a == NULL) {
-        list_free(a_minus_b, NULL);
+        list_free(a_minus_b, NULL, true);
         return NULL;
     }
 
     combination = list_union(a_minus_b, b_minus_a);
 
-    list_free(a_minus_b, NULL);
-    list_free(b_minus_a, NULL);
+    list_free(a_minus_b, NULL, true);
+    list_free(b_minus_a, NULL, true);
 
     return combination;
 }
@@ -247,7 +247,7 @@ string_list_t * list_symmetric_difference(const string_list_t *a, const string_l
  * Helper function to free a string_list_t and each entry->data.  If
  * the free_func is NULL, nothing is done to the entry->data values.
  */
-void list_free(string_list_t *list, list_entry_data_free_func free_func)
+void list_free(string_list_t *list, list_entry_data_free_func free_func, const bool free_list)
 {
     string_entry_t *entry = NULL;
 
@@ -266,7 +266,10 @@ void list_free(string_list_t *list, list_entry_data_free_func free_func)
         free(entry);
     }
 
-    free(list);
+    if (free_list) {
+        free(list);
+    }
+
     return;
 }
 
@@ -300,12 +303,9 @@ string_list_t *list_sort(const string_list_t *list)
 
     /* build a new string_list_t from the sorted hash table */
     HASH_ITER(hh, map, entry, tmp_entry) {
-        HASH_DEL(map, entry);
-
         sorted_list = list_add(sorted_list, entry->key);
-
         free(entry->key);
-        free(entry);
+        HASH_DEL(map, entry);
     }
 
     free(map);
@@ -331,7 +331,7 @@ size_t list_len(const string_list_t *list)
 
 /*
  * Returns a malloc'ed copy of the given list.  Caller must use
- * list_free(list, free) on the returned list.
+ * list_free(list, free, true) on the returned list.
  */
 string_list_t * list_copy(const string_list_t *list)
 {

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -131,7 +131,7 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
         if (list_len(fields) != 3) {
             /* not a macro line */
             DEBUG_PRINT("ignoring macro line (possibly a function): '%s'\n", specline->data);
-            list_free(fields, free);
+            list_free(fields, free, true);
             continue;
         }
 
@@ -147,22 +147,23 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
 
         if (strcmp(entry->data, SPEC_MACRO_DEFINE) && strcmp(entry->data, SPEC_MACRO_GLOBAL)) {
             /* ignore complex macros, like a conditional define with a %global */
-            list_free(fields, free);
+            list_free(fields, free, true);
             continue;
         }
 
         TAILQ_REMOVE(fields, entry, items);
+
+        if (strsuffix(entry->data, ")")) {
+            /* ignore macro functions */
+            list_free(fields, free, true);
+            continue;
+        }
+
         free(entry->data);
         free(entry);
 
         /* the macro name */
         entry = TAILQ_FIRST(fields);
-
-        if (strsuffix(entry->data, ")")) {
-            /* ignore macro functions */
-            list_free(fields, free);
-            continue;
-        }
 
         /* add the macro */
         pair = calloc(1, sizeof(*pair));
@@ -186,7 +187,7 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
     }
 
     /* clean up */
-    list_free(spec, free);
+    list_free(spec, free, true);
     regfree(&macro_regex);
 
     return n;
@@ -249,6 +250,6 @@ string_list_t *get_macros(const char *s)
         }
     }
 
-    list_free(fields, free);
+    list_free(fields, free, true);
     return macros;
 }

--- a/lib/mkdirp.c
+++ b/lib/mkdirp.c
@@ -74,6 +74,7 @@ int mkdirp(const char *path, mode_t mode)
                 continue;
             } else if (mkdir(start, mode) == -1) {
                 warn(_("*** unable to mkdir %s"), start);
+                free(start);
                 return -1;
             }
 
@@ -86,6 +87,7 @@ int mkdirp(const char *path, mode_t mode)
     /* final directory */
     if ((stat(start, &sb) != 0) && (mkdir(start, mode) == -1)) {
         warn(_("*** unable to mkdir %s"), start);
+        free(start);
         return -1;
     }
 

--- a/lib/pairfuncs.c
+++ b/lib/pairfuncs.c
@@ -24,7 +24,7 @@ bool pair_contains_key(const pair_list_t *list, const char *key)
     TAILQ_FOREACH(pair, list, items) {
         if (key == NULL && pair->key == key) {
             return true;
-        } else if (!strcmp(key, pair->key)) {
+        } else if (key && pair->key && !strcmp(key, pair->key)) {
             return true;
         }
     }

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -278,7 +278,7 @@ bool match_path(const char *pattern, const char *root, const char *path)
         len++;
     }
 
-    gp = stpcpy(gp, pattern);
+    (void) stpcpy(gp, pattern);
     r = glob(globpath, gflags, NULL, &found);
 
     if (r == GLOB_NOSPACE || r == GLOB_ABORTED) {

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -29,7 +29,6 @@
 static GElf_Half _get_elf_helper(Elf *elf, elfinfo_t type, GElf_Half fail)
 {
     GElf_Ehdr ehdr;
-    GElf_Half ret;
     Elf_Kind kind;
 
     assert(elf != NULL);
@@ -38,19 +37,19 @@ static GElf_Half _get_elf_helper(Elf *elf, elfinfo_t type, GElf_Half fail)
 
     if (gelf_getehdr(elf, &ehdr) == NULL) {
         warn("gelf_getehdr");
-        ret = fail;
+        return fail;
     }
 
     if (type == ELF_TYPE) {
-        ret = ehdr.e_type;
+        return ehdr.e_type;
     } else if (type == ELF_MACHINE) {
-        ret = ehdr.e_machine;
+        return ehdr.e_machine;
     } else {
         warn("unknown elftype_t %d", type);
-        ret = -1;
+        return fail;
     }
 
-    return ret;
+    return fail;
 }
 
 GElf_Half get_elf_type(Elf *elf)
@@ -246,7 +245,7 @@ string_list_t *get_elf_section_names(Elf *elf, size_t start)
     while ((scn = elf_nextscn(elf, scn)) != NULL) {
         /* get this header information */
         if (gelf_getshdr(scn, &shdr) != &shdr) {
-            list_free(names, free);
+            list_free(names, free, true);
             return NULL;
         }
 
@@ -517,12 +516,12 @@ static string_list_t *get_elf_symbol_list(Elf *elf, bool (*filter)(const char *)
 
     /* Get the section data */
     if ((data = elf_getdata(scn, NULL)) == NULL) {
-        list_free(list, NULL);
+        list_free(list, NULL, true);
         return NULL;
     }
 
     if ((xndxscn != NULL) && ((xndxdata = elf_getdata(xndxscn, NULL)) == NULL)) {
-        list_free(list, NULL);
+        list_free(list, NULL, true);
         return NULL;
     }
 
@@ -553,7 +552,7 @@ static string_list_t *get_elf_symbol_list(Elf *elf, bool (*filter)(const char *)
  * If filter is not NULL, only the symbol's returned true by the filter will be added.
  *
  * The memory pointed to by the list elements is owned by the Elf* context. The list
- * itself should be freed with list_free(<list>, NULL) by the caller.
+ * itself should be freed with list_free(<list>, NULL, true) by the caller.
  */
 string_list_t * get_elf_imported_functions(Elf *elf, bool (*filter)(const char *))
 {

--- a/lib/release.c
+++ b/lib/release.c
@@ -64,7 +64,7 @@ char *read_release(const rpmfile_t *files)
         }
     }
 
-    list_free(spec, free);
+    list_free(spec, free, true);
 
     return rel;
 }

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -437,10 +437,6 @@ char *extract_rpm_payload(const char *rpm)
         }
     }
 
-    if (rc == RPMERR_ITER_END) {
-        rc = 0;
-    }
-
 cleanup:
     free(hardlink);
     free(buf);

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -280,7 +280,7 @@ char **build_argv(const char *cmd)
         i++;
     }
 
-    list_free(list, free);
+    list_free(list, free, true);
     return r;
 }
 
@@ -319,9 +319,9 @@ void free_argv_table(struct rpminspect *ri, string_list_map_t *table)
     }
 
     HASH_ITER(hh, table, hentry, tmp_hentry) {
-        HASH_DEL(table, hentry);
         free(hentry->key);
-        list_free(hentry->value, free);
+        list_free(hentry->value, free, false);
+        HASH_DEL(table, hentry);
     }
 
     return;

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -20,7 +20,7 @@ static int printword(const char *word, const size_t width, const unsigned int in
 {
     int ret = 0;
 
-    if ((strlen(word) + lw) >= width) {
+    if (word && ((strlen(word) + lw) >= width)) {
         fprintf(dest, "\n");
         first = true;
 
@@ -603,7 +603,7 @@ char *strshorten(const char *s, size_t width)
     tail = stpncpy(tail, s, left_width);
     tail = stpcpy(tail, "...");
     s = s + input_len - right_width;
-    tail = stpcpy(tail, s);
+    (void) stpcpy(tail, s);
 
     return r;
 }

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -261,8 +261,6 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
         after_product = NULL;
     }
 
-    free(before_product);
-
     /* trim the leading period */
     if (after_product) {
         while (after_product[i] == '.' && after_product[i] != '\0') {
@@ -625,7 +623,7 @@ int main(int argc, char **argv)
         if (ri == NULL) {
             errx(RI_PROGRAM_ERROR, _("Failed to read configuration file %s"), tmp_cfgfile);
         }
-    } else if (access(cfgfile, F_OK|R_OK) == 0) {
+    } else if (cfgfile && (access(cfgfile, F_OK|R_OK) == 0)) {
         /* -c configuration file if it exists */
         ri = init_rpminspect(ri, cfgfile, profile);
         initialized = true;
@@ -767,7 +765,7 @@ int main(int argc, char **argv)
             }
 
             if (!found) {
-                list_free(valid_arches, free);
+                list_free(valid_arches, free, true);
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
@@ -781,7 +779,7 @@ int main(int argc, char **argv)
 
         /* clean up */
         free(archopt);
-        list_free(valid_arches, free);
+        list_free(valid_arches, free, true);
     }
 
     /* create the working directory */
@@ -871,7 +869,7 @@ int main(int argc, char **argv)
     add_result_entry(&ri->results, &params);
     free(params.msg);
     free(params.details);
-    list_free(diags, free);
+    list_free(diags, free, true);
 
     /* add command line information to the results output */
     xasprintf(&params.msg, _("Command line arguments used to invoke %s."), COMMAND_NAME);

--- a/test/lib/test-abspath.c
+++ b/test/lib/test-abspath.c
@@ -23,23 +23,37 @@ void test_abspath(void) {
 
     r = abspath("/../lib/jli");
     RI_ASSERT_PTR_NOT_NULL(r);
-    RI_ASSERT_EQUAL(strcmp(r, "/lib/jli"), 0);
-    free(r);
+
+    if (r) {
+        RI_ASSERT_EQUAL(strcmp(r, "/lib/jli"), 0);
+        free(r);
+    }
 
     r = abspath("/../lib64/");
     RI_ASSERT_PTR_NOT_NULL(r);
-    RI_ASSERT_EQUAL(strcmp(r, "/lib64"), 0);
-    free(r);
+
+    if (r) {
+        RI_ASSERT_EQUAL(strcmp(r, "/lib64"), 0);
+        free(r);
+    }
 
     r = abspath("/usr/lib/../lib64/../lib");
     RI_ASSERT_PTR_NOT_NULL(r);
-    RI_ASSERT_EQUAL(strcmp(r, "/usr/lib"), 0);
-    free(r);
+
+    if (r) {
+        RI_ASSERT_EQUAL(strcmp(r, "/usr/lib"), 0);
+        free(r);
+    }
 
     r = abspath("/usr/lib/../lib64/../lib/");
     RI_ASSERT_PTR_NOT_NULL(r);
-    RI_ASSERT_EQUAL(strcmp(r, "/usr/lib"), 0);
-    free(r);
+
+    if (r) {
+        RI_ASSERT_EQUAL(strcmp(r, "/usr/lib"), 0);
+        free(r);
+    }
+
+    return;
 }
 
 CU_pSuite get_suite(void) {

--- a/test/lib/test-badwords.c
+++ b/test/lib/test-badwords.c
@@ -55,7 +55,7 @@ int init_test_badwords(void) {
 }
 
 int clean_test_badwords(void) {
-    list_free(forbidden_words, free);
+    list_free(forbidden_words, free, true);
     return 0;
 }
 


### PR DESCRIPTION
Lots of fixups here for things found during static analysis.  Probably the biggest change is the list_free() function which gains a third parameter which is a boolean indicating whether or not you want the function to free the first parameter.  Previous behavior always did that, but in cases where I combine a TAILQ with a HASH, I need to not do that because HASH_DEL will want to free the main pointer too.