### PR TITLE
[lib] Make error messages more consistent throughout the code

### DIFF
--- a/lib/abi.c
+++ b/lib/abi.c
@@ -62,12 +62,12 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
              * seen it before
              */
             if (sscanf(line->data + 7, "%d]", &found_level) == EOF) {
-                warn(_("malformed ABI level identifier: %s"), line->data);
+                warn(_("*** malformed ABI level identifier: %s"), line->data);
                 skip_entries = true;
             }
 
             if (levels & (((uint64_t) 1) << found_level)) {
-                warn(_("ABI level %d already defined"), found_level);
+                warn(_("*** ABI level %d already defined"), found_level);
                 skip_entries = true;
             }
 
@@ -81,7 +81,7 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
             linekv = strsplit(line->data, "=");
 
             if (list_len(linekv) != 2) {
-                warn(_("malformed ABI level entry: %s"), line->data);
+                warn(_("*** malformed ABI level entry: %s"), line->data);
                 list_free(linekv, free, true);
                 continue;
             }
@@ -93,7 +93,7 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
             dsos = strsplit(dso->data, ",\n\r");
 
             if (dsos == NULL) {
-                warn("malformed DSO list: %s", dso->data);
+                warnx("*** malformed DSO list: %s", dso->data);
                 list_free(linekv, free, true);
                 continue;
             }

--- a/lib/checksums.c
+++ b/lib/checksums.c
@@ -88,7 +88,7 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
 
     /* don't calculate the checksum of a device node */
     if (S_ISCHR(*mode) || S_ISBLK(*mode) || S_ISFIFO(*mode) || S_ISSOCK(*mode)) {
-        warnx(_("%s is a FIFO"), filename);
+        warnx(_("*** %s is a FIFO"), filename);
         return NULL;
     }
 
@@ -114,14 +114,14 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
     input = open(filename, O_RDONLY);
 
     if (input == -1) {
-        warn("open");
+        warn("*** open");
         return NULL;
     }
 
     len = read(input, buf, sizeof(buf));
 
     if (len == -1) {
-        warn("read");
+        warn("*** read");
         return NULL;
     }
 
@@ -140,13 +140,13 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
         len = read(input, buf, sizeof(buf));
 
         if (len == -1) {
-            warn("read");
+            warn("*** read");
             return NULL;
         }
     }
 
     if (close(input) == -1) {
-        warn("close");
+        warn("*** close");
         return NULL;
     }
 
@@ -179,7 +179,7 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
     ret = calloc(len + 1, sizeof(buf));
 
     if (ret == NULL) {
-        warn("calloc");
+        warn("*** calloc");
         return NULL;
     }
 

--- a/lib/copyfile.c
+++ b/lib/copyfile.c
@@ -75,7 +75,7 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose)
 
     /* stat the source */
     if (lstat(src, &sb) == -1) {
-        warn("lstat");
+        warn("*** lstat");
         return -1;
     }
 
@@ -84,7 +84,6 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose)
     destdir = dirname(destpath);
 
     if (mkdirp(destdir, S_IRWXU) == -1) {
-        warn("mkdirp");
         free(destpath);
         return -1;
     }
@@ -94,12 +93,12 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose)
     /* if src is a symlink, handle it here */
     if (S_ISLNK(sb.st_mode)) {
         if (readlink(src, linkdest, PATH_MAX) == -1) {
-            warn("readlink");
+            warn("*** readlink");
             return -1;
         }
 
         if (symlink(linkdest, dest) == -1) {
-            warn("symlink");
+            warn("*** symlink");
             return -1;
         }
 
@@ -108,7 +107,7 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose)
 
     /* copy src to dest */
     if ((in = fopen(src, "r")) == NULL) {
-        warn("fopen");
+        warn("*** fopen");
         return -1;
     }
 
@@ -124,11 +123,11 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose)
                 }
 
                 if (remove(dest)) {
-                    warn("remove");
+                    warn("*** remove");
                     return -1;
                 } else {
                     if ((out_fd = open(dest, oflags, mode)) == -1) {
-                        warn("open");
+                        warn("*** open");
                     }
                 }
             } else {
@@ -137,36 +136,36 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose)
                 return -1;
             }
         } else {
-            warn("open");
+            warn("*** open");
             return -1;
         }
     }
 
     if ((out = fdopen(out_fd, "wb")) == NULL) {
-        warn("fdopen");
+        warn("*** fdopen");
         return -1;
     }
 
     while ((s = fread(buf, sizeof(char), BUFSIZ, in)) > 0) {
         if (fwrite(buf, sizeof(char), s, out) != s) {
-            warn("fwrite");
+            warn("*** fwrite");
             success = -1;
             break;
         }
     }
 
     if (fflush(out) != 0) {
-        warn("fflush");
+        warn("*** fflush");
         success = -1;
     }
 
     if (fclose(out) != 0) {
-        warn("fclose");
+        warn("*** fclose");
         success = -1;
     }
 
     if (fclose(in) != 0) {
-        warn("fclose");
+        warn("*** fclose");
     }
 
     if (success != 0) {
@@ -176,13 +175,13 @@ int copyfile(const char *src, const char *dest, bool force, bool verbose)
     /* set ownerships and permissions */
     if (geteuid() == 0) {
         if (chown(dest, sb.st_uid, sb.st_gid) == -1) {
-            warn("chown");
+            warn("*** chown");
             success = -1;
         }
     }
 
     if (chmod(dest, (sb.st_mode & (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO))) == -1) {
-        warn("chmod");
+        warn("*** chmod");
         success = -1;
     }
 

--- a/lib/curl.c
+++ b/lib/curl.c
@@ -174,7 +174,7 @@ void curl_get_file(const bool verbose, const char *src, const char *dst)
     c = curl_easy_init();
 
     if (!c) {
-        warn("curl_easy_init");
+        warn("*** curl_easy_init");
         return;
     }
 
@@ -202,7 +202,7 @@ void curl_get_file(const bool verbose, const char *src, const char *dst)
     fp = fopen(dst, "wb");
 
     if (fp == NULL) {
-        err(RI_PROGRAM_ERROR, "fopen");
+        err(RI_PROGRAM_ERROR, "*** fopen");
     }
 
     curl_easy_setopt(c, CURLOPT_URL, src);
@@ -219,13 +219,13 @@ void curl_get_file(const bool verbose, const char *src, const char *dst)
     }
 
     if (fclose(fp) != 0) {
-        err(RI_PROGRAM_ERROR, "fclose");
+        err(RI_PROGRAM_ERROR, "*** fclose");
     }
 
     /* remove output file if there was a download error (e.g., 404) */
     if (cc != CURLE_OK) {
         if (unlink(dst)) {
-            warn("unlink");
+            warn("*** unlink");
         }
     }
 
@@ -247,7 +247,7 @@ curl_off_t curl_get_size(const char *src)
 
     /* initialize curl */
     if (!(c = curl_easy_init())) {
-        warn("curl_easy_init");
+        warn("*** curl_easy_init");
         return 0;
     }
 
@@ -264,7 +264,7 @@ curl_off_t curl_get_size(const char *src)
     cc = curl_easy_perform(c);
 
     if (cc != CURLE_OK) {
-        warnx("unable to read %s", src);
+        warnx(_("*** unable to read %s"), src);
         return 0;
     }
 

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -33,7 +33,7 @@ static int fill_mmfile(mmfile_t *mf, const char *file)
     }
 
     if (stat(file, &sb)) {
-        warn("stat");
+        warn("*** stat");
         return 1;
     }
 
@@ -42,7 +42,7 @@ static int fill_mmfile(mmfile_t *mf, const char *file)
     buf = calloc(1, size + 1);
 
     if (buf == NULL) {
-        warn("malloc");
+        warn("*** malloc");
         return 1;
     }
 
@@ -72,7 +72,7 @@ static int fill_mmfile(mmfile_t *mf, const char *file)
     mf->size -= size;
 
     if (close(fd) < 0) {
-        warn("close");
+        warn("*** close");
     }
 
     return 0;
@@ -145,8 +145,7 @@ char *get_file_delta(const char *a, const char *b)
     char *r = NULL;
 
     if (fill_mmfile(&old, a) < 0 || fill_mmfile(&new, b) < 0) {
-        warn("fill_mmfile");
-//        free(old.ptr);
+        warn("*** fill_mmfile");
         return NULL;
     }
 
@@ -166,7 +165,7 @@ char *get_file_delta(const char *a, const char *b)
     ecb.outf = delta_out;
 
     if (xdl_diff(&old, &new, &xpp, &xecfg, &ecb) < 0) {
-        warn("xdl_diff");
+        warn("*** xdl_diff");
     }
 
     if (TAILQ_EMPTY(list)) {

--- a/lib/files.c
+++ b/lib/files.c
@@ -218,7 +218,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         rpm_path = rpmtdNextString(td);
 
         if (rpm_path == NULL) {
-            warn("rpmtdNextString");
+            warn("*** rpmtdNextString");
             goto cleanup;
         }
 
@@ -246,7 +246,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
 
         if (archive_read_open_filename(archive, payload, 10240) != ARCHIVE_OK) {
             /* still bad, so bail */
-            warnx("archive_read_open_filename: %s", archive_error_string(archive));
+            warnx("*** archive_read_open_filename: %s", archive_error_string(archive));
             goto cleanup;
         }
     }
@@ -262,7 +262,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         }
 
         if (archive_result != ARCHIVE_OK) {
-            warnx("archive_read_next_header: %s", archive_error_string(archive));
+            warnx("*** archive_read_next_header: %s", archive_error_string(archive));
             free_files(file_list);
             file_list = NULL;
             goto cleanup;
@@ -350,7 +350,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
 
         /* Write the file to disk */
         if (archive_read_extract(archive, entry, archive_flags) != ARCHIVE_OK) {
-            warnx("archive_read_extract: %s", archive_error_string(archive));
+            warnx("*** archive_read_extract: %s", archive_error_string(archive));
             free_files(file_list);
             file_list = NULL;
             goto cleanup;
@@ -369,7 +369,7 @@ cleanup:
 
     if (payload) {
         if (unlink(payload) == -1) {
-            warn("unlink");
+            warn("*** unlink");
         }
 
         free(payload);
@@ -512,7 +512,7 @@ static char *comparable_version_substrings(const char *s, const char *ignore)
 
     if (reg_result != 0) {
         regerror(reg_result, &num_regex, reg_error, sizeof(reg_error));
-        warn("regcomp: %s", reg_error);
+        warn("*** regcomp: %s", reg_error);
         return NULL;
     }
 

--- a/lib/fs.c
+++ b/lib/fs.c
@@ -17,7 +17,7 @@ unsigned long int get_available_space(const char *path)
     assert(path != NULL);
 
     if (statvfs(path, &svb) == -1) {
-        warn("statvfs");
+        warn("*** statvfs");
         return 0;
     }
 

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -113,7 +113,7 @@ static void set_libannocheck_profile(struct libannocheck_internals *anno, const 
         annoerr = libannocheck_enable_profile(anno, annocheck_profile);
 
         if (annoerr != libannocheck_error_none) {
-            warnx(_("libannocheck_enable_profile error: %s"), libannocheck_get_error_message(anno, annoerr));
+            warnx(_("*** libannocheck_enable_profile: %s"), libannocheck_get_error_message(anno, annoerr));
         }
 
         return;
@@ -133,7 +133,7 @@ static void set_libannocheck_profile(struct libannocheck_internals *anno, const 
     annoerr = libannocheck_get_known_profiles(anno, &profiles, &num_profiles);
 
     if (annoerr != libannocheck_error_none) {
-         warnx(_("libannocheck_get_known_profiles error: %s"), libannocheck_get_error_message(anno, annoerr));
+         warnx(_("*** libannocheck_get_known_profiles: %s"), libannocheck_get_error_message(anno, annoerr));
          return;
     }
 
@@ -148,7 +148,7 @@ static void set_libannocheck_profile(struct libannocheck_internals *anno, const 
             annoerr = libannocheck_enable_profile(anno, profiles[i]);
 
             if (annoerr != libannocheck_error_none) {
-                warnx(_("libannocheck_enable_profile error: %s"), libannocheck_get_error_message(anno, annoerr));
+                warnx(_("*** libannocheck_enable_profile: %s"), libannocheck_get_error_message(anno, annoerr));
             }
 
             return;
@@ -223,7 +223,7 @@ static struct libannocheck_internals *libannocheck_setup(struct rpminspect *ri, 
         annoerr = libannocheck_init(libannocheck_get_version(), file->fullpath, get_debuginfo_path(ri, file, arch, AFTER_BUILD), &anno);
 
         if (annoerr != libannocheck_error_none) {
-             warnx(_("libannocheck_init error: %s"), libannocheck_get_error_message(anno, annoerr));
+             warnx(_("*** libannocheck_init: %s"), libannocheck_get_error_message(anno, annoerr));
              return NULL;
         }
 
@@ -252,7 +252,7 @@ static struct libannocheck_internals *libannocheck_setup(struct rpminspect *ri, 
                     }
 
                     if (annoerr != libannocheck_error_none) {
-                        warnx(_("libannocheck_%s_test error: %s:"), test, libannocheck_get_error_message(anno, annoerr));
+                        warnx(_("*** libannocheck_%s_test: %s"), test, libannocheck_get_error_message(anno, annoerr));
                         libannocheck_finish(anno);
                         return NULL;
                     }
@@ -264,7 +264,7 @@ static struct libannocheck_internals *libannocheck_setup(struct rpminspect *ri, 
             annoerr = libannocheck_enable_all_tests(anno);
 
             if (annoerr != libannocheck_error_none) {
-                warnx(_("libannocheck_enable_all_tests error: %s:"), libannocheck_get_error_message(anno, annoerr));
+                warnx(_("*** libannocheck_enable_all_tests: %s"), libannocheck_get_error_message(anno, annoerr));
                 libannocheck_finish(anno);
                 return NULL;
             }
@@ -277,7 +277,7 @@ static struct libannocheck_internals *libannocheck_setup(struct rpminspect *ri, 
         annoerr = libannocheck_reinit(anno, file->fullpath, get_debuginfo_path(ri, file, arch, AFTER_BUILD));
 
         if (annoerr != libannocheck_error_none) {
-             warnx(_("libannocheck_reinit error: %s"), libannocheck_get_error_message(anno, annoerr));
+             warnx(_("*** libannocheck_reinit: %s"), libannocheck_get_error_message(anno, annoerr));
              libannocheck_finish(anno);
              return NULL;
         }
@@ -370,7 +370,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             annoerr = libannocheck_run_tests(ah, &failed, &maybe);
 
             if (annoerr != libannocheck_error_none) {
-                warnx(_("before libannocheck_run_tests error: %s (%d)"), libannocheck_get_error_message(ah, annoerr), annoerr);
+                warnx(_("*** before libannocheck_run_tests: %s (%d)"), libannocheck_get_error_message(ah, annoerr), annoerr);
                 libannocheck_finish(ah);
                 continue;
             }
@@ -379,7 +379,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             annoerr = libannocheck_get_known_tests(ah, &annotests, &numtests);
 
             if (annoerr != libannocheck_error_none) {
-                warnx(_("libannocheck_get_known_tests error: %s"), libannocheck_get_error_message(ah, annoerr));
+                warnx(_("*** libannocheck_get_known_tests: %s"), libannocheck_get_error_message(ah, annoerr));
                 libannocheck_finish(ah);
                 continue;
             }
@@ -397,7 +397,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             annoerr = libannocheck_finish(ah);
 
             if (annoerr != libannocheck_error_none) {
-                warnx(_("libannocheck_finish error: %s"), libannocheck_get_error_message(ah, annoerr));
+                warnx(_("*** libannocheck_finish: %s"), libannocheck_get_error_message(ah, annoerr));
             }
 
             ah = NULL;
@@ -414,7 +414,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         annoerr = libannocheck_run_tests(ah, &failed, &maybe);
 
         if (annoerr != libannocheck_error_none) {
-            warnx(_("after libannocheck_run_tests error: %s (%d)"), libannocheck_get_error_message(ah, annoerr), annoerr);
+            warnx(_("*** after libannocheck_run_tests: %s (%d)"), libannocheck_get_error_message(ah, annoerr), annoerr);
             libannocheck_finish(ah);
             continue;
         }
@@ -423,7 +423,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         annoerr = libannocheck_get_known_tests(ah, &annotests, &numtests);
 
         if (annoerr != libannocheck_error_none) {
-             warnx(_("libannocheck_get_known_tests error: %s"), libannocheck_get_error_message(ah, annoerr));
+             warnx(_("*** libannocheck_get_known_tests: %s"), libannocheck_get_error_message(ah, annoerr));
              libannocheck_finish(ah);
              continue;
         }
@@ -527,7 +527,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     if (annoerr != libannocheck_error_none) {
-        warnx(_("libannocheck_finish error: %s"), libannocheck_get_error_message(ah, annoerr));
+        warnx(_("*** libannocheck_finish: %s"), libannocheck_get_error_message(ah, annoerr));
     }
 
     return result;

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -114,11 +114,11 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         free(before);
 
         if (cap_free(aftercap) == -1) {
-            warn("cap_free");
+            warn("*** cap_free");
         }
 
         if (cap_free(beforecap) == -1) {
-            warn("cap_free");
+            warn("*** cap_free");
         }
 
         return true;
@@ -203,15 +203,15 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     free(after);
 
     if (cap_free(aftercap) == -1) {
-        warn("cap_free");
+        warn("*** cap_free");
     }
 
     if (cap_free(beforecap) == -1) {
-        warn("cap_free");
+        warn("*** cap_free");
     }
 
     if (cap_free(expected) == -1) {
-        warn("cap_free");
+        warn("*** cap_free");
     }
 
     return result;

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -59,12 +59,12 @@ static char *run_and_capture(const char *where, char **output, char *cmd, const 
     fd = mkstemp(*output);
 
     if (fd == -1) {
-        warn("mkstemp");
+        warn("*** mkstemp");
         return false;
     }
 
     if (close(fd) == -1) {
-        warn("close");
+        warn("*** close");
         return false;
     }
 
@@ -197,22 +197,22 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         fd = open(file->fullpath, flags);
 
         if (fd == -1) {
-            warn("open");
+            warn("*** open");
             return true;
         }
 
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
-            warn("read");
+            warn("*** read");
 
             if (close(fd) == -1) {
-                warn("close");
+                warn("*** close");
             }
 
             return true;
         }
 
         if (close(fd) == -1) {
-            warn("close");
+            warn("*** close");
             return true;
         }
 
@@ -370,11 +370,11 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         /* Remove the temporary files */
         if (unlink(before_tmp) == -1) {
-            warn("unlink");
+            warn("*** unlink");
         }
 
         if (unlink(after_tmp) == -1) {
-            warn("unlink");
+            warn("*** unlink");
         }
 
         if (params.details) {

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -117,7 +117,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     fd = mkstemp(output);
 
     if (fd == -1) {
-        warn("mkstemp");
+        warn("*** mkstemp");
         free(output);
         return NULL;
     }
@@ -125,7 +125,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     logfp = fdopen(fd, "w");
 
     if (logfp == NULL) {
-        warn("fdopen");
+        warn("*** fdopen");
         close(fd);
         unlink(output);
         free(output);
@@ -137,7 +137,7 @@ static char *create_changelog(const string_list_t *changelog, const char *where)
     }
 
     if (fclose(logfp) != 0) {
-        warn("fclose");
+        warn("*** fclose");
         close(fd);
         unlink(output);
         free(output);
@@ -301,13 +301,13 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
     /* cleanup */
     if (before_output) {
         if (unlink(before_output) != 0) {
-            warn("unlink");
+            warn("*** unlink");
         }
     }
 
     if (after_output) {
         if (unlink(after_output) != 0) {
-            warn("unlink");
+            warn("*** unlink");
         }
     }
 
@@ -399,13 +399,13 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
     /* cleanup */
     if (before_output) {
         if (unlink(before_output) != 0) {
-            warn("unlink");
+            warn("*** unlink");
         }
     }
 
     if (after_output) {
         if (unlink(after_output) != 0) {
-            warn("unlink");
+            warn("*** unlink");
         }
     }
 

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -93,7 +93,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 n = readlink(file->peer_file->fullpath, before_dest, PATH_MAX);
 
                 if (n == -1) {
-                    warn("readlink(%s)", file->peer_file->fullpath);
+                    warn("*** readlink(%s)", file->peer_file->fullpath);
                     return true;
                 }
             }
@@ -104,7 +104,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 n = readlink(file->fullpath, after_dest, PATH_MAX);
 
                 if (n == -1) {
-                    warn("readlink(%s)", file->fullpath);
+                    warn("*** readlink(%s)", file->fullpath);
                     return true;
                 }
             }

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -264,7 +264,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
                 found = true;
 
                 if (lstat(file_to_find, &sb) == -1) {
-                    warn("stat");
+                    warn("*** lstat");
                     list_free(contents, free, true);
                     free(file_to_find);
                     return false;
@@ -343,7 +343,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
                 found = true;
 
                 if (lstat(file_to_find, &sb) == -1) {
-                    warn("stat");
+                    warn("*** lstat");
                     list_free(contents, free, true);
                     free(file_to_find);
                     return false;

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -64,22 +64,22 @@ static short get_jvm_major(const char *filename, const char *localpath, const ch
         fd = open(filename, flags);
 
         if (fd == -1) {
-            warn("open");
+            warn("*** open");
             return -1;
         }
 
         if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
-            warn("read");
+            warn("*** read");
 
             if (close(fd) == -1) {
-                warn("close");
+                warn("*** close");
             }
 
             return -1;
         }
 
         if (close(fd) == -1) {
-            warn("close");
+            warn("*** close");
             return -1;
         }
 
@@ -194,7 +194,7 @@ static bool javabytecode_driver(struct rpminspect *ri, rpmfile_entry_t *file, co
         tmppath = mkdtemp(tmppath);
 
         if (tmppath == NULL) {
-            warn("mkdtemp");
+            warn("*** mkdtemp");
             free(tmppath);
             return false;
         }
@@ -214,7 +214,7 @@ static bool javabytecode_driver(struct rpminspect *ri, rpmfile_entry_t *file, co
 
         if (jarstatus != 0) {
             /* we errored somewhere, just report it */
-            warn("nftw");
+            warn("*** nftw");
         }
 
         /* clean up */
@@ -271,7 +271,7 @@ bool inspect_javabytecode(struct rpminspect *ri)
     supported_major = strtol(hentry->value, NULL, 10);
 
     if (errno == ERANGE) {
-        warn("strtol");
+        warn("*** strtol");
         return false;
     }
 

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -124,7 +124,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     kctx = kmod_new(NULL, NULL);
 
     if (kctx == NULL) {
-        warn("kmod_new");
+        warn("*** kmod_new");
         return true;
     }
 
@@ -142,7 +142,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     kctx = kmod_new(NULL, NULL);
 
     if (kctx == NULL) {
-        warn("kmod_new");
+        warn("*** kmod_new");
         return true;
     }
 
@@ -161,7 +161,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     err = kmod_module_get_info(beforekmod, &beforeinfo);
 
     if (err < 0) {
-        warn("kmod_module_get_info");
+        warn("*** kmod_module_get_info");
         kmod_module_unref(beforekmod);
         kmod_module_unref(afterkmod);
         kmod_unref(kctx);
@@ -171,7 +171,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     err = kmod_module_get_info(afterkmod, &afterinfo);
 
     if (err < 0) {
-        warn("kmod_module_get_info");
+        warn("*** kmod_module_get_info");
         kmod_module_info_free_list(beforeinfo);
         kmod_module_unref(beforekmod);
         kmod_module_unref(afterkmod);

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -44,7 +44,7 @@ static parser_plugin *read_licensedb(struct rpminspect *ri, const char *db, pars
     }
 
     if (p->parse_file(&context, actualdb)) {
-        warnx(_("parse error on license db %s"), db);
+        warnx(_("*** parse error in license database %s"), db);
         free(actualdb);
         return NULL;
     }
@@ -132,7 +132,7 @@ static bool check_license_abbrev(parser_plugin *p, parser_context *db, const cha
     lic_cb_data data = { p, db, lic, false };
 
     if (p->keymap(db, NULL, NULL, lic_cb, &data)) {
-        warnx(_("problem checking licensedb"));
+        warnx(_("*** problem checking license database"));
         return false;
     }
 

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -78,7 +78,7 @@ static bool inspect_manpage_alloc(void)
     free(tmp);
     if (reg_result != 0) {
         regerror(reg_result, &sections_regex, reg_error, sizeof(reg_error));
-        warnx(_("unable to compile man page path regular expression: %s"), reg_error);
+        warnx(_("*** unable to compile man page path regular expression: %s"), reg_error);
         inspect_manpage_free();
         return false;
     }
@@ -304,7 +304,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             result = false;
             free(params.msg);
         } else if (r == -1) {
-            warn("stat");
+            warn("*** stat");
         }
 
         free(uncompressed_man_page);

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -44,7 +44,7 @@ static int read_modulemd(const char *fpath, __attribute__((unused)) const struct
     }
 
     if (p->parse_file(&ctx, fpath)) {
-        warnx(_("ignoring malformed module metadata file: %s"), fpath);
+        warnx(_("*** ignoring malformed module metadata file: %s"), fpath);
         free(headptr);
         return -1;
     }
@@ -81,7 +81,7 @@ static bool get_static_context(const char *subdir, const char *build)
     static_context = false;
 
     if (nftw(path, read_modulemd, FOPEN_MAX, FTW_PHYS) == -1) {
-        warn("nftw");
+        warn("*** nftw");
         free(path);
         return false;
     }

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -144,12 +144,12 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
                 if (cap) {
                     if (cap_get_flag(cap, CAP_SETUID, CAP_EFFECTIVE, &have_setuid) == -1) {
-                        warnx("cap_get_flag");
+                        warnx("*** cap_get_flag");
                         have_setuid = CAP_CLEAR;
                     }
 
                     if (cap_free(cap) == -1) {
-                        warn("cap_free");
+                        warn("*** cap_free");
                     }
                 }
 

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -431,7 +431,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         before_patch = uncompress_file(ri, file->peer_file->fullpath, NAME_PATCHES);
 
         if (before_patch == NULL) {
-            warnx(_("unable to uncompress patch: %s"), file->peer_file->localpath);
+            warnx(_("*** unable to uncompress patch: %s"), file->peer_file->localpath);
             return false;
         }
     }
@@ -439,7 +439,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     after_patch = uncompress_file(ri, file->fullpath, NAME_PATCHES);
 
     if (after_patch == NULL) {
-        warnx(_("unable to uncompress patch: %s"), file->localpath);
+        warnx(_("*** unable to uncompress patch: %s"), file->localpath);
         return false;
     }
 
@@ -449,14 +449,14 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
      * generating multiple patches against multiple branches.
      */
     if (stat(after_patch, &sb) != 0) {
-        warn("stat");
+        warn("*** stat");
         return false;
     }
 
     apsz = sb.st_size;
 
     if (file->peer_file && before_patch && stat(before_patch, &sb) != 0) {
-        warn("stat");
+        warn("*** stat");
         return false;
     }
 
@@ -676,7 +676,7 @@ bool inspect_patches(struct rpminspect *ri)
                 speclines = read_file(file->fullpath);
 
                 if (speclines == NULL) {
-                    err(RI_PROGRAM_ERROR, "read_file");
+                    err(RI_PROGRAM_ERROR, "*** read_file");
                 }
 
                 TAILQ_FOREACH(specentry, speclines, items) {
@@ -746,7 +746,7 @@ bool inspect_patches(struct rpminspect *ri)
                         hentry->num = strtoll(buf, NULL, 10);
 
                         if (errno == ERANGE || errno == EINVAL) {
-                            warn("strtoll");
+                            warn("*** strtoll");
                             hentry->num = -1;
                         }
 
@@ -817,13 +817,13 @@ bool inspect_patches(struct rpminspect *ri)
                             buf += strlen(SPEC_MACRO_PATCH);
                             buf[strcspn(buf, " \t")] = '\0';
                         } else {
-                            warnx("*** Unrecognized %%patch line: %s", specentry->data);
+                            warnx(_("*** unrecognized %%patch line: %s"), specentry->data);
                             continue;
                         }
 
                         /* add a new patch entry to the hash table */
                         if (buf == NULL) {
-                            warnx("*** Unable to read spec file line: %s", specentry->data);
+                            warnx(_("*** unable to read spec file line: %s"), specentry->data);
                             continue;
                         }
 
@@ -832,7 +832,7 @@ bool inspect_patches(struct rpminspect *ri)
                         aentry->num = strtoll(buf, NULL, 10);
 
                         if (errno == ERANGE || errno == EINVAL) {
-                            warn("strtoll");
+                            warn("*** strtoll");
                             aentry->num = -1;
                         }
 

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -44,7 +44,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     TAILQ_FOREACH(pentry, ri->politics, items) {
         /* malformatted lines */
         if (pentry->pattern == NULL || pentry->digest == NULL) {
-            warnx(_("invalid politics entry with pattern=%s and digest=%s"), pentry->pattern, pentry->digest);
+            warnx(_("*** invalid politics entry with pattern=%s and digest=%s"), pentry->pattern, pentry->digest);
             continue;
         }
 
@@ -64,7 +64,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     TAILQ_FOREACH(pentry, ri->politics, items) {
         /* malformatted lines */
         if (pentry->pattern == NULL || pentry->digest == NULL) {
-            warnx(_("invalid politics entry with pattern=%s and digest=%s"), pentry->pattern, pentry->digest);
+            warnx(_("*** invalid politics entry with pattern=%s and digest=%s"), pentry->pattern, pentry->digest);
             continue;
         }
 
@@ -89,7 +89,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             } else if (strlen(pentry->digest) == (SHA512_DIGEST_LENGTH * 2)) {
                 type = SHA512SUM;
             } else {
-                warnx(_("unknown digest type for pattern %s: %s"), pentry->pattern, pentry->digest);
+                warnx(_("*** unknown digest type for pattern %s: %s"), pentry->pattern, pentry->digest);
                 continue;
             }
 

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -46,7 +46,7 @@ static char *remove_isa_substring(char *requirement)
 
     /* isa substring regex pattern */
     if (regcomp(&re, "\\([a-zA-Z0-9]+-(32|64)\\)", REG_EXTENDED | REG_NEWLINE) != 0) {
-        warn("regcomp");
+        warn("*** regcomp");
         r = strdup(requirement);
         return r;
     }

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -133,7 +133,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
 
                         if (reg_result != 0) {
                             regerror(reg_result, &origin_root, reg_error, sizeof(reg_error));
-                            warn(_("unable to compile $ORIGIN root prefix regular expression: %s"), reg_error);
+                            warn(_("*** unable to compile $ORIGIN root prefix regular expression: %s"), reg_error);
                             continue;
                         }
 
@@ -148,7 +148,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
 
                         if (reg_result != 0) {
                             regerror(reg_result, &origin_root, reg_error, sizeof(reg_error));
-                            warn("regexec: %s", reg_error);
+                            warnx("*** regexec: %s", reg_error);
                             regfree(&origin_root);
                             continue;
                         }

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -35,7 +35,7 @@ static char *get_shell(const struct rpminspect *ri, const char *fullpath)
     fp = fopen(fullpath, "r");
 
     if (fp == NULL) {
-        warn("fopen");
+        warn("*** fopen");
         return NULL;
     }
 
@@ -43,11 +43,11 @@ static char *get_shell(const struct rpminspect *ri, const char *fullpath)
     start = buf;
 
     if (fclose(fp) == -1) {
-        warn("fclose");
+        warn("*** fclose");
     }
 
     if (r == -1) {
-        warn("getline");
+        warn("*** getline");
     } else if (!strncmp(buf, "#!", 2)) {
         /* trim newlines */
         buf[strcspn(buf, "\n")] = '\0';

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -133,7 +133,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     memset(cwd, '\0', sizeof(cwd));
 
     if (getcwd(cwd, PATH_MAX) == NULL) {
-        err(RI_PROGRAM_ERROR, "getcwd");
+        err(RI_PROGRAM_ERROR, "*** getcwd");
     }
 
     memset(reltarget, '\0', sizeof(reltarget));
@@ -185,7 +185,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 free(params.details);
 
                 if (chdir(cwd) == -1) {
-                    warn("%s: chdir to %s", __func__, cwd);
+                    warn("*** chdir");
                 }
 
                 return false;
@@ -298,7 +298,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* return to D-station */
     if (chdir(cwd) == -1) {
-        warn("chdir");
+        warn("*** chdir");
     }
 
     return result;

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -37,7 +37,7 @@ static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         engine = cl_engine_new();
 
         if (engine == NULL) {
-            errx(RI_PROGRAM_ERROR, _("cl_engine_new returned NULL, check clamav library"));
+            errx(RI_PROGRAM_ERROR, _("*** cl_engine_new returned NULL, check clamav library"));
         }
 
         /* load clamav databases */
@@ -45,7 +45,7 @@ static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (r != CL_SUCCESS) {
             cl_engine_free(engine);
-            errx(RI_PROGRAM_ERROR, "cl_load: %s", cl_strerror(r));
+            errx(RI_PROGRAM_ERROR, "*** cl_load: %s", cl_strerror(r));
         }
 
         /* compile engine */
@@ -53,7 +53,7 @@ static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (r != CL_SUCCESS) {
             cl_engine_free(engine);
-            errx(RI_PROGRAM_ERROR, "cl_engine_compile: %s", cl_strerror(r));
+            errx(RI_PROGRAM_ERROR, "*** cl_engine_compile: %s", cl_strerror(r));
         }
 
         /* remember to not do all this again */
@@ -100,7 +100,7 @@ static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             free(params.msg);
         }
     } else if (r != CL_CLEAN) {
-        warnx("cl_scanfile(%s): %s", file->localpath, cl_strerror(r));
+        warnx("*** cl_scanfile(%s): %s", file->localpath, cl_strerror(r));
     }
 
     return result;
@@ -121,7 +121,7 @@ bool inspect_virus(struct rpminspect *ri)
     r = cl_init(CL_INIT_DEFAULT);
 
     if (r != CL_SUCCESS) {
-        warnx("cl_init: %s", cl_strerror(r));
+        warnx("*** cl_init: %s", cl_strerror(r));
         return false;
     }
 
@@ -142,7 +142,7 @@ bool inspect_virus(struct rpminspect *ri)
     d = opendir(dbpath);
 
     if (d == NULL) {
-        err(EXIT_FAILURE, _("missing %s"), dbpath);
+        err(EXIT_FAILURE, _("*** missing %s"), dbpath);
     }
 
     errno = 0;
@@ -160,7 +160,7 @@ bool inspect_virus(struct rpminspect *ri)
             free(cvdpath);
 
             if (closedir(d) == -1) {
-                warn("closedir: %s", dbpath);
+                warn("*** closedir");
             }
 
             return false;
@@ -179,11 +179,11 @@ bool inspect_virus(struct rpminspect *ri)
 
     if (errno != 0) {
         free(params.details);
-        err(EXIT_FAILURE, "readdir");
+        err(EXIT_FAILURE, "*** readdir");
     }
 
     if (closedir(d) == -1) {
-        warn("closedir: %s", dbpath);
+        warn("*** closedir");
     }
 
     params.verb = VERB_OK;

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -139,7 +139,7 @@ static const char *get_xmlrpc_fault_desc(const int fault_code)
 static void xmlrpc_abort_on_fault(xmlrpc_env *env)
 {
     if (env->fault_occurred) {
-        errx(RI_PROGRAM_ERROR, _("XML-RPC Fault: %s (%d)"), env->fault_string, env->fault_code);
+        errx(RI_PROGRAM_ERROR, _("*** XML-RPC Fault: %s (%d)"), env->fault_string, env->fault_code);
     }
 }
 
@@ -649,7 +649,7 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
             free_koji_build(build);
 
             if (env.fault_code < 0) {
-                warnx(_("xmlrpc fault code %s (%d): getBuild(%s) from %s"), get_xmlrpc_fault_desc(env.fault_code), env.fault_code, buildspec, ri->kojihub);
+                warnx(_("*** xmlrpc fault code %s (%d): getBuild(%s) from %s"), get_xmlrpc_fault_desc(env.fault_code), env.fault_code, buildspec, ri->kojihub);
             }
 
             return NULL;
@@ -881,7 +881,7 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
 
     /* build must be complete */
     if (build->state != BUILD_COMPLETE) {
-        warnx(_("Koji build state is %s for %s, cannot continue."), build_state_desc(build->state), buildspec);
+        warnx(_("*** Koji build state is %s for %s, cannot continue"), build_state_desc(build->state), buildspec);
         free_koji_build(build);
         return NULL;
     }
@@ -1144,7 +1144,7 @@ struct koji_task *get_koji_task(struct rpminspect *ri, const char *taskspec)
             free_koji_task(task);
 
             if (env.fault_code < 0) {
-                warnx(_("xmlrpc fault code %s (%d): getTaskInfo(%s) from %s"), get_xmlrpc_fault_desc(env.fault_code), env.fault_code, taskspec, ri->kojihub);
+                warnx(_("*** xmlrpc fault code %s (%d): getTaskInfo(%s) from %s"), get_xmlrpc_fault_desc(env.fault_code), env.fault_code, taskspec, ri->kojihub);
             }
 
             return NULL;
@@ -1168,7 +1168,7 @@ struct koji_task *get_koji_task(struct rpminspect *ri, const char *taskspec)
 
     /* task must be closed */
     if (task->state != TASK_CLOSED) {
-        warnx(_("Koji task state is %s for task %s, cannot continue."), task_state_desc(task->state), taskspec);
+        warnx(_("*** Koji task state is %s for task %s, cannot continue"), task_state_desc(task->state), taskspec);
         xmlrpc_env_clean(&env);
         xmlrpc_client_cleanup();
         free_koji_task(task);

--- a/lib/llvm.c
+++ b/lib/llvm.c
@@ -30,20 +30,20 @@ bool is_llvm_ir_bitcode(const char *file)
     fd = open(file, flags);
 
     if (fd == -1) {
-        warn("open");
+        warn("*** open");
         return false;
     }
 
     if (read(fd, magic, sizeof(magic)) != sizeof(magic)) {
         if (close(fd) == -1) {
-            warn("close");
+            warn("*** close");
         }
 
         return false;
     }
 
     if (close(fd) == -1) {
-        warn("close");
+        warn("*** close");
         return false;
     }
 

--- a/lib/local.c
+++ b/lib/local.c
@@ -35,7 +35,7 @@ bool is_local_build(const char *workdir, const char *build, const bool fetch_onl
     memset(cwd, '\0', sizeof(cwd));
 
     if (getcwd(cwd, PATH_MAX) == NULL) {
-        err(RI_PROGRAM_ERROR, "getcwd");
+        err(RI_PROGRAM_ERROR, "*** getcwd");
     }
 
     /* Figure out where to look */
@@ -52,7 +52,7 @@ bool is_local_build(const char *workdir, const char *build, const bool fetch_onl
     }
 
     if (stat(check, &sb) == -1) {
-        warn("stat");
+        warn("*** stat");
         free(check);
         return false;
     }
@@ -63,7 +63,7 @@ bool is_local_build(const char *workdir, const char *build, const bool fetch_onl
     }
 
     if (chdir(check) == -1) {
-        warn("chdir");
+        warn("*** chdir");
         free(check);
         return false;
     }
@@ -71,7 +71,7 @@ bool is_local_build(const char *workdir, const char *build, const bool fetch_onl
     free(check);
 
     if (chdir(cwd) == -1) {
-        warn("chdir");
+        warn("*** chdir");
         return false;
     }
 

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -95,7 +95,7 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
 
     if (reg_result != 0) {
         regerror(reg_result, &macro_regex, reg_error, sizeof(reg_error));
-        warnx("%s", reg_error);
+        warnx("*** regcomp: %s", reg_error);
         return 0;
     }
 

--- a/lib/magic.c
+++ b/lib/magic.c
@@ -29,12 +29,12 @@ char *mime_type(const char *path)
     cookie = magic_open(MAGIC_MIME | MAGIC_CHECK);
 
     if (cookie == NULL) {
-        warnx(_("unable to initialize the magic library"));
+        warnx(_("*** unable to initialize the magic library"));
         return NULL;
     }
 
     if (magic_load(cookie, NULL) != 0) {
-        warnx(_("unable to load the magic database: %s"), magic_error(cookie));
+        warnx(_("*** unable to load the magic database: %s"), magic_error(cookie));
         magic_close(cookie);
         return NULL;
     }

--- a/lib/mkdirp.c
+++ b/lib/mkdirp.c
@@ -51,7 +51,7 @@ int mkdirp(const char *path, mode_t mode)
         start = p = strdup(path);
     } else {
         if ((cwd = getcwd(NULL, 0)) == NULL) {
-            warn("getcwd");
+            warn("*** getcwd");
             return -1;
         }
 

--- a/lib/output_json.c
+++ b/lib/output_json.c
@@ -96,7 +96,7 @@ void output_json(const results_t *results, const char *dest, __attribute__((unus
             fp = fopen(dest, "w");
 
             if (fp == NULL) {
-                warn(_("error opening %s for writing"), dest);
+                warn(_("*** error opening %s for writing"), dest);
                 return;
             }
         }
@@ -104,7 +104,7 @@ void output_json(const results_t *results, const char *dest, __attribute__((unus
         /* write out the results */
         json_string = json_object_to_json_string_ext(j, flags);
         if (json_string == NULL) {
-            errx(RI_PROGRAM_ERROR, "failed to stringify object to json format");
+            errx(RI_PROGRAM_ERROR, "*** failed to stringify object to json format");
         }
         /* write out the results */
         fprintf(fp, "%s\n", json_string);

--- a/lib/output_summary.c
+++ b/lib/output_summary.c
@@ -42,7 +42,7 @@ void output_summary(const results_t *results, const char *dest, __attribute__((u
                 fp = fopen(dest, "w");
 
                 if (fp == NULL) {
-                    warn(_("error opening %s for writing"), dest);
+                    warn(_("*** error opening %s for writing"), dest);
                     return;
                 }
             }

--- a/lib/output_text.c
+++ b/lib/output_text.c
@@ -50,7 +50,7 @@ void output_text(const results_t *results, const char *dest, __attribute__((unus
                 fp = fopen(dest, "w");
 
                 if (fp == NULL) {
-                    warn(_("error opening %s for writing"), dest);
+                    warn(_("*** error opening %s for writing"), dest);
                     return;
                 }
             }

--- a/lib/output_xunit.c
+++ b/lib/output_xunit.c
@@ -51,7 +51,7 @@ void output_xunit(const results_t *results, const char *dest, const severity_t t
             }
 
             if (fp == NULL) {
-                warn(_("opening %s for writing"), dest);
+                warn(_("*** opening %s for writing"), dest);
                 return;
             }
 

--- a/lib/parse_dson.c
+++ b/lib/parse_dson.c
@@ -23,7 +23,7 @@ static bool dson_parse_file(parser_context **context_out, const char *filepath)
     free(buf);
 
     if (errmsg != NULL) {
-        warnx("%s", errmsg);
+        warnx("*** %s", errmsg);
         free(errmsg);
         return true;
     }

--- a/lib/parse_json.c
+++ b/lib/parse_json.c
@@ -27,7 +27,7 @@ static bool json_parse_file(parser_context **context_out, const char *filepath)
     jerr = json_tokener_get_error(tok);
 
     if (jerr != json_tokener_success) {
-        warnx("json_tokener_parse_ex: %s", json_tokener_error_desc(jerr));
+        warnx("*** json_tokener_parse_ex: %s", json_tokener_error_desc(jerr));
         goto done;
     }
 

--- a/lib/parse_yaml.c
+++ b/lib/parse_yaml.c
@@ -11,8 +11,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <err.h>
+
 #include "parser.h"
 #include "tyranny.h"
+#include "rpminspect.h"
 
 /* Uncomment to enable debug printing. */
 /* #define DEBUG 1 */
@@ -109,7 +111,7 @@ static bool peek(context *c, yaml_token_t *token)
 {
     if (!c->have_lookahead) {
         if (yaml_parser_scan(c->parser, &c->token) == 0) {
-            warnx("%s: broken document", __func__);
+            warnx(_("*** %s: broken document"), __func__);
             return true;
         }
 
@@ -134,7 +136,7 @@ static void next(context *c, yaml_token_t *token)
         memcpy(token, &c->token, sizeof(*token));
         return;
     } else if (yaml_parser_scan(c->parser, token) == 0) {
-        warnx("%s: broken document", __func__);
+        warnx(_("*** %s: broken document"), __func__);
         exit(1);
     }
 
@@ -153,7 +155,7 @@ static void wait_for(context *c, yaml_token_t *token, yaml_token_type_t target)
     next(c, token);
 
     while (token->type != YAML_NO_TOKEN && token->type != target) {
-        warnx("skipping token type %s", tokname(token->type));
+        warnx(_("*** skipping token type %s"), tokname(token->type));
         yaml_token_delete(token);
         next(c, token);
     }
@@ -300,7 +302,7 @@ static y_value *p_value(context *context)
 
             goto done;
         } else {
-            warnx("skipping token type %s", tokname(token.type));
+            warnx(_("*** skipping token type %s"), tokname(token.type));
             free(ret);
             ret = NULL;
             goto done;
@@ -328,7 +330,7 @@ static bool yaml_parse_file(parser_context **context_out, const char *filename)
 
     /* prepare a YAML parser */
     if (!yaml_parser_initialize(&parser)) {
-        warnx("yaml_parser_initialize");
+        warnx("*** yaml_parser_initialize");
         return true;
     }
 
@@ -336,7 +338,7 @@ static bool yaml_parse_file(parser_context **context_out, const char *filename)
     fp = fopen(filename, "r");
 
     if (fp == NULL) {
-        warn("fopen");
+        warn("*** fopen");
         return true;
     }
 
@@ -381,7 +383,7 @@ static void y_free_tree(y_value *v)
         free(v->v.dict.keys);
         free(v->v.dict.values);
     } else {
-        warnx("malformed type - freed?");
+        warnx(_("*** malformed type - freed?"));
         return;
     }
 

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -177,7 +177,7 @@ bool usable_path(const char *path)
     memset(&sb, 0, sizeof(sb));
 
     if (lstat(path, &sb) == -1) {
-        warn("lstat");
+        warn("*** lstat");
         return false;
     }
 
@@ -282,7 +282,7 @@ bool match_path(const char *pattern, const char *root, const char *path)
     r = glob(globpath, gflags, NULL, &found);
 
     if (r == GLOB_NOSPACE || r == GLOB_ABORTED) {
-        warn("glob");
+        warn("*** glob");
     }
 
     if (r != 0) {

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -108,7 +108,7 @@ void add_peer(rpmpeer_t **peers, deprule_ignore_map_t *ignores, int whichbuild, 
         peer = calloc(1, sizeof(*peer));
 
         if (peer == NULL) {
-            warn("calloc");
+            warn("*** calloc");
             return;
         }
     }

--- a/lib/pic_bits.sh
+++ b/lib/pic_bits.sh
@@ -86,8 +86,8 @@ echo "$cpp_output" | sed -n -E 's/^#define[[:space:]]+(EM_[^[:space:]]+).*/\1/p'
 
 echo "        default:" >> "$1"
 # use printf to avoid a non-bash /bin/sh's echo messing up the \'s.
-printf '            warnx(_("unknown machine type %%u\\n"), machine);\n' >> "$1"
-printf '            warnx(_("Recompile librpminspect with a newer elf.h, or make necessary modifications to pic_bits.sh\\n"));\n' >> "$1"
+printf '            warnx(_("*** unknown machine type %%u\\n"), machine);\n' >> "$1"
+printf '            warnx(_("*** Recompile librpminspect with a newer elf.h, or make necessary modifications to pic_bits.sh\\n"));\n' >> "$1"
 echo "            return false;" >> "$1"
 echo "    }" >> "$1"
 echo "}" >> "$1"

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -36,7 +36,7 @@ static GElf_Half _get_elf_helper(Elf *elf, elfinfo_t type, GElf_Half fail)
     assert(kind == ELF_K_ELF);
 
     if (gelf_getehdr(elf, &ehdr) == NULL) {
-        warn("gelf_getehdr");
+        warn("*** gelf_getehdr");
         return fail;
     }
 
@@ -45,7 +45,7 @@ static GElf_Half _get_elf_helper(Elf *elf, elfinfo_t type, GElf_Half fail)
     } else if (type == ELF_MACHINE) {
         return ehdr.e_machine;
     } else {
-        warn("unknown elftype_t %d", type);
+        warnx(_("*** unknown elftype_t %d"), type);
         return fail;
     }
 
@@ -73,7 +73,7 @@ static Elf *get_elf_with_kind(const char *fullpath, int *out_fd, Elf_Kind kind)
     /* library version check */
     if (!initialized) {
         if (elf_version(EV_CURRENT) == EV_NONE) {
-            warnx(_("libelf version mismatch"));
+            warnx(_("*** libelf version mismatch"));
             return NULL;
         }
 
@@ -82,7 +82,7 @@ static Elf *get_elf_with_kind(const char *fullpath, int *out_fd, Elf_Kind kind)
 
     /* make sure this is a regular file */
     if (lstat(fullpath, &sbuf) != 0) {
-        warn("lstat(%s)", fullpath);
+        warn("*** lstat");
         return NULL;
     }
 

--- a/lib/readfile.c
+++ b/lib/readfile.c
@@ -47,7 +47,7 @@ void *read_file_bytes(const char *path, off_t *len)
     *len = lseek(fd, 0, SEEK_END);
 
     if (*len == -1) {
-        warn("unable to find end of %s", path);
+        warn(_("*** unable to find end of %s"), path);
         r = close(fd);
         assert(r != -1);
         return NULL;
@@ -57,7 +57,7 @@ void *read_file_bytes(const char *path, off_t *len)
     buf = mmap(NULL, *len, PROT_READ, MAP_PRIVATE, fd, 0);
 
     if (buf == MAP_FAILED) {
-        warn("unable to read %s", path);
+        warn(_("*** unable to read %s"), path);
         r = close(fd);
         assert(r != -1);
         return NULL;
@@ -65,7 +65,7 @@ void *read_file_bytes(const char *path, off_t *len)
 
     /* the actual file close we care about */
     if (close(fd) == -1) {
-        warn("unable to close %s", path);
+        warn(_("*** unable to close %s"), path);
     }
 
     /* break up the file in to lines */

--- a/lib/rebase.c
+++ b/lib/rebase.c
@@ -85,6 +85,6 @@ bool is_rebase(struct rpminspect *ri)
         return true;
     } else {
         /* should not reach this */
-        err(RI_PROGRAM_ERROR, "is_rebase");
+        err(RI_PROGRAM_ERROR, "*** is_rebase");
     }
 }

--- a/lib/rmtree.c
+++ b/lib/rmtree.c
@@ -62,7 +62,7 @@ int rmtree(const char *path, const bool ignore_errors, const bool contentsonly)
         if (ignore_errors) {
             return 0;
         } else {
-            warn("stat(%s)", path);
+            warn("*** stat");
             return 1;
         }
     }
@@ -71,7 +71,7 @@ int rmtree(const char *path, const bool ignore_errors, const bool contentsonly)
         if (ignore_errors) {
             return 0;
         } else {
-            warn("%s is not a directory", path);
+            warnx(_("*** %s is not a directory"), path);
             return 2;
         }
     }

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -68,7 +68,7 @@ Header get_rpm_header(struct rpminspect *ri, const char *pkg)
     fd = Fopen(pkg, "r.ufdio");
 
     if (fd == NULL || Ferror(fd)) {
-        warnx(_("Fopen failed for %s: %s"), pkg, Fstrerror(fd));
+        warnx(_("*** Fopen failed for %s: %s"), pkg, Fstrerror(fd));
 
         if (fd) {
             Fclose(fd);
@@ -324,7 +324,7 @@ char *extract_rpm_payload(const char *rpm)
     rc = rpmReadPackageFile(ts, fdi, COMMAND_NAME, &hdr);
 
     if (rc == RPMRC_NOTFOUND || rc == RPMRC_FAIL) {
-        warn("rpmReadPackageFile");
+        warn("*** rpmReadPackageFile");
         goto cleanup;
     }
 
@@ -338,7 +338,7 @@ char *extract_rpm_payload(const char *rpm)
     free(rpmio_flags);
 
     if (gzdi == NULL) {
-        warnx("Fdopen: %s", Fstrerror(gzdi));
+        warnx("*** Fdopen: %s", Fstrerror(gzdi));
         goto cleanup;
     }
 
@@ -349,12 +349,12 @@ char *extract_rpm_payload(const char *rpm)
     archive = archive_write_new();
 
     if (archive_write_add_filter_gzip(archive) != ARCHIVE_OK) {
-        warnx("archive_write_add_filter_gzip: %s", archive_error_string(archive));
+        warnx("*** archive_write_add_filter_gzip: %s", archive_error_string(archive));
         goto cleanup;
     }
 
     if (archive_write_set_format_pax_restricted(archive) != ARCHIVE_OK) {
-        warnx("archive_write_set_format_pax_restricted: %s", archive_error_string(archive));
+        warnx("*** archive_write_set_format_pax_restricted: %s", archive_error_string(archive));
         goto cleanup;
     }
 
@@ -362,7 +362,7 @@ char *extract_rpm_payload(const char *rpm)
     assert(payload != NULL);
 
     if (archive_write_open_filename(archive, payload) != ARCHIVE_OK) {
-        warnx("archive_write_open_filename: %s", archive_error_string(archive));
+        warnx("*** archive_write_open_filename: %s", archive_error_string(archive));
         goto cleanup;
     }
 
@@ -428,7 +428,7 @@ char *extract_rpm_payload(const char *rpm)
                 if (read == len) {
                     archive_write_data(archive, buf, len);
                 } else {
-                    warnx("error reading file from RPM payload");
+                    warnx(_("*** error reading file from RPM payload"));
                     break;
                 }
 

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -62,12 +62,12 @@ char *run_cmd_vpe(int *exitcode, const char *workdir, char **argv)
         memset(cwd, '\0', sizeof(cwd));
 
         if (getcwd(cwd, PATH_MAX) == NULL) {
-            err(RI_PROGRAM_ERROR, "getcwd");
+            err(RI_PROGRAM_ERROR, "*** getcwd");
         }
 
         /* power through if it fails */
         if (chdir(workdir) == -1) {
-            warn("chdir");
+            warn("*** chdir");
         }
     }
 
@@ -77,7 +77,7 @@ char *run_cmd_vpe(int *exitcode, const char *workdir, char **argv)
             *exitcode = EXIT_FAILURE;
         }
 
-        warn("pipe");
+        warn("*** pipe");
         return NULL;
     }
 
@@ -87,13 +87,13 @@ char *run_cmd_vpe(int *exitcode, const char *workdir, char **argv)
     if (proc == 0) {
         /* connect the output */
         if (dup2(pfd[WR], STDOUT_FILENO) == -1 || dup2(pfd[WR], STDERR_FILENO) == -1) {
-            warn("dup2");
+            warn("*** dup2");
             _exit(EXIT_FAILURE);
         }
 
         /* close the pipes */
         if (close(pfd[RD]) == -1 || close(pfd[WR]) == -1) {
-            warn("close");
+            warn("*** close");
             _exit(EXIT_FAILURE);
         }
 
@@ -102,16 +102,16 @@ char *run_cmd_vpe(int *exitcode, const char *workdir, char **argv)
 
         /* run the command */
         if (execvp(argv[0], argv) == -1) {
-            warn("execvp");
+            warn("*** execvp");
             _exit(EXIT_FAILURE);
         }
     } else if (proc == -1) {
         /* failure */
-        warn("fork");
+        warn("*** fork");
     } else {
         /* close the pipe */
         if (close(pfd[WR]) == -1) {
-            warn("close");
+            warn("*** close");
         }
 
         /*
@@ -143,7 +143,7 @@ char *run_cmd_vpe(int *exitcode, const char *workdir, char **argv)
         free(buf);
 
         if (fclose(reader) == -1) {
-            warn("fclose");
+            warn("*** fclose");
         }
 
         /* wait for the command */
@@ -152,7 +152,7 @@ char *run_cmd_vpe(int *exitcode, const char *workdir, char **argv)
                 *exitcode = EXIT_FAILURE;
             }
 
-            warn("waitpid");
+            warn("*** waitpid");
         }
 
         if (WIFEXITED(status)) {
@@ -198,7 +198,7 @@ char *run_cmd_vpe(int *exitcode, const char *workdir, char **argv)
 
     /* go back to where we started */
     if (workdir && chdir(cwd) == -1) {
-        warn("chdir");
+        warn("*** chdir");
     }
 
     return output;

--- a/lib/uncompress.c
+++ b/lib/uncompress.c
@@ -56,7 +56,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     r = stat(outfile, &sb);
 
     if ((r == -1) && (errno != ENOENT)) {
-        warn("stat");
+        warn("*** stat");
         goto error1;
     }
 
@@ -66,7 +66,6 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
      */
     if (errno == ENOENT) {
         if (mkdirp(outfile, mode) == -1) {
-            warn("mkdirp");
             goto error1;
         }
     }
@@ -88,7 +87,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     fd = mkstemp(outfile);
 
     if (fd == -1) {
-        warn("mkstemp");
+        warn("*** mkstemp");
         goto error1;
     }
 
@@ -183,7 +182,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     r = archive_read_next_header(input, &entry);
 
     if (r == ARCHIVE_WARN || r == ARCHIVE_FAILED || r == ARCHIVE_FATAL) {
-        warn("archive_read_next_header: %s", archive_error_string(input));
+        warn("*** archive_read_next_header: %s", archive_error_string(input));
         goto error2;
     }
 
@@ -196,7 +195,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
             }
 
             if (write(fd, buf, size) == -1) {
-                warn("write");
+                warn("*** write");
                 goto error2;
             }
         }
@@ -205,7 +204,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
         fp = fdopen(fd, "w");
 
         if (fp == NULL) {
-            warn("fdopen");
+            warn("*** fdopen");
             goto error2;
         }
 
@@ -215,7 +214,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
          * the fd
          */
         if (fclose(fp) == -1) {
-            warn("fclose");
+            warn("*** fclose");
             goto error2;
         }
 
@@ -226,7 +225,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
 
     /* close up our uncompressed file */
     if (fd && close(fd) == -1) {
-        warn("close");
+        warn("*** close");
         goto error1;
     }
 

--- a/lib/unpack.c
+++ b/lib/unpack.c
@@ -53,7 +53,7 @@ static int copy_data(struct archive *ar, struct archive *aw)
         r = archive_write_data_block(aw, buf, s, o);
 
         if (r != ARCHIVE_OK) {
-            warnx("archive_write_data_block: %s", archive_error_string(aw));
+            warnx("*** archive_write_data_block: %s", archive_error_string(aw));
             return r;
         }
     }
@@ -70,7 +70,7 @@ static int extract_entry(struct archive *input, struct archive *output, struct a
     r = archive_write_header(output, entry);
 
     if (r != ARCHIVE_OK) {
-        warnx("archive_write_header: %s", archive_error_string(output));
+        warnx("*** archive_write_header: %s", archive_error_string(output));
         ret = -1;
     } else if (archive_entry_size(entry) > 0) {
         if (copy_data(input, output) != ARCHIVE_OK) {
@@ -78,7 +78,7 @@ static int extract_entry(struct archive *input, struct archive *output, struct a
         }
 
         if (r != ARCHIVE_OK) {
-            warnx("archive_write_header: %s", archive_error_string(output));
+            warnx("*** archive_write_header: %s", archive_error_string(output));
         } else if (r < ARCHIVE_WARN) {
             ret = -1;
         }
@@ -87,7 +87,7 @@ static int extract_entry(struct archive *input, struct archive *output, struct a
     r = archive_write_finish_entry(output);
 
     if (r != ARCHIVE_OK) {
-        warnx("archive_write_finish_entry: %s", archive_error_string(output));
+        warnx("*** archive_write_finish_entry: %s", archive_error_string(output));
     } else if (r < ARCHIVE_WARN) {
         ret = -1;
     }
@@ -128,7 +128,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force)
         if (errno == ENOENT) {
             return 0;
         } else {
-            warn("realpath: %s", archive);
+            warn("*** realpath: %s", archive);
             return -1;
         }
     }
@@ -144,7 +144,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force)
     r = archive_read_open_filename(input, archive, 16384);
 
     if (r != ARCHIVE_OK) {
-        warnx("archive_read_open_filename: %s", archive_error_string(input));
+        warnx("*** archive_read_open_filename: %s", archive_error_string(input));
         archive_read_free(input);
         return -1;
     }
@@ -152,11 +152,11 @@ int unpack_archive(const char *archive, const char *dest, const bool force)
     /* change to dest */
     if (getcwd(cwd, PATH_MAX) == NULL) {
         archive_read_free(input);
-        err(RI_PROGRAM_ERROR, "getcwd");
+        err(RI_PROGRAM_ERROR, "*** getcwd");
     }
 
     if (chdir(dest) != 0) {
-        warn("chdir");
+        warn("*** chdir");
         archive_read_free(input);
         return -1;
     }
@@ -169,7 +169,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force)
     /* extract each archive member */
     while ((r = archive_read_next_header(input, &entry)) != ARCHIVE_EOF) {
         if (r != ARCHIVE_OK) {
-            warnx("archive_read_next_header: %s", archive_error_string(input));
+            warnx("*** archive_read_next_header: %s", archive_error_string(input));
         } else if (r < ARCHIVE_WARN) {
             ret = -1;
         }
@@ -188,7 +188,7 @@ int unpack_archive(const char *archive, const char *dest, const bool force)
 
     /* change back to original directory */
     if (chdir(cwd) != 0) {
-        warn("chdir");
+        warn("*** chdir");
         return -1;
     }
 

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -82,6 +82,7 @@ lib/joinpath.c
 lib/kmods.c
 lib/koji.c
 lib/listfuncs.c
+lib/llvm.c
 lib/local.c
 lib/macros.c
 lib/magic.c

--- a/po/rpminspect.pot
+++ b/po/rpminspect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rpminspect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-03 14:19-0500\n"
+"POT-Creation-Date: 2023-05-31 11:18-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -311,12 +311,14 @@ msgstr ""
 #: include/inspect.h:1551
 msgid ""
 "Inspects all patches defined in the spec file and reports changes between "
-"builds.  At the INFO level, rpminspect reports file count, line count, and "
-"patch size changes.  If thresholds are reached regarding a change in the "
-"patch size or the number of files the patch touches, rpminspect reports the "
-"change at the VERIFY level unless the comparison is for a rebase.  The "
-"configuration file can also list patch names that rpminspect should ignore "
-"during the inspection."
+"builds.  The functional check here is to ensure all defined patches in the "
+"preamble have a corresponding application macro in the spec file.  At the "
+"INFO level, rpminspect reports file count, line count, and patch size "
+"changes.  If thresholds are reached regarding a change in the patch size or "
+"the number of files the patch touches, rpminspect reports the change at the "
+"VERIFY level unless the comparison is for a rebase.  The configuration file "
+"can also list patch names that rpminspect should ignore during the "
+"inspection."
 msgstr ""
 
 #: include/inspect.h:1557
@@ -585,27 +587,37 @@ msgid ""
 "and send a patch to the project that owns it."
 msgstr ""
 
-#: include/results.h:417
-msgid "Consult the shell documentation for proper syntax."
+#: include/results.h:409
+msgid ""
+"rpminspect is expecting a fileinfo rule from the vendor data package for "
+"this file. Usually this means the file carries a non-standard set of "
+"permissions (e.g., setuid) which is a condition where rpminspect would check "
+"the fileinfo list to ensure the package conforms to the vendor rules. To "
+"remedy, add a fileinfo rule for this file to the vendor data package under "
+"the appropriate product release file."
 msgstr ""
 
 #: include/results.h:424
+msgid "Consult the shell documentation for proper syntax."
+msgstr ""
+
+#: include/results.h:431
 msgid ""
 "The file referenced was not a known shell script in the before build but is "
 "now a shell script in the after build."
 msgstr ""
 
-#: include/results.h:431
+#: include/results.h:438
 msgid ""
 "The referenced shell script is invalid. Consider debugging it with the '-n' "
 "option on the shell to find and fix the problem."
 msgstr ""
 
-#: include/results.h:446
+#: include/results.h:453
 msgid "See annocheck(1) for more information."
 msgstr ""
 
-#: include/results.h:453
+#: include/results.h:460
 msgid ""
 "Ensure all object files are compiled with '-O2 -D_FORTIFY_SOURCE=2', and "
 "that all appropriate headers are included (no implicit function "
@@ -613,7 +625,7 @@ msgid ""
 "unable to determine the size of a buffer, which is not necessarily an error."
 msgstr ""
 
-#: include/results.h:468
+#: include/results.h:475
 msgid ""
 "DT_NEEDED symbols have been added or removed.  This happens when the build "
 "environment has different versions of the required libraries.  Sometimes "
@@ -622,33 +634,33 @@ msgid ""
 "the correct shared libraries."
 msgstr ""
 
-#: include/results.h:483
+#: include/results.h:490
 msgid ""
 "A file grew by a noticeable amount.  Ensure this change is intended.  If it "
 "is, you can adjust the filesize inspection settings in the rpminspect.yaml "
 "file."
 msgstr ""
 
-#: include/results.h:490
+#: include/results.h:497
 msgid ""
 "A file shrank by a noticeable amount.  Ensure this change is intended.  If "
 "it is, you can adjust the filesize inspection settings in the rpminspect."
 "yaml file."
 msgstr ""
 
-#: include/results.h:497
+#: include/results.h:504
 msgid ""
 "A previously empty file is no longer empty.  Make sure this change is "
 "intended and fix the package spec file if necessary."
 msgstr ""
 
-#: include/results.h:504
+#: include/results.h:511
 msgid ""
 "A previously non-empty file is now empty.  Make sure this change is intended "
 "and fix the package space file if necessary."
 msgstr ""
 
-#: include/results.h:519
+#: include/results.h:526
 #, c-format
 msgid ""
 "Unexpected capabilities were found on the indicated file.  Consult "
@@ -658,73 +670,73 @@ msgid ""
 "changes found here and send a patch to the project that owns the data file."
 msgstr ""
 
-#: include/results.h:534
+#: include/results.h:541
 msgid ""
 "Kernel module parameters were removed between builds.  This may present "
 "usability problems for users if module parameters were removed in a "
 "maintenance update."
 msgstr ""
 
-#: include/results.h:541
+#: include/results.h:548
 msgid ""
 "Kernel module dependencies changed between builds.  This may present "
 "usability problems for users if module dependencies changed in a maintenance "
 "update."
 msgstr ""
 
-#: include/results.h:548
+#: include/results.h:555
 msgid ""
 "Kernel module device aliases changed between builds.  This may present "
 "usability problems for users if module device aliases changed in a "
 "maintenance update."
 msgstr ""
 
-#: include/results.h:558
+#: include/results.h:565
 msgid ""
 "An architecture present in the before build is now missing in the after "
 "build.  This may be deliberate, but check to make sure you do not have any "
 "unexpected ExclusiveArch lines in the spec file."
 msgstr ""
 
-#: include/results.h:559
+#: include/results.h:566
 msgid ""
 "A new architecture has appeared in the after build.  This may indicate "
 "progress in the world of computing."
 msgstr ""
 
-#: include/results.h:569
+#: include/results.h:576
 msgid ""
 "A subpackage present in the before build is now missing in the after build.  "
 "This may be deliberate, but check to make sure you have correct syntax "
 "defining the subpackage in the spec file"
 msgstr ""
 
-#: include/results.h:570
+#: include/results.h:577
 msgid ""
 "A new subpackage has appeared in the after build.  This may indicate "
 "progress in the world of computing."
 msgstr ""
 
-#: include/results.h:580
+#: include/results.h:587
 #, c-format
 msgid ""
 "Make sure the spec file in the after build contains a valid %changelog "
 "section."
 msgstr ""
 
-#: include/results.h:590
+#: include/results.h:597
 msgid ""
 "Files should not be installed in old directory names.  Modify the package to "
 "install the affected file to the preferred directory."
 msgstr ""
 
-#: include/results.h:600
+#: include/results.h:607
 msgid ""
 "ELF .o and .a files should not carry LTO (Link Time Optimization) bytecode.  "
 "Make sure you have stripped LTO bytecode from those files at install time."
 msgstr ""
 
-#: include/results.h:610
+#: include/results.h:617
 msgid ""
 "Make sure symlinks point to a valid destination in one of the subpackages of "
 "the build; dangling symlinks are not allowed.  If you are comparing builds "
@@ -732,7 +744,7 @@ msgid ""
 "NOTE:  You cannot turn a directory in to a symlink due to RPM limitations."
 msgstr ""
 
-#: include/results.h:611
+#: include/results.h:618
 #, c-format
 msgid ""
 "Make sure symlinks point to a valid destination in one of the subpackages of "
@@ -744,7 +756,7 @@ msgid ""
 "'Scriptlet to replace a directory' for more information."
 msgstr ""
 
-#: include/results.h:621
+#: include/results.h:628
 #, c-format
 msgid ""
 "Remove forbidden path references from the indicated line in the %files "
@@ -753,28 +765,28 @@ msgid ""
 "information."
 msgstr ""
 
-#: include/results.h:631
+#: include/results.h:638
 msgid ""
 "In many cases the changing MIME type is deliberate.  Verify that the change "
 "is intended and if necessary fix the spec file so the correct file is "
 "included in the built package."
 msgstr ""
 
-#: include/results.h:641
+#: include/results.h:648
 msgid ""
 "ABI changes introduced during maintenance updates can lead to problems for "
 "users.  See the abidiff(1) documentation and the distribution ABI policies "
 "to determine if this detected change is allowed."
 msgstr ""
 
-#: include/results.h:651
+#: include/results.h:658
 msgid ""
 "Kernel Module Interface introduced during maintenance updates can lead to "
 "problems for users.  See the libabigail documentation and the distribution "
 "KMI policy to determine if this detected change is allowed."
 msgstr ""
 
-#: include/results.h:661
+#: include/results.h:668
 #, c-format
 msgid ""
 "Changes to %config should be done carefully.  Make sure you have installed "
@@ -783,7 +795,7 @@ msgid ""
 "package -or- honor the old file locations."
 msgstr ""
 
-#: include/results.h:671
+#: include/results.h:678
 #, c-format
 msgid ""
 "Changes found among the %doc files.  Verify these changes are intended if "
@@ -791,7 +803,7 @@ msgid ""
 "documentation files and the spec file needs to account for those changes."
 msgstr ""
 
-#: include/results.h:681
+#: include/results.h:688
 msgid ""
 "An invalid patch file was found.  This is usually the result of generating a "
 "collection of patches by comparing two trees.  When files disappear that can "
@@ -800,7 +812,7 @@ msgid ""
 "correct the problem."
 msgstr ""
 
-#: include/results.h:683
+#: include/results.h:690
 #, c-format
 msgid ""
 "The named patch is defined in the source RPM header (this means it has a "
@@ -809,25 +821,26 @@ msgid ""
 "the %autosetup or %autopatch macros.  You can fix this by adding the "
 "appropriate %patch macro in the spec file (usually in the %prep section).  "
 "The number specified with the %patch macro corresponds to the number used to "
-"define the patch at the top of the spec file.  So Patch47 is applied with a "
-"%patch47 macro."
+"define the patch at the top of the spec file.  So Patch47 is applied with "
+"either a '%patch 47', '%patch -P 47', '%patch -P47', or '%patch47' macro."
 msgstr ""
 
-#: include/results.h:685
+#: include/results.h:692
 #, c-format
 msgid ""
 "The named patch is defined but is mismatched by number with the %patch "
 "macro.  Make sure all numbered patches have corresponding %patch macros.  "
-"For example, Patch47 needs to have a %patch47 macro."
+"For example, Patch47 needs to have either a '%patch 47', '%patch -P 47', "
+"'%patch -P47', or '%patch47' macro."
 msgstr ""
 
-#: include/results.h:687
+#: include/results.h:694
 msgid ""
 "The defined patch file is not something rpminspect can handle.  This is "
 "likely a bug and should be reported to the upstream rpminspect project."
 msgstr ""
 
-#: include/results.h:697
+#: include/results.h:704
 msgid ""
 "ClamAV has found a virus in the named file.  This may be a false positive, "
 "but you should manually inspect the file in question to ensure it is clean.  "
@@ -836,7 +849,7 @@ msgid ""
 "further help."
 msgstr ""
 
-#: include/results.h:707
+#: include/results.h:714
 #, c-format
 msgid ""
 "A file with potential politically sensitive content was found in the "
@@ -845,7 +858,7 @@ msgid ""
 "the project that owns it."
 msgstr ""
 
-#: include/results.h:717
+#: include/results.h:724
 msgid ""
 "Forbidden symbols were found in an ELF file in the package.  The "
 "configuration settings for rpminspect indicate the named symbols are "
@@ -857,7 +870,7 @@ msgid ""
 "deprecated functions should not be used."
 msgstr ""
 
-#: include/results.h:727
+#: include/results.h:734
 msgid ""
 "Either DT_RPATH or DT_RUNPATH properties were found on ELF shared objects in "
 "this package.  The use of DT_RPATH and DT_RUNPATH is discouraged except in "
@@ -867,14 +880,14 @@ msgid ""
 "files."
 msgstr ""
 
-#: include/results.h:729
+#: include/results.h:736
 msgid ""
 "Both DT_RPATH and DT_RUNPATH properties were found in an ELF shared object.  "
 "This indicates a linker error and should not happen.  ELF objects should "
 "only carry DT_RPATH or DT_RUNPATH, never both."
 msgstr ""
 
-#: include/results.h:739
+#: include/results.h:746
 msgid ""
 "The rpminspect configuration file contains a list of forbidden Unicode code "
 "points.  One was found in the extracted and patched source tree or in one of "
@@ -883,7 +896,7 @@ msgid ""
 "correct course of action."
 msgstr ""
 
-#: include/results.h:741
+#: include/results.h:748
 #, c-format
 msgid ""
 "The %prep section of the spec file could not be executed for some reason.  "
@@ -893,14 +906,14 @@ msgid ""
 "program is executing."
 msgstr ""
 
-#: include/results.h:751
+#: include/results.h:758
 msgid ""
 "Unexpanded RPM spec file macros were found in the noted dependency rule.  "
 "Check the spec file for this dependency and ensure you have not misspelled a "
 "macro or used a macro name that does not exist."
 msgstr ""
 
-#: include/results.h:753
+#: include/results.h:760
 msgid ""
 "Add the indicated explicit Requires to the spec file for the named "
 "subpackage.  Subpackages depending on shared libraries in another subpackage "
@@ -908,7 +921,7 @@ msgid ""
 "in the spec file."
 msgstr ""
 
-#: include/results.h:755
+#: include/results.h:762
 msgid ""
 "Add the indicated explicit Requires to the spec file for the named "
 "subpackage.  Subpackages depending on shared libraries in another subpackage "
@@ -916,7 +929,7 @@ msgid ""
 "%{release}' in the spec file."
 msgstr ""
 
-#: include/results.h:757
+#: include/results.h:764
 #, c-format
 msgid ""
 "Check subpackage %files sections and explicit Provides statements.  Only one "
@@ -926,7 +939,7 @@ msgid ""
 "the shared library in question."
 msgstr ""
 
-#: include/results.h:759
+#: include/results.h:766
 msgid ""
 "A dependency listed in the before build changed to the indicated dependency "
 "in the after build.  If this is a VERIFY result, it means rpminspect noticed "
@@ -935,7 +948,7 @@ msgid ""
 "a rebased build."
 msgstr ""
 
-#: include/results.h:761
+#: include/results.h:768
 msgid ""
 "A new dependency is seen in the after build that was not present in the "
 "before build.  If this is a VERIFY result, it means rpminspect noticed the "
@@ -944,7 +957,7 @@ msgid ""
 "a rebased build."
 msgstr ""
 
-#: include/results.h:763
+#: include/results.h:770
 msgid ""
 "A dependency seen in the before build is not seen in the after build meaning "
 "it was removed or lost.  If this is a VERIFY result, it means rpminspect "
@@ -953,7 +966,7 @@ msgid ""
 "comparing a rebased build."
 msgstr ""
 
-#: include/results.h:765
+#: include/results.h:772
 msgid ""
 "The package has an Epoch value greater than zero, but the explicit "
 "subpackage dependencies are not consistently using it.  For the dependency "
@@ -964,135 +977,135 @@ msgstr ""
 
 #: lib/abi.c:65
 #, c-format
-msgid "malformed ABI level identifier: %s"
+msgid "*** malformed ABI level identifier: %s"
 msgstr ""
 
 #: lib/abi.c:70
 #, c-format
-msgid "ABI level %d already defined"
+msgid "*** ABI level %d already defined"
 msgstr ""
 
 #: lib/abi.c:84
 #, c-format
-msgid "malformed ABI level entry: %s"
+msgid "*** malformed ABI level entry: %s"
 msgstr ""
 
 #: lib/builds.c:73
 #, c-format
-msgid "unable to create download directory %s"
+msgid "*** unable to create download directory %s"
 msgstr ""
 
 #: lib/builds.c:85
 #, c-format
-msgid "unknown workdir type %d"
+msgid "*** unknown working directory type: %d"
 msgstr ""
 
 #: lib/builds.c:173
 #, c-format
-msgid "unable to read %s, skipping"
+msgid "*** unable to read %s, skipping"
 msgstr ""
 
-#: lib/builds.c:206
+#: lib/builds.c:205
 #, c-format
-msgid "unknown directory member encountered: %s"
+msgid "*** unknown directory member encountered: %s"
 msgstr ""
 
-#: lib/builds.c:235
+#: lib/builds.c:234
 #, c-format
 msgid "There is not enough available space to download the requested %s.\n"
 msgstr ""
 
-#: lib/builds.c:236 lib/peers.c:177
+#: lib/builds.c:235 lib/peers.c:177
 #, c-format
 msgid "    Need %s in %s, have %s.\n"
 msgstr ""
 
-#: lib/builds.c:237 lib/peers.c:178
+#: lib/builds.c:236 lib/peers.c:178
 #, c-format
 msgid "See the `-w' option for specifying an alternate working directory.\n"
 msgstr ""
 
-#: lib/builds.c:250
+#: lib/builds.c:249
 #, c-format
 msgid "Unable to determine the required space to download the requested %s.\n"
 msgstr ""
 
-#: lib/builds.c:251
+#: lib/builds.c:250
 #, c-format
 msgid "Ensure %s has sufficient space available."
 msgstr ""
 
-#: lib/builds.c:291 lib/builds.c:295
+#: lib/builds.c:290 lib/builds.c:294
 msgid "build"
 msgstr ""
 
-#: lib/builds.c:321
+#: lib/builds.c:320
 msgid "Downloading module"
 msgstr ""
 
-#: lib/builds.c:324
+#: lib/builds.c:323
 msgid "Downloading RPM build"
 msgstr ""
 
-#: lib/builds.c:375 lib/inspect_modularity.c:47
+#: lib/builds.c:373 lib/inspect_modularity.c:47
 #, c-format
-msgid "ignoring malformed module metadata file: %s"
+msgid "*** ignoring malformed module metadata file: %s"
 msgstr ""
 
-#: lib/builds.c:385
+#: lib/builds.c:383
 #, c-format
-msgid "malformed rpm filters in file: %s"
+msgid "*** malformed rpm filters in file: %s"
 msgstr ""
 
-#: lib/builds.c:544 lib/builds.c:548
+#: lib/builds.c:541 lib/builds.c:545
 msgid "task"
 msgstr ""
 
-#: lib/builds.c:664 lib/builds.c:667
+#: lib/builds.c:659 lib/builds.c:662
 msgid "RPM"
 msgstr ""
 
-#: lib/builds.c:796
+#: lib/builds.c:791
 #, c-format
-msgid "`%s' already exists in %s"
+msgid "*** `%s' already exists in %s"
 msgstr ""
 
-#: lib/builds.c:828
+#: lib/builds.c:823
 msgid "after"
 msgstr ""
 
-#: lib/builds.c:831
+#: lib/builds.c:826
 msgid "before"
 msgstr ""
 
-#: lib/builds.c:837
+#: lib/builds.c:832
 #, c-format
-msgid "unable to gather %s build: %s"
+msgid "*** unable to gather %s build: %s"
 msgstr ""
 
-#: lib/builds.c:849
+#: lib/builds.c:844
 #, c-format
-msgid "unable to download %s RPM: %s"
+msgid "*** unable to download %s RPM: %s"
 msgstr ""
 
-#: lib/builds.c:868 lib/builds.c:901
+#: lib/builds.c:863 lib/builds.c:896
 #, c-format
-msgid "unable to download %s build: %s"
+msgid "*** unable to download %s build: %s"
 msgstr ""
 
-#: lib/builds.c:880
+#: lib/builds.c:875
 #, c-format
-msgid "unable to download %s task: %s"
+msgid "*** unable to download %s task: %s"
 msgstr ""
 
-#: lib/builds.c:911
+#: lib/builds.c:906
 #, c-format
-msgid "unable to locate %s build: %s"
+msgid "*** unable to locate %s build: %s"
 msgstr ""
 
-#: lib/checksums.c:92
+#: lib/checksums.c:91
 #, c-format
-msgid "%s is a FIFO"
+msgid "*** %s is a FIFO"
 msgstr ""
 
 #: lib/copyfile.c:117
@@ -1104,180 +1117,193 @@ msgstr ""
 msgid ", overwriting"
 msgstr ""
 
-#: lib/fileinfo.c:58
+#: lib/curl.c:267 lib/readfile.c:60
+#, c-format
+msgid "*** unable to read %s"
+msgstr ""
+
+#: lib/fileinfo.c:64
 #, c-format
 msgid "%s in %s on %s carries expected mode %04o"
 msgstr ""
 
-#: lib/fileinfo.c:71
+#: lib/fileinfo.c:76
 #, c-format
 msgid ""
 "%s in %s on %s carries unexpected mode %04o; expected mode %04o; requires "
 "inspection by the Security Team"
 msgstr ""
 
-#: lib/fileinfo.c:92
+#: lib/fileinfo.c:96
 #, c-format
 msgid ""
 "%s in %s on %s carries insecure mode %04o, Security Team review may be "
 "required"
 msgstr ""
 
-#: lib/fileinfo.c:149
+#: lib/fileinfo.c:155
 #, c-format
 msgid "%s in %s on %s carries expected owner '%s'"
 msgstr ""
 
-#: lib/fileinfo.c:162
+#: lib/fileinfo.c:168
 #, c-format
 msgid ""
 "%s in %s on %s carries unexpected owner '%s'; expected owner '%s'; requires "
 "inspection by the Security Team"
 msgstr ""
 
-#: lib/fileinfo.c:225
+#: lib/fileinfo.c:192 lib/fileinfo.c:286
+#, c-format
+msgid ""
+"%s in %s on %s carries insecure mode %04o but has no fileinfo rule for owner "
+"specification, Security Team review may be required"
+msgstr ""
+
+#: lib/fileinfo.c:249
 #, c-format
 msgid "%s in %s on %s carries expected group '%s'"
 msgstr ""
 
-#: lib/fileinfo.c:238
+#: lib/fileinfo.c:262
 #, c-format
 msgid ""
 "%s in %s on %s carries group unexpected '%s'; expected group '%s'; requires "
 "inspection by the Security Team"
 msgstr ""
 
-#: lib/init.c:233
+#: lib/init.c:219
 #, c-format
-msgid "invalid input string `%s`"
+msgid "*** invalid input string `%s`"
 msgstr ""
 
-#: lib/init.c:260 lib/init.c:269 lib/init.c:277 lib/init.c:289 lib/init.c:298
-#: lib/init.c:306 lib/init.c:318 lib/init.c:327 lib/init.c:335 lib/init.c:347
+#: lib/init.c:246 lib/init.c:255 lib/init.c:263 lib/init.c:275 lib/init.c:284
+#: lib/init.c:292 lib/init.c:304 lib/init.c:313 lib/init.c:321 lib/init.c:333
 #, c-format
 msgid "*** invalid mode string: %s"
 msgstr ""
 
-#: lib/init.c:385
+#: lib/init.c:371
 #, c-format
-msgid "problem adding entries to array %s->%s"
+msgid "*** problem adding entries to array %s->%s"
 msgstr ""
 
-#: lib/init.c:406
+#: lib/init.c:392
 #, c-format
-msgid "problem adding ignore entries to %s"
+msgid "*** problem adding ignore entries to %s"
 msgstr ""
 
-#: lib/init.c:425 lib/init.c:439
-msgid "error reading "
+#: lib/init.c:411 lib/init.c:425
+msgid "*** error reading "
 msgstr ""
 
-#: lib/init.c:465
+#: lib/init.c:451
 #, c-format
-msgid "ignoring malformed section %s->%s"
+msgid "*** ignoring malformed section %s->%s"
 msgstr ""
 
-#: lib/init.c:522 lib/init.c:535
+#: lib/init.c:508 lib/init.c:521
 #, c-format
-msgid "error reading %s ignore pattern"
+msgid "*** error reading %s ignore pattern"
 msgstr ""
 
-#: lib/init.c:551
+#: lib/init.c:537
 #, c-format
 msgid "*** flag must be 'on' or 'off'; ignoring '%s'"
 msgstr ""
 
-#: lib/init.c:555
+#: lib/init.c:541
 #, c-format
-msgid "*** Unknown inspections: `%s`"
+msgid "*** unknown inspections: `%s`"
 msgstr ""
 
-#: lib/init.c:566
-msgid "malformed/unknown inspections section"
+#: lib/init.c:552
+msgid "*** malformed/unknown inspections section"
 msgstr ""
 
-#: lib/init.c:598
+#: lib/init.c:584
 #, c-format
-msgid "ignoring malformed %s configuration file: %s"
+msgid "*** ignoring malformed %s configuration file: %s"
 msgstr ""
 
-#: lib/init.c:651
+#: lib/init.c:645
 #, c-format
 msgid "*** unknown modularity static context settiongs '%s'"
 msgstr ""
 
-#: lib/init.c:715
+#: lib/init.c:709
 #, c-format
 msgid "*** unknown specname match setting '%s', defaulting to 'full'"
 msgstr ""
 
-#: lib/init.c:730
+#: lib/init.c:724
 #, c-format
 msgid "*** unknown specname primary setting '%s', defaulting to 'name'"
 msgstr ""
 
-#: lib/init.c:745
+#: lib/init.c:739
 #, c-format
-msgid "Invalid annocheck failure_reporting_level: %s, defaulting to %s."
+msgid "*** invalid annocheck failure_reporting_level: %s, defaulting to %s"
 msgstr ""
 
-#: lib/init.c:802
-msgid "Malformed badfuncs->allowed section"
+#: lib/init.c:796
+msgid "*** malformed badfuncs->allowed section"
 msgstr ""
 
-#: lib/init.c:820
-msgid "error reading unicode exclude regular expression"
+#: lib/init.c:814
+#, c-format
+msgid "*** error reading unicode exclude regular expression: %s"
 msgstr ""
 
-#: lib/init.c:830
-msgid "Malformed rpmdeps->ignore section; skipping"
+#: lib/init.c:824
+msgid "*** malformed rpmdeps->ignore section; skipping"
 msgstr ""
 
-#: lib/init.c:967
+#: lib/init.c:957
 #, c-format
 msgid "*** Invalid filename in the fileinfo list: %s"
 msgstr ""
 
-#: lib/init.c:968
+#: lib/init.c:958
 msgid "*** From this invalid line:"
 msgstr ""
 
-#: lib/init.c:969
+#: lib/init.c:959
 #, c-format
 msgid "***     %s"
 msgstr ""
 
-#: lib/init.c:1104
+#: lib/init.c:1110
 #, c-format
 msgid "*** unexpected token `%s' seen in %s, cannot continue"
 msgstr ""
 
-#: lib/init.c:1397
+#: lib/init.c:1403
 #, c-format
 msgid "*** invalid security rule: %s"
 msgstr ""
 
-#: lib/init.c:1431
+#: lib/init.c:1415
 #, c-format
 msgid "*** unknown security rule: %s"
 msgstr ""
 
-#: lib/init.c:1451
+#: lib/init.c:1424
 #, c-format
 msgid "*** unknown security action: %s"
 msgstr ""
 
-#: lib/init.c:1477
+#: lib/init.c:1450
 #, c-format
 msgid "*** malformed security line: %s"
 msgstr ""
 
-#: lib/init.c:1634
+#: lib/init.c:1609
 #, c-format
 msgid "*** missing configuration file `%s'"
 msgstr ""
 
-#: lib/init.c:1663
+#: lib/init.c:1645
 #, c-format
 msgid "*** unable to find profile '%s'"
 msgstr ""
@@ -1328,65 +1354,65 @@ msgid ""
 "%s"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:150
+#: lib/inspect_addedfiles.c:149
 #, c-format
 msgid ""
 "Packages should not contain files or directories starting with `%s` on %s in "
 "%s: %s"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:151 lib/inspect_addedfiles.c:165
+#: lib/inspect_addedfiles.c:150 lib/inspect_addedfiles.c:164
 msgid "invalid directory ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:164
+#: lib/inspect_addedfiles.c:163
 #, c-format
 msgid ""
 "Packages should not contain files or directories ending with `%s` on %s in "
 "%s: %s"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:178
+#: lib/inspect_addedfiles.c:177
 #, c-format
 msgid "Forbidden directory `%s` found on %s in %s: %s"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:179
+#: lib/inspect_addedfiles.c:178
 msgid "forbidden directory ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:214
+#: lib/inspect_addedfiles.c:209
 #, c-format
 msgid ""
 "New security-related file `%s` added on %s in %s requires inspection by the "
 "Security Team"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:216
+#: lib/inspect_addedfiles.c:211
 msgid "new security-related file ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:242
+#: lib/inspect_addedfiles.c:231
 #, c-format
 msgid "`%s` added on %s in %s"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:243
+#: lib/inspect_addedfiles.c:232
 msgid "new file ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_addedfiles.c:259
+#: lib/inspect_addedfiles.c:248
 msgid "the fileinfo list"
 msgstr ""
 
 #: lib/inspect_annocheck.c:116 lib/inspect_annocheck.c:151
 #, c-format
-msgid "libannocheck_enable_profile error: %s"
+msgid "*** libannocheck_enable_profile: %s"
 msgstr ""
 
 #: lib/inspect_annocheck.c:136
 #, c-format
-msgid "libannocheck_get_known_profiles error: %s"
+msgid "*** libannocheck_get_known_profiles: %s"
 msgstr ""
 
 #: lib/inspect_annocheck.c:168
@@ -1415,99 +1441,99 @@ msgstr ""
 
 #: lib/inspect_annocheck.c:226
 #, c-format
-msgid "libannocheck_init error: %s"
+msgid "*** libannocheck_init: %s"
 msgstr ""
 
 #: lib/inspect_annocheck.c:255
 #, c-format
-msgid "libannocheck_%s_test error: %s:"
+msgid "*** libannocheck_%s_test: %s"
 msgstr ""
 
 #: lib/inspect_annocheck.c:267
 #, c-format
-msgid "libannocheck_enable_all_tests error: %s:"
+msgid "*** libannocheck_enable_all_tests: %s"
 msgstr ""
 
 #: lib/inspect_annocheck.c:280
 #, c-format
-msgid "libannocheck_reinit error: %s"
+msgid "*** libannocheck_reinit: %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:370
+#: lib/inspect_annocheck.c:373
 #, c-format
-msgid "before libannocheck_run_tests error: %s (%d)"
+msgid "*** before libannocheck_run_tests: %s (%d)"
 msgstr ""
 
-#: lib/inspect_annocheck.c:379 lib/inspect_annocheck.c:423
+#: lib/inspect_annocheck.c:382 lib/inspect_annocheck.c:426
 #, c-format
-msgid "libannocheck_get_known_tests error: %s"
+msgid "*** libannocheck_get_known_tests: %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:397 lib/inspect_annocheck.c:525
+#: lib/inspect_annocheck.c:400 lib/inspect_annocheck.c:530
 #, c-format
-msgid "libannocheck_finish error: %s"
+msgid "*** libannocheck_finish: %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:414
+#: lib/inspect_annocheck.c:417
 #, c-format
-msgid "after libannocheck_run_tests error: %s (%d)"
+msgid "*** after libannocheck_run_tests: %s (%d)"
 msgstr ""
 
-#: lib/inspect_annocheck.c:458 lib/inspect_annocheck.c:606
+#: lib/inspect_annocheck.c:461 lib/inspect_annocheck.c:613
 msgid "lost -D_FORTIFY_SOURCE in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_annocheck.c:461
+#: lib/inspect_annocheck.c:464
 #, c-format
 msgid "%s may have lost -O2 -D_FORTIFY_SOURCE on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:485
+#: lib/inspect_annocheck.c:489
 #, c-format
 msgid "libannocheck '%s' continues passing for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:488
+#: lib/inspect_annocheck.c:492
 #, c-format
 msgid "libannocheck '%s' test now passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:491
+#: lib/inspect_annocheck.c:495
 #, c-format
 msgid "libannocheck '%s' test now fails for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:494 lib/inspect_annocheck.c:501
+#: lib/inspect_annocheck.c:498 lib/inspect_annocheck.c:505
 #, c-format
 msgid "libannocheck '%s' test fails for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:499
+#: lib/inspect_annocheck.c:503
 #, c-format
 msgid "libannocheck '%s' test passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:545 lib/inspect_annocheck.c:563
+#: lib/inspect_annocheck.c:551 lib/inspect_annocheck.c:569
 #, c-format
 msgid "annocheck '%s' test passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:547
+#: lib/inspect_annocheck.c:553
 #, c-format
 msgid "annocheck '%s' test now passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:549
+#: lib/inspect_annocheck.c:555
 #, c-format
 msgid "annocheck '%s' test now fails for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:555 lib/inspect_annocheck.c:565
+#: lib/inspect_annocheck.c:561 lib/inspect_annocheck.c:571
 #, c-format
 msgid "annocheck '%s' test fails for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:609
+#: lib/inspect_annocheck.c:616
 #, c-format
 msgid "%s may have lost -D_FORTIFY_SOURCE on %s"
 msgstr ""
@@ -1544,45 +1570,49 @@ msgstr ""
 msgid "forbidden functions in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_capabilities.c:81
+#: lib/inspect_capabilities.c:82
 #, c-format
-msgid "File capabilities for %s changed from '%s' to '%s' on %s\n"
+msgid "File capabilities for %s changed from '%s' to '%s' in %s on %s\n"
 msgstr ""
 
-#: lib/inspect_capabilities.c:85
+#: lib/inspect_capabilities.c:86
 msgid "${FILE} capabilities on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_capabilities.c:97
+#: lib/inspect_capabilities.c:98
 #, c-format
-msgid "File capabilities found for %s: '%s' on %s\n"
-msgstr ""
-
-#: lib/inspect_capabilities.c:123
-#, c-format
-msgid ""
-"File capabilities list entry found for %s: '%s' on %s, matches package\n"
+msgid "File capabilities found for %s: '%s' in %s on %s\n"
 msgstr ""
 
 #: lib/inspect_capabilities.c:134
 #, c-format
-msgid "File capabilities list mismatch for %s: expected '%s', got '%s'\n"
+msgid ""
+"File capabilities list entry found for %s: '%s' in %s on %s, matches "
+"package\n"
 msgstr ""
 
-#: lib/inspect_capabilities.c:138 lib/inspect_capabilities.c:158
-#: lib/inspect_capabilities.c:177
+#: lib/inspect_capabilities.c:145
+#, c-format
+msgid ""
+"File capabilities list mismatch for %s: expected '%s', got '%s' in %s on %s\n"
+msgstr ""
+
+#: lib/inspect_capabilities.c:149 lib/inspect_capabilities.c:169
+#: lib/inspect_capabilities.c:188
 msgid "${FILE} capabilities list on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_capabilities.c:154
+#: lib/inspect_capabilities.c:165
 #, c-format
 msgid ""
-"File capabilities for %s (%s) not found on the capabilities list on %s\n"
+"File capabilities for %s (%s) not found on the capabilities list in %s on "
+"%s\n"
 msgstr ""
 
-#: lib/inspect_capabilities.c:173
+#: lib/inspect_capabilities.c:184
 #, c-format
-msgid "File capabilities expected for %s but not found on %s: expected '%s'\n"
+msgid ""
+"File capabilities expected for %s in %s but not found on %s: expected '%s'\n"
 msgstr ""
 
 #: lib/inspect_changedfiles.c:31
@@ -1591,38 +1621,38 @@ msgid ""
 "Security Response Team."
 msgstr ""
 
-#: lib/inspect_changedfiles.c:289
+#: lib/inspect_changedfiles.c:306
 #, c-format
 msgid "Compressed %s file %s changed content in %s on %s."
 msgstr ""
 
-#: lib/inspect_changedfiles.c:322 lib/inspect_changedfiles.c:337
+#: lib/inspect_changedfiles.c:342 lib/inspect_changedfiles.c:357
 #, c-format
 msgid "Error running msgunfmt on %s in %s on %s; malformed mo file?"
 msgstr ""
 
-#: lib/inspect_changedfiles.c:326 lib/inspect_changedfiles.c:341
+#: lib/inspect_changedfiles.c:346 lib/inspect_changedfiles.c:361
 msgid "msgunfmt on ${FILE}"
 msgstr ""
 
-#: lib/inspect_changedfiles.c:362
+#: lib/inspect_changedfiles.c:382
 #, c-format
 msgid "Message catalog %s changed content in %s on %s"
 msgstr ""
 
-#: lib/inspect_changedfiles.c:366 lib/inspect_changedfiles.c:424
-#: lib/inspect_changedfiles.c:446
+#: lib/inspect_changedfiles.c:386 lib/inspect_changedfiles.c:444
+#: lib/inspect_changedfiles.c:466
 msgid "${FILE}"
 msgstr ""
 
-#: lib/inspect_changedfiles.c:420
+#: lib/inspect_changedfiles.c:440
 #, c-format
 msgid ""
 "Public header file %s changed content in %s on %s.  A unified diff of the "
 "changes follows."
 msgstr ""
 
-#: lib/inspect_changedfiles.c:443
+#: lib/inspect_changedfiles.c:463
 #, c-format
 msgid "File %s changed content in %s on %s."
 msgstr ""
@@ -1676,70 +1706,70 @@ msgstr ""
 msgid "not "
 msgstr ""
 
-#: lib/inspect_debuginfo.c:219
+#: lib/inspect_debuginfo.c:217
 #, c-format
 msgid "%s in %s on %s is missing debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:223
+#: lib/inspect_debuginfo.c:221
 msgid "missing debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:226
+#: lib/inspect_debuginfo.c:224
 #, c-format
 msgid "Missing: %s"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:237
+#: lib/inspect_debuginfo.c:235
 #, c-format
 msgid "%s in %s on %s contains debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:241
+#: lib/inspect_debuginfo.c:239
 msgid "contains debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:243
+#: lib/inspect_debuginfo.c:241
 #, c-format
 msgid "Contains: %s"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:262
+#: lib/inspect_debuginfo.c:260
 #, c-format
 msgid "%s in %s on %s gained debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:263
+#: lib/inspect_debuginfo.c:261
 msgid "gained debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:268
+#: lib/inspect_debuginfo.c:266
 #, c-format
 msgid "Gained: %s"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:288
+#: lib/inspect_debuginfo.c:286
 #, c-format
 msgid "%s in %s on %s lost debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:289
+#: lib/inspect_debuginfo.c:287
 msgid "lost debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:294
+#: lib/inspect_debuginfo.c:292
 #, c-format
 msgid "Lost: %s"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:320
+#: lib/inspect_debuginfo.c:318
 #, c-format
 msgid ""
 "%s in %s on %s carries .gosymtab but should not have the .gnu_debugdata "
 "symbol"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:322
+#: lib/inspect_debuginfo.c:320
 msgid ".gnu_debugdata with .gosymtab"
 msgstr ""
 
@@ -1814,16 +1844,16 @@ msgid ""
 "File %s is not a valid desktop file on %s; desktop-file-validate reports:"
 msgstr ""
 
-#: lib/inspect_disttag.c:181
+#: lib/inspect_disttag.c:184
 #, c-format
 msgid "The %s file is missing the %s tag."
 msgstr ""
 
-#: lib/inspect_disttag.c:183
+#: lib/inspect_disttag.c:186
 msgid "${FILE} missing Release tag"
 msgstr ""
 
-#: lib/inspect_disttag.c:189
+#: lib/inspect_disttag.c:192
 #, c-format
 msgid ""
 "The %s tag value is missing the dist tag in the proper form. The dist tag "
@@ -1831,12 +1861,12 @@ msgid ""
 "After RPM macro expansion, no dist tag was found in this %s tag value."
 msgstr ""
 
-#: lib/inspect_disttag.c:191
+#: lib/inspect_disttag.c:194
 #, c-format
 msgid "${FILE} does not use '%%{?dist}' in Release"
 msgstr ""
 
-#: lib/inspect_disttag.c:260
+#: lib/inspect_disttag.c:263
 msgid "Specified package is not a source RPM, skipping."
 msgstr ""
 
@@ -1885,102 +1915,102 @@ msgstr ""
 msgid "DT_NEEDED symbol(s) added to %s on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:430
+#: lib/inspect_elf.c:433
 #, c-format
 msgid "Object still has executable stack (no GNU-stack note): %s on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:432
+#: lib/inspect_elf.c:435
 #, c-format
 msgid "Object has executable stack (no GNU-stack note): %s on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:435
+#: lib/inspect_elf.c:438
 #, c-format
 msgid "Program built without GNU_STACK: %s on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:441
+#: lib/inspect_elf.c:444
 msgid "GNU_STACK in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_elf.c:493
+#: lib/inspect_elf.c:496
 #, c-format
 msgid "File %s has invalid execstack flags (%s) on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:498
+#: lib/inspect_elf.c:501
 #, c-format
 msgid "File %s has unrecognized GNU_STACK '%s' (expected RW or RWE) on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:507 lib/inspect_elf.c:537
+#: lib/inspect_elf.c:510 lib/inspect_elf.c:540
 msgid "execstack in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_elf.c:522
+#: lib/inspect_elf.c:525
 #, c-format
 msgid "Object still has executable stack (GNU-stack note = X): %s on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:524
+#: lib/inspect_elf.c:527
 #, c-format
 msgid "Object has executable stack (GNU-stack note = X): %s on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:528
+#: lib/inspect_elf.c:531
 #, c-format
 msgid "Stack is still executable: %s on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:530
+#: lib/inspect_elf.c:533
 #, c-format
 msgid "Stack is executable: %s on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:561
+#: lib/inspect_elf.c:564
 #, c-format
 msgid "%s lost full GNU_RELRO security protection on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:564
+#: lib/inspect_elf.c:567
 #, c-format
 msgid "%s lost GNU_RELRO security protection on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:575
+#: lib/inspect_elf.c:578
 msgid "lost GNU_RELRO in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_elf.c:722
+#: lib/inspect_elf.c:725
 #, c-format
 msgid "The following objects lost -fPIC:\n"
 msgstr ""
 
-#: lib/inspect_elf.c:739
+#: lib/inspect_elf.c:742
 #, c-format
 msgid "The following new objects were built without -fPIC:\n"
 msgstr ""
 
-#: lib/inspect_elf.c:752
+#: lib/inspect_elf.c:755
 #, c-format
 msgid "%s in %s has objects built without -fPIC on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:760
+#: lib/inspect_elf.c:763
 msgid "missing -fPIC in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_elf.c:796
+#: lib/inspect_elf.c:799
 msgid "TEXTREL relocations in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_elf.c:811
+#: lib/inspect_elf.c:814
 #, c-format
 msgid "%s in %s acquired TEXTREL relocations on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:814
+#: lib/inspect_elf.c:817
 #, c-format
 msgid "%s in %s has TEXTREL relocations on %s"
 msgstr ""
@@ -2058,38 +2088,38 @@ msgstr ""
 msgid "${FILE} size shrank on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_javabytecode.c:125
+#: lib/inspect_javabytecode.c:130
 #, c-format
 msgid ""
 "File %s (%s), Java byte code version %d is incorrect (wrong endianness? "
 "corrupted file? space JDK?)"
 msgstr ""
 
-#: lib/inspect_javabytecode.c:126
+#: lib/inspect_javabytecode.c:131
 msgid "incorrect Java byte code version in ${FILE}"
 msgstr ""
 
-#: lib/inspect_javabytecode.c:131
+#: lib/inspect_javabytecode.c:136
 #, c-format
 msgid ""
 "File %s (%s), Java byte code version %d greater than supported major version "
 "%d for product release %s"
 msgstr ""
 
-#: lib/inspect_javabytecode.c:132
+#: lib/inspect_javabytecode.c:137
 msgid "Java byte code version too new in ${FILE}"
 msgstr ""
 
-#: lib/inspect_javabytecode.c:147
+#: lib/inspect_javabytecode.c:152
 #, c-format
 msgid "Java byte code version changed from %d to %d in %s from %s"
 msgstr ""
 
-#: lib/inspect_javabytecode.c:148
+#: lib/inspect_javabytecode.c:153
 msgid "Java byte code version changed in ${FILE}"
 msgstr ""
 
-#: lib/inspect_javabytecode.c:250 lib/inspect_javabytecode.c:262
+#: lib/inspect_javabytecode.c:255 lib/inspect_javabytecode.c:267
 msgid "*** missing JVM version to product release mapping"
 msgstr ""
 
@@ -2135,7 +2165,7 @@ msgstr ""
 msgid "kmidiff unexpected exit"
 msgstr ""
 
-#: lib/inspect_kmidiff.c:277
+#: lib/inspect_kmidiff.c:274
 #, c-format
 msgid ""
 "Command: %s\n"
@@ -2156,45 +2186,45 @@ msgstr ""
 msgid "Kernel module '%s' gained alias '%s'"
 msgstr ""
 
-#: lib/inspect_kmod.c:190
+#: lib/inspect_kmod.c:188
 #, c-format
 msgid "Kernel module %s removes parameter '%s' (was present in %s)."
 msgstr ""
 
-#: lib/inspect_kmod.c:193 lib/inspect_kmod.c:210
+#: lib/inspect_kmod.c:191 lib/inspect_kmod.c:208
 msgid "${FILE} kernel module parameter on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_kmod.c:207
+#: lib/inspect_kmod.c:205
 #, c-format
 msgid "Kernel module %s adds parameter '%s' (was not present in %s)."
 msgstr ""
 
-#: lib/inspect_kmod.c:228
+#: lib/inspect_kmod.c:226
 #, c-format
 msgid "Kernel module %s removes dependency '%s' (was present in %s)."
 msgstr ""
 
-#: lib/inspect_kmod.c:231
+#: lib/inspect_kmod.c:229
 msgid "${FILE} kernel module dependency on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_kmod.c:245
+#: lib/inspect_kmod.c:243
 #, c-format
 msgid "Kernel module %s adds dependency '%s' (was not present in %s)."
 msgstr ""
 
-#: lib/inspect_kmod.c:248
+#: lib/inspect_kmod.c:246
 msgid "${FILE} kernel module parameter"
 msgstr ""
 
 #: lib/inspect_license.c:47
 #, c-format
-msgid "parse error on license db %s"
+msgid "*** parse error in license database %s"
 msgstr ""
 
 #: lib/inspect_license.c:135
-msgid "problem checking licensedb"
+msgid "*** problem checking license database"
 msgstr ""
 
 #: lib/inspect_license.c:464
@@ -2260,17 +2290,17 @@ msgstr ""
 msgid "subpackage ${FILE} on ${ARCH} now has empty payload"
 msgstr ""
 
-#: lib/inspect_lto.c:135
+#: lib/inspect_lto.c:144
 msgid "${FILE} not portable on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_lto.c:144
+#: lib/inspect_lto.c:152
 #, c-format
 msgid ""
 "%s contains symbols [%s] on %s; this is not portable across compiler versions"
 msgstr ""
 
-#: lib/inspect_lto.c:159
+#: lib/inspect_lto.c:168
 #, c-format
 msgid ""
 "%s contains symbol [%s] on %s; this is not portable across compiler versions"
@@ -2283,7 +2313,7 @@ msgstr ""
 
 #: lib/inspect_manpage.c:81
 #, c-format
-msgid "unable to compile man page path regular expression: %s"
+msgid "*** unable to compile man page path regular expression: %s"
 msgstr ""
 
 #: lib/inspect_manpage.c:179
@@ -2420,120 +2450,59 @@ msgid ""
 "%s"
 msgstr ""
 
-#: lib/inspect_modularity.c:123
-#, c-format
-msgid ""
-"The /data/static_context value in %s matches the value in %s, but the "
-"product release rules forbid the presence of /data/static_context in the "
-"module metadata."
-msgstr ""
-
-#: lib/inspect_modularity.c:129
-#, c-format
-msgid ""
-"The /data/static_context value in %s matches the value in %s, and the "
-"product release rules require the presence of /data/static_context in the "
-"module metadata."
-msgstr ""
-
-#: lib/inspect_modularity.c:131
-#, c-format
-msgid ""
-"The /data/static_context value in %s matches the value in %s, and the "
-"product release rules recommend the presence of /data/static_context in the "
-"module metadata."
-msgstr ""
-
-#: lib/inspect_modularity.c:133
-#, c-format
-msgid ""
-"The /data/static_context value in %s matches the value in %s, but the "
-"product release rules do not have a setting for /data/static_context in the "
-"module metadata."
-msgstr ""
-
-#: lib/inspect_modularity.c:137
-#, c-format
-msgid ""
-"The /data/static_context value in %s was %s and became %s in %s, but the "
-"product release rules forbid the presence of /data/static_context in the "
-"module metadata."
-msgstr ""
-
-#: lib/inspect_modularity.c:137 lib/inspect_modularity.c:143
-#: lib/inspect_modularity.c:149 lib/inspect_modularity.c:151
-#: lib/inspect_modularity.c:156 lib/inspect_modularity.c:162
-#: lib/inspect_modularity.c:168 lib/inspect_modularity.c:170
-msgid "true"
-msgstr ""
-
-#: lib/inspect_modularity.c:137 lib/inspect_modularity.c:143
-#: lib/inspect_modularity.c:149 lib/inspect_modularity.c:151
-#: lib/inspect_modularity.c:156 lib/inspect_modularity.c:162
-#: lib/inspect_modularity.c:168 lib/inspect_modularity.c:170
-msgid "false"
-msgstr ""
-
-#: lib/inspect_modularity.c:143
-#, c-format
-msgid ""
-"The /data/static_context value in %s was %s and became %s in %s, but the "
-"product release rules require the presence of /data/static_context in the "
-"module metadata."
-msgstr ""
-
-#: lib/inspect_modularity.c:149
-#, c-format
-msgid ""
-"The /data/static_context value in %s was %s and became %s in %s, and the "
-"product release rules recommend the presence of /data/static_context in the "
-"module metadata."
-msgstr ""
-
-#: lib/inspect_modularity.c:151
-#, c-format
-msgid ""
-"The /data/static_context value in %s was %s and became %s in %s, but the "
-"product release rules do not have a setting for /data/static_context in the "
-"module metadata."
-msgstr ""
-
-#: lib/inspect_modularity.c:156
+#: lib/inspect_modularity.c:119
 #, c-format
 msgid ""
 "The /data/static_context value in %s is %s, but the product release rules "
 "forbid the presence of /data/static_context in the module metadata."
 msgstr ""
 
-#: lib/inspect_modularity.c:162
+#: lib/inspect_modularity.c:125
 #, c-format
 msgid ""
 "The /data/static_context value in %s is %s, but the product release rules "
 "require the presence of /data/static_context in the module metadata."
 msgstr ""
 
-#: lib/inspect_modularity.c:168
+#: lib/inspect_modularity.c:131
 #, c-format
 msgid ""
-"The /data/static_context value in %s is %s, and the product release rules "
+"The /data/static_context value in %s is %s, but the product release rules "
 "recommend the presence of /data/static_context in the module metadata."
 msgstr ""
 
-#: lib/inspect_modularity.c:170
+#: lib/inspect_modularity.c:133
 #, c-format
 msgid ""
-"The /data/static_context value in %s is %s, but the product release rules do "
+"The /data/static_context value in %s is %s, and the product release rules do "
 "not have a setting for /data/static_context in the module metadata."
 msgstr ""
 
-#: lib/inspect_modularity.c:202
+#: lib/inspect_modularity.c:135
+#, c-format
+msgid ""
+"The /data/static_context value in %s is %s as required by the product "
+"release rules."
+msgstr ""
+
+#: lib/inspect_modularity.c:143
+#, c-format
+msgid "%s The /data/static_context value is the same as in %s."
+msgstr ""
+
+#: lib/inspect_modularity.c:145
+#, c-format
+msgid "%s The /data/static_context value has changed since %s."
+msgstr ""
+
+#: lib/inspect_modularity.c:180
 #, c-format
 msgid ""
 "Package \"%s\" is part of a module but lacks the '%%{modularitylabel}' "
 "header tag."
 msgstr ""
 
-#: lib/inspect_modularity.c:246
+#: lib/inspect_modularity.c:224
 msgid "Inspection skipped because this build's type is not `module'."
 msgstr ""
 
@@ -2547,164 +2516,174 @@ msgstr ""
 msgid "%s probably moved to %s on %s\n"
 msgstr ""
 
-#: lib/inspect_ownership.c:68
+#: lib/inspect_ownership.c:77
 #, c-format
 msgid "File %s has forbidden owner `%s` on %s"
 msgstr ""
 
-#: lib/inspect_ownership.c:73
+#: lib/inspect_ownership.c:82
 msgid "forbidden owner for ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_ownership.c:83
+#: lib/inspect_ownership.c:92
 #, c-format
 msgid "File %s has forbidden group `%s` on %s"
 msgstr ""
 
-#: lib/inspect_ownership.c:88
+#: lib/inspect_ownership.c:97
 msgid "forbidden group for ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_ownership.c:105
+#: lib/inspect_ownership.c:119
 #, c-format
 msgid "File %s has owner `%s` on %s, but should be `%s`"
 msgstr ""
 
-#: lib/inspect_ownership.c:110
+#: lib/inspect_ownership.c:124
 msgid "invalid owner for ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_ownership.c:144
+#: lib/inspect_ownership.c:162
 #, c-format
 msgid ""
 "File %s on %s has CAP_SETUID capability but group `%s` and is world "
 "executable"
 msgstr ""
 
-#: lib/inspect_ownership.c:148
+#: lib/inspect_ownership.c:166
 msgid "CAP_SETUID and o+x for ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_ownership.c:161
+#: lib/inspect_ownership.c:179
 #, c-format
 msgid ""
 "File %s on %s has CAP_SETUID capability but group `%s` and is group writable"
 msgstr ""
 
-#: lib/inspect_ownership.c:165
+#: lib/inspect_ownership.c:183
 msgid "CAP_SETUID and g+w for ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_ownership.c:179
+#: lib/inspect_ownership.c:199
 #, c-format
 msgid "File %s has group `%s` on %s, but should be `%s`"
 msgstr ""
 
-#: lib/inspect_ownership.c:184
+#: lib/inspect_ownership.c:204
 msgid "invalid group for ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_ownership.c:248
+#: lib/inspect_ownership.c:268
 #, c-format
 msgid "File %s changed %s from `%s` to `%s` on %s"
 msgstr ""
 
-#: lib/inspect_ownership.c:250
+#: lib/inspect_ownership.c:270
 msgid "${FILE} changed owner on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_patches.c:371
+#: lib/inspect_patches.c:393
 #, c-format
 msgid ""
 "Patch number %ld (%s) is missing a corresponding %%patch%ld macro, usually "
 "in %%prep."
 msgstr ""
 
-#: lib/inspect_patches.c:373
+#: lib/inspect_patches.c:395
 #, c-format
 msgid "missing %%patch macro for ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:375
+#: lib/inspect_patches.c:397
 #, c-format
 msgid "Patch number %ld (%s) is mismatched with %%patch%ld macro."
 msgstr ""
 
-#: lib/inspect_patches.c:377
+#: lib/inspect_patches.c:399
 #, c-format
 msgid "mismatched %%patch macro for ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:398
+#: lib/inspect_patches.c:420
 msgid "undefined Patch ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:399
+#: lib/inspect_patches.c:421
 #, c-format
 msgid "Undefined Patch file %s."
 msgstr ""
 
-#: lib/inspect_patches.c:412 lib/inspect_patches.c:420
+#: lib/inspect_patches.c:434 lib/inspect_patches.c:442
 #, c-format
-msgid "unable to uncompress patch: %s"
+msgid "*** unable to uncompress patch: %s"
 msgstr ""
 
-#: lib/inspect_patches.c:449
+#: lib/inspect_patches.c:471
 msgid "corrupt patch ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:453 lib/inspect_patches.c:460
+#: lib/inspect_patches.c:475 lib/inspect_patches.c:482
 #, c-format
 msgid "Patch %s is under 4 bytes in size - is it corrupt?"
 msgstr ""
 
-#: lib/inspect_patches.c:482
+#: lib/inspect_patches.c:504
 #, c-format
 msgid "%s changed (%ld bytes -> %ld bytes)"
 msgstr ""
 
-#: lib/inspect_patches.c:486 lib/inspect_patches.c:511
+#: lib/inspect_patches.c:508 lib/inspect_patches.c:533
 msgid "patch file ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:507
+#: lib/inspect_patches.c:529
 #, c-format
 msgid "New patch file `%s` appeared"
 msgstr ""
 
-#: lib/inspect_patches.c:527
+#: lib/inspect_patches.c:549
 msgid "patch changes ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:531
+#: lib/inspect_patches.c:553
 #, c-format
 msgid "%s touches as many as %ld line%s"
 msgstr ""
 
-#: lib/inspect_patches.c:533
+#: lib/inspect_patches.c:555
 #, c-format
 msgid "%s touches %ld file%s"
 msgstr ""
 
-#: lib/inspect_patches.c:535
+#: lib/inspect_patches.c:557
 #, c-format
 msgid "%s touches %ld file%s and %s%ld line%s"
 msgstr ""
 
-#: lib/inspect_patches.c:535
+#: lib/inspect_patches.c:557
 msgid "as many as "
 msgstr ""
 
-#: lib/inspect_patches.c:599 lib/inspect_upstream.c:140
+#: lib/inspect_patches.c:624 lib/inspect_upstream.c:141
 msgid "No source packages available, skipping inspection."
 msgstr ""
 
-#: lib/inspect_patches.c:696
+#: lib/inspect_patches.c:723
 #, c-format
 msgid "Unhandled patch file `%s` defined in spec file"
 msgstr ""
 
-#: lib/inspect_patches.c:791
+#: lib/inspect_patches.c:820
+#, c-format
+msgid "*** unrecognized %%patch line: %s"
+msgstr ""
+
+#: lib/inspect_patches.c:826
+#, c-format
+msgid "*** unable to read spec file line: %s"
+msgstr ""
+
+#: lib/inspect_patches.c:879
 #, c-format
 msgid "Patch file `%s` removed"
 msgstr ""
@@ -2719,77 +2698,77 @@ msgstr ""
 msgid "${FILE} should be in %s on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_permissions.c:71
+#: lib/inspect_permissions.c:84
 msgid " changed setuid/setgid;"
 msgstr ""
 
-#: lib/inspect_permissions.c:76
+#: lib/inspect_permissions.c:89
 msgid " became a directory;"
 msgstr ""
 
-#: lib/inspect_permissions.c:78
+#: lib/inspect_permissions.c:91
 msgid " became a character device;"
 msgstr ""
 
-#: lib/inspect_permissions.c:80
+#: lib/inspect_permissions.c:93
 msgid " became a block device;"
 msgstr ""
 
-#: lib/inspect_permissions.c:82
+#: lib/inspect_permissions.c:95
 msgid " became a regular file;"
 msgstr ""
 
-#: lib/inspect_permissions.c:84
+#: lib/inspect_permissions.c:97
 msgid " became a FIFO;"
 msgstr ""
 
-#: lib/inspect_permissions.c:86
+#: lib/inspect_permissions.c:99
 msgid " became a symbolic link;"
 msgstr ""
 
-#: lib/inspect_permissions.c:88
+#: lib/inspect_permissions.c:101
 msgid " became a socket;"
 msgstr ""
 
-#: lib/inspect_permissions.c:92
+#: lib/inspect_permissions.c:105
 msgid " permissions"
 msgstr ""
 
-#: lib/inspect_permissions.c:98
+#: lib/inspect_permissions.c:111
 msgid " relaxed"
 msgstr ""
 
-#: lib/inspect_permissions.c:101
+#: lib/inspect_permissions.c:114
 msgid " changed"
 msgstr ""
 
-#: lib/inspect_permissions.c:111
+#: lib/inspect_permissions.c:129
 #, c-format
 msgid "%s from %04o to %04o on %s"
 msgstr ""
 
-#: lib/inspect_permissions.c:117
+#: lib/inspect_permissions.c:135
 #, c-format
 msgid "${FILE} permissions from %04o to %04o on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_permissions.c:131
+#: lib/inspect_permissions.c:149
 #, c-format
 msgid "%s (%s) is world-writable on %s"
 msgstr ""
 
-#: lib/inspect_permissions.c:134
+#: lib/inspect_permissions.c:152
 msgid "${FILE} is world-writable on ${ARCH}"
 msgstr ""
 
 #: lib/inspect_politics.c:47 lib/inspect_politics.c:67
 #, c-format
-msgid "invalid politics entry with pattern=%s and digest=%s"
+msgid "*** invalid politics entry with pattern=%s and digest=%s"
 msgstr ""
 
 #: lib/inspect_politics.c:92
 #, c-format
-msgid "unknown digest type for pattern %s: %s"
+msgid "*** unknown digest type for pattern %s: %s"
 msgstr ""
 
 #: lib/inspect_politics.c:126
@@ -2939,25 +2918,25 @@ msgstr ""
 msgid "Lost '%s' in subpackage %s on %s"
 msgstr ""
 
-#: lib/inspect_runpath.c:140
+#: lib/inspect_runpath.c:136
 #, c-format
-msgid "unable to compile $ORIGIN root prefix regular expression: %s"
+msgid "*** unable to compile $ORIGIN root prefix regular expression: %s"
 msgstr ""
 
-#: lib/inspect_runpath.c:194
+#: lib/inspect_runpath.c:190
 #, c-format
 msgid "%s has an invalid-looking %s on %s: %s"
 msgstr ""
 
-#: lib/inspect_runpath.c:196
+#: lib/inspect_runpath.c:192
 msgid "runtime search path in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_runpath.c:274
+#: lib/inspect_runpath.c:270
 msgid "both DT_RPATH and DT_RUNPATH in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_runpath.c:276
+#: lib/inspect_runpath.c:272
 #, c-format
 msgid "%s has both DT_RPATH and DT_RUNPATH on %s; this is not allowed"
 msgstr ""
@@ -3100,35 +3079,35 @@ msgstr ""
 msgid "MIME type for %s in %s was `%s/%s' and became `%s/%s'"
 msgstr ""
 
-#: lib/inspect_unicode.c:430
+#: lib/inspect_unicode.c:471
 #, c-format
-msgid "empty localpath on %s"
+msgid "*** empty localpath on %s"
 msgstr ""
 
-#: lib/inspect_unicode.c:445
+#: lib/inspect_unicode.c:480
 msgid "forbidden code point in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_unicode.c:497
+#: lib/inspect_unicode.c:557
 #, c-format
 msgid ""
-"A forbidden code point was found in the %s source file on line %ld at column "
-"%ld."
+"A forbidden code point, 0x%04X, was found in the %s source file on line %ld "
+"at column %ld.  This source file is used by %s."
 msgstr ""
 
-#: lib/inspect_unicode.c:554
+#: lib/inspect_unicode.c:627
 #, c-format
 msgid "unable to run %prep in ${FILE}"
 msgstr ""
 
-#: lib/inspect_unicode.c:557
+#: lib/inspect_unicode.c:630
 #, c-format
 msgid ""
 "Unable to run through the %%prep section in %s or manually unpack sources "
 "for further scanning."
 msgstr ""
 
-#: lib/inspect_unicode.c:662
+#: lib/inspect_unicode.c:750
 msgid "The unicode inspection is only for source packages, skipping."
 msgstr ""
 
@@ -3150,84 +3129,84 @@ msgstr ""
 msgid "checksum of ${FILE}"
 msgstr ""
 
-#: lib/inspect_upstream.c:194
+#: lib/inspect_upstream.c:195
 #, c-format
 msgid "Source file `%s` removed"
 msgstr ""
 
-#: lib/inspect_upstream.c:196
+#: lib/inspect_upstream.c:197
 msgid "source file ${FILE} removed"
 msgstr ""
 
 #: lib/inspect_virus.c:40
-msgid "cl_engine_new returned NULL, check clamav library"
+msgid "*** cl_engine_new returned NULL, check clamav library"
 msgstr ""
 
-#: lib/inspect_virus.c:86
+#: lib/inspect_virus.c:98
 #, c-format
 msgid "Virus detected in %s in the %s package on %s: %s"
 msgstr ""
 
-#: lib/inspect_virus.c:124
+#: lib/inspect_virus.c:135
 msgid "clamav version information"
 msgstr ""
 
-#: lib/inspect_virus.c:129
+#: lib/inspect_virus.c:140
 #, c-format
 msgid "clamav version %s"
 msgstr ""
 
-#: lib/inspect_virus.c:134
+#: lib/inspect_virus.c:145
 #, c-format
-msgid "missing %s"
+msgid "*** missing %s"
 msgstr ""
 
-#: lib/inspect_virus.c:158
+#: lib/inspect_virus.c:169
 #, c-format
 msgid "%s version %u (%s)"
 msgstr ""
 
-#: lib/inspect_virus.c:193
+#: lib/inspect_virus.c:201
 msgid "virus or malware in ${FILE} on ${ARCH}"
-msgstr ""
-
-#: lib/inspect_xml.c:187
-#, c-format
-msgid "%s is a well-formed XML file in %s on %s, but is not a valid XML file"
 msgstr ""
 
 #: lib/inspect_xml.c:195
 #, c-format
+msgid "%s is a well-formed XML file in %s on %s, but is not a valid XML file"
+msgstr ""
+
+#: lib/inspect_xml.c:203
+#, c-format
 msgid "%s is not a well-formed XML file in %s on %s"
 msgstr ""
 
-#: lib/inspect_xml.c:199
+#: lib/inspect_xml.c:207
 msgid "${FILE} is not well-formed XML on ${ARCH}"
 msgstr ""
 
 #: lib/koji.c:142
 #, c-format
-msgid "XML-RPC Fault: %s (%d)"
+msgid "*** XML-RPC Fault: %s (%d)"
 msgstr ""
 
 #: lib/koji.c:652
 #, c-format
-msgid "xmlrpc fault code %s (%d): getBuild(%s) from %s"
+msgid "*** xmlrpc fault code %s (%d): getBuild(%s) from %s"
 msgstr ""
 
 #: lib/koji.c:884
 #, c-format
-msgid "Koji build state is %s for %s, cannot continue."
+msgid "*** Koji build state is %s for %s, cannot continue"
 msgstr ""
 
 #: lib/koji.c:1147
 #, c-format
-msgid "xmlrpc fault code %s (%d): getTaskInfo(%s) from %s"
+msgid "*** xmlrpc fault code %s (%d): getTaskInfo(%s) from %s"
 msgstr ""
 
 #: lib/koji.c:1171
 #, c-format
-msgid "Koji task state is %s for task %s, cannot continue."
+msgid "*** Koji task state is %s for task %s, cannot continue"
 msgstr ""
 
 #: lib/koji.c:1399
@@ -3239,15 +3218,15 @@ msgid "Module build consisting of multiple RPM package builds"
 msgstr ""
 
 #: lib/magic.c:32
-msgid "unable to initialize the magic library"
+msgid "*** unable to initialize the magic library"
 msgstr ""
 
 #: lib/magic.c:37
 #, c-format
-msgid "unable to load the magic database: %s"
+msgid "*** unable to load the magic database: %s"
 msgstr ""
 
-#: lib/mkdirp.c:76 lib/mkdirp.c:88
+#: lib/mkdirp.c:76 lib/mkdirp.c:89
 #, c-format
 msgid "*** unable to mkdir %s"
 msgstr ""
@@ -3275,9 +3254,9 @@ msgid ""
 "with a paging program."
 msgstr ""
 
-#: lib/output_json.c:98 lib/output_summary.c:45 lib/output_text.c:53
+#: lib/output_json.c:99 lib/output_summary.c:45 lib/output_text.c:53
 #, c-format
-msgid "error opening %s for writing"
+msgid "*** error opening %s for writing"
 msgstr ""
 
 #: lib/output_summary.c:53
@@ -3329,7 +3308,21 @@ msgstr ""
 
 #: lib/output_xunit.c:54
 #, c-format
-msgid "opening %s for writing"
+msgid "*** opening %s for writing"
+msgstr ""
+
+#: lib/parse_yaml.c:114 lib/parse_yaml.c:139
+#, c-format
+msgid "*** %s: broken document"
+msgstr ""
+
+#: lib/parse_yaml.c:158 lib/parse_yaml.c:305
+#, c-format
+msgid "*** skipping token type %s"
+msgstr ""
+
+#: lib/parse_yaml.c:386
+msgid "*** malformed type - freed?"
 msgstr ""
 
 #: lib/peers.c:176
@@ -3337,31 +3330,55 @@ msgstr ""
 msgid "There is not enough available space to unpack all of the RPMs.\n"
 msgstr ""
 
-#: lib/readelf.c:77
-msgid "libelf version mismatch"
-msgstr ""
-
-#: lib/rpm.c:68
+#: lib/readelf.c:48
 #, c-format
-msgid "Fopen failed for %s: %s"
+msgid "*** unknown elftype_t %d"
 msgstr ""
 
-#: lib/rpm.c:252
+#: lib/readelf.c:76
+msgid "*** libelf version mismatch"
+msgstr ""
+
+#: lib/readfile.c:50
+#, c-format
+msgid "*** unable to find end of %s"
+msgstr ""
+
+#: lib/readfile.c:68
+#, c-format
+msgid "*** unable to close %s"
+msgstr ""
+
+#: lib/rmtree.c:74
+#, c-format
+msgid "*** %s is not a directory"
+msgstr ""
+
+#: lib/rpm.c:71
+#, c-format
+msgid "*** Fopen failed for %s: %s"
+msgstr ""
+
+#: lib/rpm.c:255
 #, c-format
 msgid "*** file index %d is out of bounds for %s"
 msgstr ""
 
-#: lib/runcmd.c:170
+#: lib/rpm.c:431
+msgid "*** error reading file from RPM payload"
+msgstr ""
+
+#: lib/runcmd.c:171
 #, c-format
 msgid "%d"
 msgstr ""
 
-#: lib/runcmd.c:172
+#: lib/runcmd.c:173
 #, c-format
 msgid "%d (%s)"
 msgstr ""
 
-#: lib/runcmd.c:177
+#: lib/runcmd.c:178
 #, c-format
 msgid ""
 "%s\n"
@@ -3369,7 +3386,7 @@ msgid ""
 "%s tried to run the command and it received signal %s"
 msgstr ""
 
-#: lib/runcmd.c:181
+#: lib/runcmd.c:182
 #, c-format
 msgid "%s tried to run the command and it received signal %s"
 msgstr ""
@@ -3650,17 +3667,17 @@ msgstr ""
 
 #: src/rpminspect.c:168 src/rpminspect.c:179
 #, c-format
-msgid "*** Product release for after build (%s) is empty"
+msgid "*** product release for after build (%s) is empty"
 msgstr ""
 
 #: src/rpminspect.c:196 src/rpminspect.c:204
 #, c-format
-msgid "*** Product release for before build (%s) is empty"
+msgid "*** product release for before build (%s) is empty"
 msgstr ""
 
 #: src/rpminspect.c:259
 #, c-format
-msgid "*** Unable to determine product release for %s and %s"
+msgid "*** unable to determine product release for %s and %s"
 msgstr ""
 
 #: src/rpminspect.c:260
@@ -3668,39 +3685,44 @@ msgid ""
 "*** See the 'favor_release' setting in the rpminspect configuration file."
 msgstr ""
 
-#: src/rpminspect.c:289
-msgid "*** The -T and -E options are mutually exclusive"
+#: src/rpminspect.c:287
+msgid "*** the -T and -E options are mutually exclusive"
 msgstr ""
 
-#: src/rpminspect.c:290 src/rpminspect.c:306 src/rpminspect.c:736
+#: src/rpminspect.c:288 src/rpminspect.c:304 src/rpminspect.c:736
 #: src/rpminspect.c:775
 #, c-format
 msgid "*** See `%s --help` for more information."
 msgstr ""
 
-#: src/rpminspect.c:305
+#: src/rpminspect.c:303
 #, c-format
-msgid "*** Unknown inspection: `%s`"
+msgid "*** unknown inspection: `%s`"
 msgstr ""
 
-#: src/rpminspect.c:456
+#: src/rpminspect.c:454
 #, c-format
-msgid "*** Unsupported build type: `%s`."
+msgid "*** unsupported build type: `%s`."
 msgstr ""
 
-#: src/rpminspect.c:465
+#: src/rpminspect.c:463
 #, c-format
-msgid "*** Invalid build type: `%s`."
+msgid "*** invalid build type: `%s`."
 msgstr ""
 
-#: src/rpminspect.c:482
+#: src/rpminspect.c:480
 #, c-format
-msgid "*** Invalid output format: `%s`."
+msgid "*** invalid output format: `%s`."
 msgstr ""
 
-#: src/rpminspect.c:494
+#: src/rpminspect.c:492
 #, c-format
-msgid "*** Unable to expand workdir: `%s`"
+msgid "*** unable to expand working directory: `%s`"
+msgstr ""
+
+#: src/rpminspect.c:505
+#, c-format
+msgid "*** unable to use `%s' as working directory"
 msgstr ""
 
 #: src/rpminspect.c:535
@@ -3710,7 +3732,7 @@ msgstr ""
 
 #: src/rpminspect.c:538
 #, c-format
-msgid "?? getopt returned character code 0%o ??"
+msgid "*** ?? getopt returned character code 0%o ??"
 msgstr ""
 
 #: src/rpminspect.c:545
@@ -3734,12 +3756,12 @@ msgstr ""
 
 #: src/rpminspect.c:626 src/rpminspect.c:634 src/rpminspect.c:652
 #, c-format
-msgid "Failed to read configuration file %s"
+msgid "*** failed to read configuration file %s"
 msgstr ""
 
 #: src/rpminspect.c:657
 #, c-format
-msgid "Please specify a configuration file using '-c' or supply ./%s"
+msgid "*** Please specify a configuration file using '-c' or supply ./%s"
 msgstr ""
 
 #: src/rpminspect.c:735
@@ -3752,12 +3774,12 @@ msgstr ""
 
 #: src/rpminspect.c:774
 #, c-format
-msgid "*** Unsupported architecture specified: `%s`"
+msgid "*** unsupported architecture specified: `%s`"
 msgstr ""
 
 #: src/rpminspect.c:792
 #, c-format
-msgid "*** Unable to create directory %s"
+msgid "*** unable to create directory %s"
 msgstr ""
 
 #: src/rpminspect.c:850
@@ -3782,42 +3804,47 @@ msgstr ""
 msgid "Command line arguments used to invoke %s."
 msgstr ""
 
-#: src/rpminspect.c:910
-msgid "*** No peers, ensure packages exist for specified architecture(s)."
+#: src/rpminspect.c:901
+#, c-format
+msgid "Local configuration file: %s"
 msgstr ""
 
-#: src/rpminspect.c:931
+#: src/rpminspect.c:919
+msgid "*** no peers, ensure packages exist for specified architecture(s)"
+msgstr ""
+
+#: src/rpminspect.c:940
 msgid ""
-"unable to find a set of peer packages between the before and after builds"
+"*** unable to find a set of peer packages between the before and after builds"
 msgstr ""
 
-#: src/rpminspect.c:945
-msgid "*** Unable to determine product release or none specified (-r)."
+#: src/rpminspect.c:954
+msgid "*** unable to determine product release or none specified (-r)."
 msgstr ""
 
-#: src/rpminspect.c:957
+#: src/rpminspect.c:966
 #, c-format
 msgid "Skipping %s inspection..."
 msgstr ""
 
-#: src/rpminspect.c:962
+#: src/rpminspect.c:971
 msgid "skip"
 msgstr ""
 
-#: src/rpminspect.c:982
+#: src/rpminspect.c:991
 #, c-format
 msgid "Running %s inspection..."
 msgstr ""
 
-#: src/rpminspect.c:991
+#: src/rpminspect.c:1000
 msgid "pass"
 msgstr ""
 
-#: src/rpminspect.c:991
+#: src/rpminspect.c:1000
 msgid "FAIL"
 msgstr ""
 
-#: src/rpminspect.c:1019
+#: src/rpminspect.c:1028
 #, c-format
 msgid ""
 "\n"

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -165,7 +165,7 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
     }
 
     if (!after) {
-        warnx(_("*** Product release for after build (%s) is empty"), after);
+        warnx(_("*** product release for after build (%s) is empty"), after);
         return NULL;
     }
 
@@ -176,7 +176,7 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
     after_candidate = strdup(after);
 
     if (after_candidate == NULL) {
-        warnx(_("*** Product release for after build (%s) is empty"), after);
+        warnx(_("*** product release for after build (%s) is empty"), after);
         return NULL;
     }
 
@@ -193,7 +193,7 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
         }
 
         if (!before) {
-            warnx(_("*** Product release for before build (%s) is empty"), before);
+            warnx(_("*** product release for before build (%s) is empty"), before);
             free(after_candidate);
             return NULL;
         }
@@ -201,7 +201,7 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
         before_candidate = strdup(before);
 
         if (before_candidate == NULL) {
-            warnx(_("*** Product release for before build (%s) is empty"), before);
+            warnx(_("*** product release for before build (%s) is empty"), before);
             free(after_candidate);
             return NULL;
         }
@@ -256,7 +256,7 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
     }
 
     if (!matched) {
-        warnx(_("*** Unable to determine product release for %s and %s"), before, after);
+        warnx(_("*** unable to determine product release for %s and %s"), before, after);
         warnx(_("*** See the 'favor_release' setting in the rpminspect configuration file."));
         after_product = NULL;
     }
@@ -284,7 +284,7 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
 static void check_inspection_options(const bool inspection_opt)
 {
     if (inspection_opt) {
-        warnx(_("*** The -T and -E options are mutually exclusive"));
+        warnx(_("*** the -T and -E options are mutually exclusive"));
         errx(RI_PROGRAM_ERROR, _("*** See `%s --help` for more information."), COMMAND_NAME);
     }
 
@@ -300,7 +300,7 @@ static void check_found(const bool found, const char *inspection)
     assert(inspection != NULL);
 
     if (!found) {
-        warnx(_("*** Unknown inspection: `%s`"), inspection);
+        warnx(_("*** unknown inspection: `%s`"), inspection);
         errx(RI_PROGRAM_ERROR, _("*** See `%s --help` for more information."), COMMAND_NAME);
     }
 
@@ -451,7 +451,7 @@ int main(int argc, char **argv)
                 for (i = 0; buildtypes[i].type != KOJI_BUILD_NULL; i++) {
                     if (!strcasecmp(buildtypes[i].name, optarg)) {
                         if (!buildtypes[i].supported) {
-                            errx(RI_PROGRAM_ERROR, _("*** Unsupported build type: `%s`."), optarg);
+                            errx(RI_PROGRAM_ERROR, _("*** unsupported build type: `%s`."), optarg);
                         }
 
                         buildtype = buildtypes[i].type;
@@ -460,7 +460,7 @@ int main(int argc, char **argv)
                 }
 
                 if (buildtype == KOJI_BUILD_NULL) {
-                    errx(RI_PROGRAM_ERROR, _("*** Invalid build type: `%s`."), optarg);
+                    errx(RI_PROGRAM_ERROR, _("*** invalid build type: `%s`."), optarg);
                 }
 
                 break;
@@ -477,7 +477,7 @@ int main(int argc, char **argv)
                 }
 
                 if (formatidx < 0) {
-                    errx(RI_PROGRAM_ERROR, _("*** Invalid output format: `%s`."), optarg);
+                    errx(RI_PROGRAM_ERROR, _("*** invalid output format: `%s`."), optarg);
                 }
 
                 break;
@@ -489,7 +489,7 @@ int main(int argc, char **argv)
                 j = wordexp(optarg, &expand, 0);
 
                 if (j != 0 || expand.we_wordc != 1) {
-                    errx(RI_PROGRAM_ERROR, _("*** Unable to expand workdir: `%s`"), optarg);
+                    errx(RI_PROGRAM_ERROR, _("*** unable to expand working directory: `%s`"), optarg);
                 }
 
                 if (stat(expand.we_wordv[0], &sb) == 0) {
@@ -535,7 +535,7 @@ int main(int argc, char **argv)
                 printf(_("%s version %s\n"), COMMAND_NAME, PACKAGE_VERSION);
                 exit(0);
             default:
-                errx(RI_PROGRAM_ERROR, _("?? getopt returned character code 0%o ??"), c);
+                errx(RI_PROGRAM_ERROR, _("*** ?? getopt returned character code 0%o ??"), c);
         }
     }
 
@@ -623,7 +623,7 @@ int main(int argc, char **argv)
         initialized = true;
 
         if (ri == NULL) {
-            errx(RI_PROGRAM_ERROR, _("Failed to read configuration file %s"), tmp_cfgfile);
+            errx(RI_PROGRAM_ERROR, _("*** failed to read configuration file %s"), tmp_cfgfile);
         }
     } else if (cfgfile && (access(cfgfile, F_OK|R_OK) == 0)) {
         /* -c configuration file if it exists */
@@ -631,7 +631,7 @@ int main(int argc, char **argv)
         initialized = true;
 
         if (ri == NULL) {
-            errx(RI_PROGRAM_ERROR, _("Failed to read configuration file %s"), cfgfile);
+            errx(RI_PROGRAM_ERROR, _("*** failed to read configuration file %s"), cfgfile);
         }
     }
 
@@ -649,12 +649,12 @@ int main(int argc, char **argv)
         initialized = true;
 
         if (ri == NULL) {
-            errx(RI_PROGRAM_ERROR, _("Failed to read configuration file %s"), CFGFILE);
+            errx(RI_PROGRAM_ERROR, _("*** failed to read configuration file %s"), CFGFILE);
         }
     }
 
     if (!initialized) {
-        errx(RI_PROGRAM_ERROR, _("Please specify a configuration file using '-c' or supply ./%s"), CFGFILE);
+        errx(RI_PROGRAM_ERROR, _("*** Please specify a configuration file using '-c' or supply ./%s"), CFGFILE);
     }
 
     free(profile);
@@ -771,7 +771,7 @@ int main(int argc, char **argv)
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
-                warnx(_("*** Unsupported architecture specified: `%s`"), token);
+                warnx(_("*** unsupported architecture specified: `%s`"), token);
                 errx(RI_PROGRAM_ERROR, _("*** See `%s --help` for more information."), COMMAND_NAME);
             }
 
@@ -789,7 +789,7 @@ int main(int argc, char **argv)
         free_rpminspect(ri);
         rpmFreeMacros(NULL);
         rpmFreeRpmrc();
-        errx(RI_PROGRAM_ERROR, _("*** Unable to create directory %s"), ri->workdir);
+        errx(RI_PROGRAM_ERROR, _("*** unable to create directory %s"), ri->workdir);
     }
 
     /* validate and gather the builds specified */
@@ -806,7 +806,7 @@ int main(int argc, char **argv)
                 rpmFreeRpmrc();
 
                 if (j > 0) {
-                    errx(j, "%s", strexitcode(j));
+                    errx(j, "*** %s", strexitcode(j));
                 } else {
                     exit(j);
                 }
@@ -831,7 +831,7 @@ int main(int argc, char **argv)
             rpmFreeRpmrc();
 
             if (j > 0) {
-                errx(j, "%s", strexitcode(j));
+                errx(j, "*** %s", strexitcode(j));
             } else {
                 exit(j);
             }
@@ -916,7 +916,7 @@ int main(int argc, char **argv)
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
-                errx(RI_PROGRAM_ERROR, _("*** No peers, ensure packages exist for specified architecture(s)."));
+                errx(RI_PROGRAM_ERROR, _("*** no peers, ensure packages exist for specified architecture(s)"));
             }
 
             /* try to find a before and after peer */
@@ -937,7 +937,7 @@ int main(int argc, char **argv)
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
-                errx(RI_PROGRAM_ERROR, _("unable to find a set of peer packages between the before and after builds"));
+                errx(RI_PROGRAM_ERROR, _("*** unable to find a set of peer packages between the before and after builds"));
             }
 
             /* get the product release */
@@ -951,7 +951,7 @@ int main(int argc, char **argv)
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
-                errx(RI_PROGRAM_ERROR, _("*** Unable to determine product release or none specified (-r)."));
+                errx(RI_PROGRAM_ERROR, _("*** unable to determine product release or none specified (-r)."));
             }
         }
 


### PR DESCRIPTION
These were sort of all over the place and I have tried to make them appear a bit more consistent and I corrected a few that had minor mistakes in them or used 'x' variants of err or warn where there would be no errno -or- we don't care about the errno at that moment.  Likely more to do here, but that's housekeeping.