### PR TITLE
[ci] Account for dnf5 presence in Fedora rawhide

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -112,7 +112,16 @@ jobs:
             # Set up
             - name: git clone requirements
               run: |
-                  dnf install -y git
+                  . /etc/os-release
+
+                  if [ "${REDHAT_BUGZILLA_PRODUCT_VERSION}" = "rawhide" ] || [ "${REDHAT_SUPPORT_PRODUCT_VERSION}" = "rawhide" ]; then
+                      rm -f /etc/dnf/dnf.conf
+                      dnf install -y dnf5
+                      dnf5 install -y git
+                  else
+                      dnf install -y git
+                  fi
+
                   git config --global --add safe.directory /__w/rpminspect/rpminspect
 
             # This means clone the git repo
@@ -122,8 +131,16 @@ jobs:
             # and run the test suite
             - name: Build and run the test suite
               run: |
-                  dnf remove -y fedora-repos-modular
-                  dnf install -y make
+                  . /etc/os-release
+
+                  if [ "${REDHAT_BUGZILLA_PRODUCT_VERSION}" = "rawhide" ] || [ "${REDHAT_SUPPORT_PRODUCT_VERSION}" = "rawhide" ]; then
+                      dnf5 remove -y fedora-repos-modular
+                      dnf5 install -y make
+                  else
+                      dnf remove -y fedora-repos-modular
+                      dnf install -y make
+                  fi
+
                   make instreqs OSDEPS_ARCH=i686
                   env CFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig make debug
                   make check

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -61,7 +61,16 @@ jobs:
             # Set up
             - name: git clone requirements
               run: |
-                  dnf install -y git
+                  . /etc/os-release
+
+                  if [ "${REDHAT_BUGZILLA_PRODUCT_VERSION}" = "rawhide" ] || [ "${REDHAT_SUPPORT_PRODUCT_VERSION}" = "rawhide" ]; then
+                      rm -f /etc/dnf/dnf.conf
+                      dnf install -y dnf5
+                      dnf5 install -y git
+                  else
+                      dnf install -y git
+                  fi
+
                   git config --global --add safe.directory /__w/rpminspect/rpminspect
 
             # This means clone the git repo
@@ -71,7 +80,14 @@ jobs:
             # and run the test suite
             - name: Build and run the test suite
               run: |
-                  dnf install -y make
+                  . /etc/os-release
+
+                  if [ "${REDHAT_BUGZILLA_PRODUCT_VERSION}" = "rawhide" ] || [ "${REDHAT_SUPPORT_PRODUCT_VERSION}" = "rawhide" ]; then
+                      dnf5 install -y make
+                  else
+                      dnf install -y make
+                  fi
+
                   make instreqs
                   make debug
                   make check

--- a/osdeps/fedora-rawhide.i686/defs.mk
+++ b/osdeps/fedora-rawhide.i686/defs.mk
@@ -1,2 +1,2 @@
-PKG_CMD = dnf install -y
+PKG_CMD = dnf5 install -y
 PIP_CMD = pip-3 install

--- a/osdeps/fedora-rawhide.i686/post.sh
+++ b/osdeps/fedora-rawhide.i686/post.sh
@@ -4,10 +4,10 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 # Install 32-bit development files on 64-bit systems when available
 case "$(uname -m)" in
     x86_64)
-        dnf install -y glibc-devel.i686 glibc.i686 libgcc.i686 glibc-headers-x86
+        dnf5 install -y glibc-devel.i686 glibc.i686 libgcc.i686 glibc-headers-x86
         ;;
     s390x)
-        dnf install -y glibc-headers-s390
+        dnf5 install -y glibc-headers-s390
         ;;
 esac
 

--- a/osdeps/fedora-rawhide/defs.mk
+++ b/osdeps/fedora-rawhide/defs.mk
@@ -1,2 +1,2 @@
-PKG_CMD = dnf install -y
+PKG_CMD = dnf5 install -y
 PIP_CMD = pip-3 install

--- a/osdeps/fedora-rawhide/post.sh
+++ b/osdeps/fedora-rawhide/post.sh
@@ -4,10 +4,10 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 # Install 32-bit development files on 64-bit systems when available
 case "$(uname -m)" in
     x86_64)
-        dnf install -y glibc-devel.i686 glibc.i686 libgcc.i686 glibc-headers-x86
+        dnf5 install -y glibc-devel.i686 glibc.i686 libgcc.i686 glibc-headers-x86
         ;;
     s390x)
-        dnf install -y glibc-headers-s390
+        dnf5 install -y glibc-headers-s390
         ;;
 esac
 


### PR DESCRIPTION
Our GitHub Action for Fedora rawhide builds needs to account for dnf5 presence.  Use that if we find it.  Currently the Fedora rawhide Docker images carry an unusable /etc/dnf/dnf.conf file that we have to remove to get dnf doing anything.