### PR TITLE
[cmd] Add build NVRs to the diagnostics output section

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -905,6 +905,23 @@ int main(int argc, char **argv)
         free(params.details);
     }
 
+    /* add the builds */
+    if (ri->before != NULL) {
+        /* before build */
+        params.msg = _("Before Build");
+        params.details = ri->before;
+        add_result_entry(&ri->results, &params);
+
+        /* after build */
+        params.msg = _("After Build");
+    } else {
+        /* only have single build */
+        params.msg = _("Build");
+    }
+
+    params.details = ri->after;
+    add_result_entry(&ri->results, &params);
+
     /* make sure the worst result is set before running inspections */
     ri->worst_result = params.severity;
 


### PR DESCRIPTION
This just adds one or two more results to the diagnostics section.  If only one build was given on the command line, there will be a diagnostics result that looks like this in JSON:

    {
      "result": "DIAGNOSTICS",
      "message": "Build",
      "details": "NAME-VERSION-RELEASE"
    }

If there are two build specified, you will see two entries in the diagnostics section like this:

    {
      "result": "DIAGNOSTICS",
      "message": "Before Build",
      "details": "NAME-VERSION-RELEASE"
    },
    {
      "result": "DIAGNOSTICS",
      "message": "After Build",
      "details": "NAME-VERSION-RELEASE"
    }

Fixes: #982