### PR TITLE
[fix] Correct two list_free() calls; missing third argument

### DIFF
--- a/lib/diags.c
+++ b/lib/diags.c
@@ -263,7 +263,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strdup(entry->data);
-    list_free(details, free);
+    list_free(details, free, true);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);

--- a/lib/free.c
+++ b/lib/free.c
@@ -271,7 +271,7 @@ void free_rpminspect(struct rpminspect *ri)
     list_free(ri->unicode_forbidden_codepoints, free, true);
     free_deprule_ignore_map(ri->deprules_ignore);
     free(ri->debuginfo_sections);
-    list_free(ri->udev_rules_dirs, free);
+    list_free(ri->udev_rules_dirs, free, true);
 
     free_peers(ri->peers);
 


### PR DESCRIPTION
This came in through the udevrules PR and CI was broken because of the rawhide change with dnf5 and I just merged everything anyway, but it needed two list_free() call updates.