### PR TITLE
[lib] Use BUFSIZ for archive_read_open_filename()

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -232,7 +232,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
     /* Open the file with libarchive */
     archive = new_archive_reader();
 
-    if (archive_read_open_filename(archive, pkg, 10240) != ARCHIVE_OK) {
+    if (archive_read_open_filename(archive, pkg, BUFSIZ) != ARCHIVE_OK) {
         /* maybe the payload has large files, so try to convert */
         payload = extract_rpm_payload(pkg);
 
@@ -244,9 +244,9 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         archive_read_free(archive);
         archive = new_archive_reader();
 
-        if (archive_read_open_filename(archive, payload, 10240) != ARCHIVE_OK) {
+        if (archive_read_open_filename(archive, payload, BUFSIZ) != ARCHIVE_OK) {
             /* still bad, so bail */
-            warnx("*** archive_read_open_filename: %s", archive_error_string(archive));
+            warnx("*** archive_read_open_filename(%s): %s", pkg, archive_error_string(archive));
             goto cleanup;
         }
     }

--- a/lib/uncompress.c
+++ b/lib/uncompress.c
@@ -172,7 +172,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     archive_read_support_format_empty(input);
 
     /* open the input file, decompress, and write to output */
-    r = archive_read_open_filename(input, infile, 16384);
+    r = archive_read_open_filename(input, infile, BUFSIZ);
 
     if (r != ARCHIVE_OK) {
         /* just stop trying to uncompress if this errors */

--- a/lib/unpack.c
+++ b/lib/unpack.c
@@ -141,10 +141,9 @@ int unpack_archive(const char *archive, const char *dest, const bool force)
     archive_read_support_filter_all(input);
 #endif
     archive_read_support_format_all(input);
-    r = archive_read_open_filename(input, archive, 16384);
+    r = archive_read_open_filename(input, archive, BUFSIZ);
 
     if (r != ARCHIVE_OK) {
-        warnx("*** archive_read_open_filename: %s", archive_error_string(input));
         archive_read_free(input);
         return -1;
     }


### PR DESCRIPTION
Use BUFSIZ for the block size argument for
archive_read_open_filename().  At one point they recommended 10240 and then 16384.  librpminspect had both, so I just changed this to BUFSIZ and will leave it at that unless someone wants to convince me otherwise.

I also dropped a warnx() call in unpack_archive().  If unpack_archive() can't open an archive, it just returns -1.  The warnx() call is unnecessary since the intent here is to return a failure code when the function receives a non-archive.