### PR TITLE
Restructure MIME handling and prevent crashes in 'changedfiles'

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -296,9 +296,9 @@ void output_summary(const results_t *results, const char *dest, const severity_t
 int unpack_archive(const char *, const char *, const bool);
 
 /* magic.c */
-char *mime_type(const char *);
-char *get_mime_type(rpmfile_entry_t *);
-bool is_text_file(rpmfile_entry_t *);
+const char *mime_type(struct rpminspect *, const char *);
+const char *get_mime_type(struct rpminspect *, rpmfile_entry_t *);
+bool is_text_file(struct rpminspect *, rpmfile_entry_t *);
 
 /* checksums.c */
 char *compute_checksum(const char *, mode_t *, int);

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -263,7 +263,7 @@ int extract_peers(struct rpminspect *ri, bool fetchonly);
 void free_files(rpmfile_t *files);
 rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const char *subdir, char **output_dir);
 bool process_file_path(const rpmfile_entry_t *file, regex_t *include_regex, regex_t *exclude_regex);
-void find_file_peers(rpmfile_t *before, rpmfile_t *after);
+void find_file_peers(struct rpminspect *ri, rpmfile_t *before, rpmfile_t *after);
 bool is_debug_or_build_path(const char *path);
 
 /* tty.c */

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -140,7 +140,7 @@ string_list_t * list_intersection(const string_list_t *, const string_list_t *);
 string_list_t * list_union(const string_list_t *, const string_list_t *);
 string_list_t * list_symmetric_difference(const string_list_t *, const string_list_t *);
 typedef void (*list_entry_data_free_func)(void *);
-void list_free(string_list_t *, list_entry_data_free_func, const bool);
+void list_free(string_list_t *, list_entry_data_free_func);
 size_t list_len(const string_list_t *);
 string_list_t * list_sort(const string_list_t *);
 string_list_t * list_copy(const string_list_t *);

--- a/include/types.h
+++ b/include/types.h
@@ -14,6 +14,7 @@
 #include <rpm/rpmlib.h>
 #include <rpm/rpmfi.h>
 #include <unicode/utypes.h>
+#include <magic.h>
 
 #ifdef _WITH_LIBKMOD
 #ifdef _LIBKMOD_HEADER_SUBDIR
@@ -737,6 +738,11 @@ struct rpminspect {
 
     /* spec file macros */
     pair_list_t *macros;
+
+    /* MIME type stuff from libmagic */
+    magic_t magic_cookie;
+    bool magic_initialized;
+    string_hash_t *magic_types;
 
     /* inspection results */
     results_t *results;

--- a/include/types.h
+++ b/include/types.h
@@ -399,6 +399,12 @@ typedef struct _string_map_t {
     UT_hash_handle hh;
 } string_map_t;
 
+/* Hash table which is just a list of strings; think of it as a set */
+typedef struct _string_hash_t {
+    char *data;
+    UT_hash_handle hh;
+} string_hash_t;
+
 /* Hash table with a string key and a string_list_t value. */
 typedef struct _string_list_map_t {
     char *key;

--- a/lib/abi.c
+++ b/lib/abi.c
@@ -152,9 +152,10 @@ void free_abi(abi_t *table)
     }
 
     HASH_ITER(hh, table, entry, tmp_entry) {
-        free(entry->pkg);
-        list_free(entry->dsos, free);
         HASH_DEL(table, entry);
+        list_free(entry->dsos, free);
+        free(entry->pkg);
+        free(entry);
     }
 
     free(table);

--- a/lib/abi.c
+++ b/lib/abi.c
@@ -82,7 +82,7 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
 
             if (list_len(linekv) != 2) {
                 warn(_("*** malformed ABI level entry: %s"), line->data);
-                list_free(linekv, free, true);
+                list_free(linekv, free);
                 continue;
             }
 
@@ -94,7 +94,7 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
 
             if (dsos == NULL) {
                 warnx("*** malformed DSO list: %s", dso->data);
-                list_free(linekv, free, true);
+                list_free(linekv, free);
                 continue;
             }
 
@@ -127,14 +127,14 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
             }
 
             /* clean up */
-            list_free(linekv, free, true);
-            list_free(dsos, free, true);
+            list_free(linekv, free);
+            list_free(dsos, free);
             entry = NULL;          /* for the next loop iteration */
         }
     }
 
     /* clean up */
-    list_free(contents, free, true);
+    list_free(contents, free);
 
     return r;
 }
@@ -153,7 +153,7 @@ void free_abi(abi_t *table)
 
     HASH_ITER(hh, table, entry, tmp_entry) {
         free(entry->pkg);
-        list_free(entry->dsos, free, false);
+        list_free(entry->dsos, free);
         HASH_DEL(table, entry);
     }
 

--- a/lib/abspath.c
+++ b/lib/abspath.c
@@ -69,8 +69,8 @@ char *abspath(const char *path)
     }
 
     /* clean up */
-    list_free(tokens, free, true);
-    list_free(newpath, free, true);
+    list_free(tokens, free);
+    list_free(newpath, free);
     free(p);
 
     return r;

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -474,7 +474,7 @@ static int download_build(struct rpminspect *ri, const struct koji_build *build)
             free(pkg);
         }
 
-        list_free(filter, free, true);
+        list_free(filter, free);
         filter = NULL;
     }
 

--- a/lib/checksums.c
+++ b/lib/checksums.c
@@ -176,7 +176,7 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
     }
 
     /* this is our human readable digest, caller must free */
-    ret = calloc(len + 1, sizeof(buf));
+    ret = calloc(len + 1, sizeof(char *));
 
     if (ret == NULL) {
         warn("*** calloc");

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -82,6 +82,7 @@ static int delta_out(void *priv, mmbuffer_t *mb, int nbuf)
 {
     int i = 0;
     char *prefix = NULL;
+    char *end = NULL;
     string_list_t *list = (string_list_t *) priv;
     string_entry_t *entry = NULL;
 
@@ -109,10 +110,15 @@ static int delta_out(void *priv, mmbuffer_t *mb, int nbuf)
 
         if ((mb[i].size > 1) && mb[i].ptr != NULL) {
             if (prefix) {
-                xasprintf(&entry->data, "%s%s", prefix, mb[i].ptr);
+                entry->data = calloc(1, strlen(prefix) + mb[i].size + 1);
+                assert(entry->data != NULL);
+
+                end = stpcpy(entry->data, prefix);
+                end = strncpy(end, mb[i].ptr, mb[i].size);
             } else {
                 entry->data = calloc(1, mb[i].size + 1);
                 assert(entry->data != NULL);
+
                 entry->data = strncpy(entry->data, mb[i].ptr, mb[i].size);
             }
         } else {

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -176,7 +176,7 @@ char *get_file_delta(const char *a, const char *b)
     }
 
     r = list_to_string(list, "\n");
-    list_free(list, free, true);
+    list_free(list, free);
     free(old.ptr);
     free(new.ptr);
 

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -150,8 +150,14 @@ char *get_file_delta(const char *a, const char *b)
     string_list_t *list = NULL;
     char *r = NULL;
 
-    if (fill_mmfile(&old, a) < 0 || fill_mmfile(&new, b) < 0) {
+    if (fill_mmfile(&old, a) < 0) {
         warn("*** fill_mmfile");
+        return NULL;
+    }
+
+    if (fill_mmfile(&new, b) < 0) {
+        warn("*** fill_mmfile");
+        free(old.ptr);
         return NULL;
     }
 
@@ -172,13 +178,6 @@ char *get_file_delta(const char *a, const char *b)
 
     if (xdl_diff(&old, &new, &xpp, &xecfg, &ecb) < 0) {
         warn("*** xdl_diff");
-    }
-
-    if (TAILQ_EMPTY(list)) {
-        free(old.ptr);
-        free(new.ptr);
-        free(list);
-        return NULL;
     }
 
     r = list_to_string(list, "\n");

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -115,7 +115,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(entry);
 
     tmp = list_to_string(details, " ");                     /* rejoin remaining details */
-    list_free(details, free, true);
+    list_free(details, free);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -138,7 +138,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     free(entry);
 
     tmp = list_to_string(details, " ");
-    list_free(details, free, true);
+    list_free(details, free);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -197,7 +197,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strdup(entry->data);
-    list_free(details, free, true);
+    list_free(details, free);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -214,7 +214,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strreplace(entry->data, ": Version ", " version ");
-    list_free(details, free, true);
+    list_free(details, free);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -231,7 +231,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strreplace(entry->data, ": ", " version ");
-    list_free(details, free, true);
+    list_free(details, free);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -247,7 +247,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strreplace(entry->data, ": ", " version ");
-    list_free(details, free, true);
+    list_free(details, free);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);
@@ -263,7 +263,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     entry = TAILQ_FIRST(details);
     ver = strdup(entry->data);
-    list_free(details, free, true);
+    list_free(details, free);
 
     entry = calloc(1, sizeof(*entry));
     assert(entry != NULL);

--- a/lib/files.c
+++ b/lib/files.c
@@ -359,8 +359,9 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
 
 cleanup:
     HASH_ITER(hh, path_table, path_entry, tmp_entry) {
-        free(path_entry->path);
         HASH_DEL(path_table, path_entry);
+        free(path_entry->path);
+        free(path_entry);
     }
 
     if (archive != NULL) {
@@ -816,6 +817,7 @@ void find_file_peers(rpmfile_t *before, rpmfile_t *after)
     /* Clean up the hash table */
     HASH_ITER(hh, after_table, entry, tmp_entry) {
         HASH_DEL(after_table, entry);
+        free(entry);
     }
 
     return;

--- a/lib/free.c
+++ b/lib/free.c
@@ -8,6 +8,24 @@
 #include "queue.h"
 #include "rpminspect.h"
 
+static void free_string_hash(string_hash_t *hash)
+{
+    string_hash_t *entry = NULL;
+    string_hash_t *tmp_entry = NULL;
+
+    if (hash == NULL) {
+        return;
+    }
+
+    HASH_ITER(hh, hash, entry, tmp_entry) {
+        HASH_DEL(hash, entry);
+        free(entry->data);
+        free(entry);
+    }
+
+    return;
+}
+
 static void free_string_list_map(string_list_map_t *table)
 {
     string_list_map_t *entry = NULL;

--- a/lib/free.c
+++ b/lib/free.c
@@ -18,9 +18,10 @@ static void free_string_list_map(string_list_map_t *table)
     }
 
     HASH_ITER(hh, table, entry, tmp_entry) {
+        HASH_DEL(table, entry);
         free(entry->key);
         list_free(entry->value, free);
-        HASH_DEL(table, entry);
+        free(entry);
     }
 
     return;
@@ -65,9 +66,10 @@ void free_string_map(string_map_t *table)
     }
 
     HASH_ITER(hh, table, entry, tmp_entry) {
+        HASH_DEL(table, entry);
         free(entry->key);
         free(entry->value);
-        HASH_DEL(table, entry);
+        free(entry);
     }
 
     return;
@@ -182,6 +184,7 @@ void free_rpminspect(struct rpminspect *ri)
             if (sentry->rules) {
                 HASH_ITER(hh, sentry->rules, srentry, tmp_srentry) {
                     HASH_DEL(sentry->rules, srentry);
+                    free(srentry);
                 }
             }
 
@@ -276,9 +279,10 @@ void free_rpminspect(struct rpminspect *ri)
     free_peers(ri->peers);
 
     HASH_ITER(hh, ri->header_cache, hentry, tmp_hentry) {
+        HASH_DEL(ri->header_cache, hentry);
         free(hentry->pkg);
         headerFree(hentry->hdr);
-        HASH_DEL(ri->header_cache, hentry);
+        free(hentry);
     }
 
     free(ri->before_rel);

--- a/lib/free.c
+++ b/lib/free.c
@@ -19,7 +19,7 @@ static void free_string_list_map(string_list_map_t *table)
 
     HASH_ITER(hh, table, entry, tmp_entry) {
         free(entry->key);
-        list_free(entry->value, free, false);
+        list_free(entry->value, free);
         HASH_DEL(table, entry);
     }
 
@@ -94,9 +94,9 @@ void free_rpminspect(struct rpminspect *ri)
     }
 
     free(ri->progname);
-    list_free(ri->cfgfiles, free, true);
+    list_free(ri->cfgfiles, free);
     free(ri->localcfg);
-    list_free(ri->locallines, free, true);
+    list_free(ri->locallines, free);
     free(ri->workdir);
     free(ri->kojihub);
     free(ri->kojiursine);
@@ -104,7 +104,7 @@ void free_rpminspect(struct rpminspect *ri)
     free(ri->worksubdir);
 
     free(ri->vendor_data_dir);
-    list_free(ri->licensedb, free, true);
+    list_free(ri->licensedb, free);
 
     if (ri->fileinfo) {
         while (!TAILQ_EMPTY(ri->fileinfo)) {
@@ -151,7 +151,7 @@ void free_rpminspect(struct rpminspect *ri)
     }
 
     free(ri->caps_filename);
-    list_free(ri->rebaseable, free, true);
+    list_free(ri->rebaseable, free);
     free(ri->rebaseable_filename);
 
     if (ri->politics) {
@@ -192,8 +192,8 @@ void free_rpminspect(struct rpminspect *ri)
     }
 
     free(ri->security_filename);
-    list_free(ri->badwords, free, true);
-    list_free(ri->icons, free, true);
+    list_free(ri->badwords, free);
+    list_free(ri->icons, free);
     free(ri->icons_filename);
 
     free_regex(ri->elf_path_include);
@@ -205,8 +205,8 @@ void free_rpminspect(struct rpminspect *ri)
 
     free(ri->elf_path_include_pattern);
     free(ri->elf_path_exclude_pattern);
-    list_free(ri->automacros, free, true);
-    list_free(ri->bad_functions, free, true);
+    list_free(ri->automacros, free);
+    list_free(ri->bad_functions, free);
     free_string_list_map(ri->bad_functions_allowed);
     free(ri->manpage_path_include_pattern);
     free(ri->manpage_path_exclude_pattern);
@@ -225,53 +225,53 @@ void free_rpminspect(struct rpminspect *ri)
 #endif
     free(ri->commands.udevadm);
 
-    list_free(ri->buildhost_subdomain, free, true);
-    list_free(ri->macrofiles, free, true);
-    list_free(ri->security_path_prefix, free, true);
-    list_free(ri->header_file_extensions, free, true);
-    list_free(ri->forbidden_path_prefixes, free, true);
-    list_free(ri->forbidden_path_suffixes, free, true);
-    list_free(ri->forbidden_directories, free, true);
+    list_free(ri->buildhost_subdomain, free);
+    list_free(ri->macrofiles, free);
+    list_free(ri->security_path_prefix, free);
+    list_free(ri->header_file_extensions, free);
+    list_free(ri->forbidden_path_prefixes, free);
+    list_free(ri->forbidden_path_suffixes, free);
+    list_free(ri->forbidden_directories, free);
     free(ri->before);
     free(ri->after);
     free(ri->product_release);
-    list_free(ri->arches, free, true);
-    list_free(ri->bin_paths, free, true);
+    list_free(ri->arches, free);
+    list_free(ri->bin_paths, free);
     free(ri->bin_owner);
     free(ri->bin_group);
-    list_free(ri->forbidden_owners, free, true);
-    list_free(ri->forbidden_groups, free, true);
-    list_free(ri->shells, free, true);
+    list_free(ri->forbidden_owners, free);
+    list_free(ri->forbidden_groups, free);
+    list_free(ri->shells, free);
     free_string_map(ri->jvm);
     free_string_map(ri->annocheck);
     free(ri->annocheck_profile);
     free_string_map(ri->pathmigration);
-    list_free(ri->pathmigration_excluded_paths, free, true);
+    list_free(ri->pathmigration_excluded_paths, free);
     free_string_map(ri->products);
-    list_free(ri->ignores, free, true);
-    list_free(ri->lto_symbol_name_prefixes, free, true);
-    list_free(ri->forbidden_paths, free, true);
+    list_free(ri->ignores, free);
+    list_free(ri->lto_symbol_name_prefixes, free);
+    list_free(ri->forbidden_paths, free);
     free(ri->abidiff_suppression_file);
     free(ri->abidiff_debuginfo_path);
     free(ri->abidiff_extra_args);
     free(ri->kmidiff_suppression_file);
     free(ri->kmidiff_debuginfo_path);
     free(ri->kmidiff_extra_args);
-    list_free(ri->kernel_filenames, free, true);
+    list_free(ri->kernel_filenames, free);
     free(ri->kabi_dir);
     free(ri->kabi_filename);
-    list_free(ri->patch_ignore_list, free, true);
-    list_free(ri->runpath_allowed_paths, free, true);
-    list_free(ri->runpath_allowed_origin_paths, free, true);
-    list_free(ri->runpath_origin_prefix_trim, free, true);
+    list_free(ri->patch_ignore_list, free);
+    list_free(ri->runpath_allowed_paths, free);
+    list_free(ri->runpath_allowed_origin_paths, free);
+    list_free(ri->runpath_origin_prefix_trim, free);
     free_string_list_map(ri->inspection_ignores);
-    list_free(ri->expected_empty_rpms, free, true);
+    list_free(ri->expected_empty_rpms, free);
     free_regex(ri->unicode_exclude);
-    list_free(ri->unicode_excluded_mime_types, free, true);
-    list_free(ri->unicode_forbidden_codepoints, free, true);
+    list_free(ri->unicode_excluded_mime_types, free);
+    list_free(ri->unicode_forbidden_codepoints, free);
     free_deprule_ignore_map(ri->deprules_ignore);
     free(ri->debuginfo_sections);
-    list_free(ri->udev_rules_dirs, free, true);
+    list_free(ri->udev_rules_dirs, free);
 
     free_peers(ri->peers);
 
@@ -306,7 +306,7 @@ void free_deprules(deprule_list_t *list)
         TAILQ_REMOVE(list, entry, items);
         free(entry->requirement);
         free(entry->version);
-        list_free(entry->providers, free, true);
+        list_free(entry->providers, free);
         free(entry);
     }
 

--- a/lib/free.c
+++ b/lib/free.c
@@ -307,6 +307,12 @@ void free_rpminspect(struct rpminspect *ri)
     free(ri->after_rel);
     free_pair(ri->macros);
 
+    if (ri->magic_cookie) {
+        magic_close(ri->magic_cookie);
+    }
+
+    free_string_hash(ri->magic_types);
+
     free_results(ri->results);
 
     return;

--- a/lib/init.c
+++ b/lib/init.c
@@ -198,7 +198,7 @@ static void process_table(const char *key, const char *value, const bool require
             tokens = list_add(tokens, value);
 
             tmp = list_to_string(tokens, " ");
-            list_free(tokens, free, true);
+            list_free(tokens, free);
         } else {
             tmp = strdup(value);
         }
@@ -992,7 +992,7 @@ bool init_fileinfo(struct rpminspect *ri)
         field = MODE;
     }
 
-    list_free(contents, free, true);
+    list_free(contents, free);
 
     return true;
 }
@@ -1132,7 +1132,7 @@ bool init_caps(struct rpminspect *ri)
         field = PACKAGE;
     }
 
-    list_free(contents, free, true);
+    list_free(contents, free);
 
     return true;
 }
@@ -1194,7 +1194,7 @@ bool init_rebaseable(struct rpminspect *ri)
         ri->rebaseable = list_add(ri->rebaseable, line);
     }
 
-    list_free(contents, free, true);
+    list_free(contents, free);
 
     return true;
 }
@@ -1294,7 +1294,7 @@ bool init_politics(struct rpminspect *ri)
         field = PATTERN;
     }
 
-    list_free(contents, free, true);
+    list_free(contents, free);
 
     return true;
 }
@@ -1412,7 +1412,7 @@ bool init_security(struct rpminspect *ri)
                 /* we must have a rule and action */
                 if (list_len(kv) != 2) {
                     warnx(_("*** invalid security rule: %s"), rentry->data);
-                    list_free(kv, free, true);
+                    list_free(kv, free);
                     continue;
                 }
 
@@ -1424,7 +1424,7 @@ bool init_security(struct rpminspect *ri)
 
                 if (stype == SECRULE_NULL) {
                     warnx(_("*** unknown security rule: %s"), key->data);
-                    list_free(kv, free, true);
+                    list_free(kv, free);
                     continue;
                 }
 
@@ -1433,7 +1433,7 @@ bool init_security(struct rpminspect *ri)
 
                 if (severity == RESULT_NULL) {
                     warnx(_("*** unknown security action: %s"), value->data);
-                    list_free(kv, free, true);
+                    list_free(kv, free);
                     continue;
                 }
 
@@ -1452,7 +1452,7 @@ bool init_security(struct rpminspect *ri)
                 }
 
                 /* clean up */
-                list_free(kv, free, true);
+                list_free(kv, free);
             }
 
             /* add new entry to the security rules list */
@@ -1465,11 +1465,11 @@ bool init_security(struct rpminspect *ri)
         free(pkg);
         free(ver);
         free(rel);
-        list_free(rules, free, true);
+        list_free(rules, free);
         pos = 0;
     }
 
-    list_free(contents, free, true);
+    list_free(contents, free);
     free(path);
 
     return true;
@@ -1528,7 +1528,7 @@ bool init_icons(struct rpminspect *ri)
         ri->icons = list_add(ri->icons, line);
     }
 
-    list_free(contents, free, true);
+    list_free(contents, free);
 
     return true;
 }

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -355,7 +355,7 @@ bool inspect_abidiff(struct rpminspect *ri)
     /* clean up */
     free_abi(abi);
     free(cmdprefix);
-    list_free(suppressions, free, true);
+    list_free(suppressions, free);
     free_pair(before_headers);
     free_pair(after_headers);
 

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -258,7 +258,7 @@ static struct libannocheck_internals *libannocheck_setup(struct rpminspect *ri, 
                     }
                 }
 
-                list_free(args, free, true);
+                list_free(args, free);
             }
         } else {
             annoerr = libannocheck_enable_all_tests(anno);
@@ -512,7 +512,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
             free(params.details);
             free(params.msg);
-            list_free(details, free, true);
+            list_free(details, free);
         }
     }
 
@@ -626,7 +626,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 }
             }
 
-            list_free(slist, free, true);
+            list_free(slist, free);
         }
 
         /* Cleanup */

--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -102,10 +102,10 @@ bool inspect_arch(struct rpminspect *ri)
         result = false;
     }
 
-    list_free(lost, free, true);
-    list_free(gain, free, true);
-    list_free(before_arches, free, true);
-    list_free(after_arches, free, true);
+    list_free(lost, free);
+    list_free(gain, free);
+    list_free(before_arches, free);
+    list_free(after_arches, free);
 
     return result;
 }

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -180,9 +180,9 @@ static bool badfuncs_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     free(output_buffer);
 
 cleanup:
-    list_free(after_symbols, free, true);
-    list_free(used_symbols, free, true);
-    list_free(sorted_used, free, true);
+    list_free(after_symbols, free);
+    list_free(used_symbols, free);
+    list_free(sorted_used, free);
 
     if (after_elf) {
         elf_end(after_elf);

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -311,8 +311,8 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
         }
     }
 
-    list_free(before_changelog, free, true);
-    list_free(after_changelog, free, true);
+    list_free(before_changelog, free);
+    list_free(after_changelog, free);
     free(before_nevr);
     free(after_nevr);
     free(before_output);
@@ -411,8 +411,8 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     free(before_output);
     free(after_output);
-    list_free(before_changelog, free, true);
-    list_free(after_changelog, free, true);
+    list_free(before_changelog, free);
+    list_free(after_changelog, free);
     free(before_nevr);
     free(after_nevr);
 

--- a/lib/inspect_debuginfo.c
+++ b/lib/inspect_debuginfo.c
@@ -43,7 +43,7 @@ static uint64_t get_flags(const char *s)
         }
     }
 
-    list_free(sections, free, true);
+    list_free(sections, free);
     return r;
 }
 
@@ -111,7 +111,7 @@ static char *strflags(const uint64_t flags)
     }
 
     r = list_to_string(list, " ");
-    list_free(list, free, true);
+    list_free(list, free);
     return r;
 }
 
@@ -151,7 +151,7 @@ static bool is_guile(const char *path)
         }
     }
 
-    list_free(sections, free, true);
+    list_free(sections, free);
     return r;
 }
 

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -81,7 +81,7 @@ static int find_file(const char *fpath, __attribute__((unused)) const struct sta
                 if (strsuffix(fpath, tmp)) {
                     free(file_to_find);
                     file_to_find = strdup(fpath);
-                    list_free(list, free, true);
+                    list_free(list, free);
                     free(tmp);
                     return 1;
                 }
@@ -90,7 +90,7 @@ static int find_file(const char *fpath, __attribute__((unused)) const struct sta
             }
         }
 
-        list_free(list, free, true);
+        list_free(list, free);
     }
 
     /* Might be a base name missing a graphics format ending */
@@ -265,7 +265,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
 
                 if (lstat(file_to_find, &sb) == -1) {
                     warn("*** lstat");
-                    list_free(contents, free, true);
+                    list_free(contents, free);
                     free(file_to_find);
                     return false;
                 }
@@ -344,7 +344,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
 
                 if (lstat(file_to_find, &sb) == -1) {
                     warn("*** lstat");
-                    list_free(contents, free, true);
+                    list_free(contents, free);
                     free(file_to_find);
                     return false;
                 }
@@ -385,7 +385,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
         free(file_to_find);
     }
 
-    list_free(contents, free, true);
+    list_free(contents, free);
 
     return result;
 }

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -17,6 +17,7 @@
 #include "rpminspect.h"
 
 /* Global variables */
+static struct rpminspect *sri = NULL;
 static char *file_to_find = NULL;
 static filetype_t filetype = FILETYPE_NULL;
 
@@ -105,7 +106,7 @@ static int find_file(const char *fpath, __attribute__((unused)) const struct sta
      * will pass.
      */
     if (filetype == FILETYPE_ICON) {
-        if (strsuffix(fpath, file_to_find) && strprefix(mime_type(fpath), "image/")) {
+        if (strsuffix(fpath, file_to_find) && strprefix(mime_type(sri, fpath), "image/")) {
             /* file is found and is an image type according to libmagic */
             free(file_to_find);
             file_to_find = strdup(fpath);
@@ -398,6 +399,9 @@ static bool desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     const char *arch = NULL;
     char *tmpbuf = NULL;
     struct result_params params;
+
+    /* allow static callback functions to see ri */
+    sri = ri;
 
     /*
      * Is this a file we should look at?

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -74,7 +74,7 @@ static bool check_release_macros(const int macrocount, const pair_list_t *macros
     if (tag_macros == NULL) {
         return false;
     } else if (TAILQ_EMPTY(tag_macros)) {
-        list_free(tag_macros, free, true);
+        list_free(tag_macros, free);
         return false;
     }
 
@@ -112,7 +112,7 @@ static bool check_release_macros(const int macrocount, const pair_list_t *macros
     }
 
     /* clean up */
-    list_free(tag_macros, free, true);
+    list_free(tag_macros, free);
 
     return ret;
 }
@@ -198,7 +198,7 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     free(expanded_release);
     free(params.msg);
-    list_free(contents, free, true);
+    list_free(contents, free);
     return result;
 }
 

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -99,7 +99,7 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             }
 
             /* only add the diff output for text content */
-            if (strprefix(get_mime_type(file->peer_file), "text/") && strprefix(get_mime_type(file), "text/")) {
+            if (strprefix(get_mime_type(ri, file->peer_file), "text/") && strprefix(get_mime_type(ri, file), "text/")) {
                 params.details = diff_output;
             }
 

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -189,8 +189,8 @@ done:
 
     free(removed);
     free(added);
-    list_free(before_needed, free, true);
-    list_free(after_needed, free, true);
+    list_free(before_needed, free);
+    list_free(after_needed, free);
 
     return result;
 }

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -496,7 +496,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
             xasprintf(&params.msg, _("File %s has invalid execstack flags (%s) on %s"), file->localpath, fs, arch);
 
             free(fs);
-            list_free(flaglist, free, true);
+            list_free(flaglist, free);
         } else {
             xasprintf(&params.msg, _("File %s has unrecognized GNU_STACK '%s' (expected RW or RWE) on %s"), file->localpath, pflags_to_str(execstack_flags), arch);
         }
@@ -773,11 +773,11 @@ static bool elf_archive_tests(struct rpminspect *ri, Elf *after_elf, int after_e
 
     free(params.msg);
 
-    list_free(after_lost_pic, free, true);
-    list_free(after_new, free, true);
-    list_free(after_no_pic, free, true);
-    list_free(before_pic, free, true);
-    list_free(before_all, free, true);
+    list_free(after_lost_pic, free);
+    list_free(after_new, free);
+    list_free(after_no_pic, free);
+    list_free(before_pic, free);
+    list_free(before_all, free);
 
     free(screendump);
 

--- a/lib/inspect_files.c
+++ b/lib/inspect_files.c
@@ -128,7 +128,7 @@ static bool files_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         valid_macro = false;
     }
 
-    list_free(spec, free, true);
+    list_free(spec, free);
     return result;
 }
 

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -342,7 +342,7 @@ bool inspect_kmidiff(struct rpminspect *ri)
 
     /* clean up */
     free(cmdprefix);
-    list_free(suppressions, free, true);
+    list_free(suppressions, free);
     free(kabi_dir);
 
     /* report the inspection results */

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -196,7 +196,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
         }
 
-        list_free(lost, free, true);
+        list_free(lost, free);
         lost = NULL;
     }
 
@@ -213,7 +213,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
         }
 
-        list_free(gain, free, true);
+        list_free(gain, free);
         gain = NULL;
     }
 
@@ -234,7 +234,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
         }
 
-        list_free(lost, free, true);
+        list_free(lost, free);
         lost = NULL;
     }
 
@@ -250,7 +250,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             reported = true;
         }
 
-        list_free(gain, free, true);
+        list_free(gain, free);
         gain = NULL;
     }
 

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -411,7 +411,7 @@ static bool is_valid_license(struct rpminspect *ri, struct result_params *params
                 }
             }
 
-            list_free(parenexps, free, true);
+            list_free(parenexps, free);
         }
 
         /* close this db */

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -74,11 +74,11 @@ static bool find_lto_symbols(Elf *elf, __attribute__((unused)) string_list_t **u
     }
 
     if (TAILQ_EMPTY(specifics)) {
-        list_free(specifics, free, true);
+        list_free(specifics, free);
         specifics = NULL;
     }
 
-    list_free(names, free, true);
+    list_free(names, free);
 
     return true;
 }
@@ -181,7 +181,7 @@ static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         close(fd);
     }
 
-    list_free(names, free, true);
+    list_free(names, free);
 
     return result;
 }

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -45,8 +45,9 @@ static void free_patches(patches_t *table)
     }
 
     HASH_ITER(hh, table, entry, tmp_entry) {
-        free(entry->patch);
         HASH_DEL(table, entry);
+        free(entry->patch);
+        free(entry);
     }
 
     return;
@@ -65,8 +66,9 @@ static void free_applied_patches(applied_patches_t *table)
     }
 
     HASH_ITER(hh, table, entry, tmp_entry) {
-        free(entry->opts);
         HASH_DEL(table, entry);
+        free(entry->opts);
+        free(entry);
     }
 
     return;

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -162,7 +162,7 @@ static bool have_automacro(const struct rpminspect *ri, const rpmfile_entry_t *s
         }
     }
 
-    list_free(contents, free, true);
+    list_free(contents, free);
     return r;
 }
 
@@ -256,7 +256,7 @@ static char *expand_patchname_macros(struct rpminspect *ri, const rpmfile_entry_
         }
     }
 
-    list_free(macros, free, true);
+    list_free(macros, free);
     return r;
 }
 
@@ -336,7 +336,7 @@ static patchstat_t get_patch_stats(const char *patch)
     }
 
     /* clean up */
-    list_free(lines, free, true);
+    list_free(lines, free);
 
     return r;
 }
@@ -726,7 +726,7 @@ bool inspect_patches(struct rpminspect *ri)
                             reported = true;
                             result = !(params.severity >= RESULT_VERIFY);
 
-                            list_free(fields, free, true);
+                            list_free(fields, free);
                             continue;
                         }
 
@@ -852,11 +852,11 @@ bool inspect_patches(struct rpminspect *ri)
                     }
 
                     /* clean up */
-                    list_free(fields, free, true);
+                    list_free(fields, free);
                 }
 
                 /* clean up the spec file we read in */
-                list_free(speclines, free, true);
+                list_free(speclines, free);
             }
         }
 
@@ -883,14 +883,14 @@ bool inspect_patches(struct rpminspect *ri)
                         result = !(params.severity >= RESULT_VERIFY);
                     }
 
-                    list_free(removed, free, true);
+                    list_free(removed, free);
                 }
 
-                list_free(before_patchfiles, free, true);
+                list_free(before_patchfiles, free);
             }
         }
 
-        list_free(patchfiles, free, true);
+        list_free(patchfiles, free);
     }
 
     /* Clean up the patches and applied hash tables */

--- a/lib/inspect_permissions.c
+++ b/lib/inspect_permissions.c
@@ -146,7 +146,7 @@ static bool permissions_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.severity = get_secrule_result_severity(ri, file, SECRULE_WORLDWRITABLE);
 
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
-            xasprintf(&params.msg, _("%s (%s) is world-writable on %s"), file->localpath, get_mime_type(file), arch);
+            xasprintf(&params.msg, _("%s (%s) is world-writable on %s"), file->localpath, get_mime_type(ri, file), arch);
             params.waiverauth = WAIVABLE_BY_SECURITY;
             params.verb = VERB_FAILED;
             params.noun = _("${FILE} is world-writable on ${ARCH}");

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -38,7 +38,7 @@ static void add_removedfiles_result(struct rpminspect *ri, struct result_params 
 static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool result = true;
-    char *type = NULL;
+    const char *type = NULL;
     const char *arch = NULL;
     char *soname = NULL;
     string_entry_t *entry = NULL;
@@ -71,7 +71,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Collect the RPM architecture and file MIME type */
-    type = get_mime_type(file);
+    type = get_mime_type(ri, file);
     arch = get_rpm_header_arch(file->rpm_header);
 
     /* Get any possible security rule for this path */

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -423,7 +423,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
             result = false;
         }
 
-        list_free(explicit_requires, free, true);
+        list_free(explicit_requires, free);
     }
 
     return result;

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -196,7 +196,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
             }
         }
 
-        list_free(parts, free, true);
+        list_free(parts, free);
     }
 
     return r;
@@ -292,8 +292,8 @@ cleanup:
         close(fd);
     }
 
-    list_free(rpath, free, true);
-    list_free(runpath, free, true);
+    list_free(rpath, free);
+    list_free(runpath, free);
 
     return result;
 }

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -81,7 +81,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool result = true;
     const char *arch = NULL;
-    char *type = NULL;
+    const char *type = NULL;
     char *shell = NULL;
     char *before_shell = NULL;
     int exitcode = -1;
@@ -98,7 +98,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Get the mime type of the file */
-    type = get_mime_type(file);
+    type = get_mime_type(ri, file);
 
     if (!strprefix(type, "text/")) {
         return true;

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -105,10 +105,10 @@ bool inspect_subpackages(struct rpminspect *ri)
         result = false;
     }
 
-    list_free(lost, free, true);
-    list_free(gain, free, true);
-    list_free(before_pkgs, free, true);
-    list_free(after_pkgs, free, true);
+    list_free(lost, free);
+    list_free(gain, free);
+    list_free(before_pkgs, free);
+    list_free(after_pkgs, free);
 
     /* Sound the everything-is-ok alarm if everything is, in fact, ok */
     if (result) {

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -69,17 +69,17 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.noun = _("${FILE} MIME type on ${ARCH}");
 
     /* Get the MIME types */
-    bmt = strsplit(get_mime_type(file->peer_file), "/");
-    amt = strsplit(get_mime_type(file), "/");
+    bmt = strsplit(get_mime_type(ri, file->peer_file), "/");
+    amt = strsplit(get_mime_type(ri, file), "/");
 
     /* A MIME type should be category/subcategory, so these lists should be length 2 */
     if (r && list_len(bmt) != 2) {
-        xasprintf(&params.msg, _("Unknown MIME type `%s' on %s in %s"), get_mime_type(file->peer_file), file->peer_file->localpath, bnevra);
+        xasprintf(&params.msg, _("Unknown MIME type `%s' on %s in %s"), get_mime_type(ri, file->peer_file), file->peer_file->localpath, bnevra);
         r = false;
     }
 
     if (r && list_len(amt) != 2) {
-        xasprintf(&params.msg, _("Unknown MIME type `%s' on %s in %s"), get_mime_type(file), file->localpath, anevra);
+        xasprintf(&params.msg, _("Unknown MIME type `%s' on %s in %s"), get_mime_type(ri, file), file->localpath, anevra);
         r = false;
     }
 

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -117,8 +117,8 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* clean up */
-    list_free(bmt, free, true);
-    list_free(amt, free, true);
+    list_free(bmt, free);
+    list_free(amt, free);
     free(bnevra);
     free(anevra);
 

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -347,13 +347,12 @@ static char *manual_prep_source(struct rpminspect *ri, const rpmfile_entry_t *fi
             }
 
             free(extractdir);
-            free(mime);
             free(srcfile);
         }
     }
 
     free(fp);
-    list_free(sources, free, true);
+    list_free(sources, free);
     return build;
 }
 

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -202,9 +202,9 @@ bool inspect_upstream(struct rpminspect *ri)
             }
         }
 
-        list_free(removed, free, true);
-        list_free(before_source, free, true);
-        list_free(source, free, true);
+        list_free(removed, free);
+        list_free(before_source, free);
+        list_free(source, free);
     }
 
     free(params.remedy);

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -74,7 +74,7 @@ static bool upstream_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (strcmp(before_sum, after_sum)) {
             /* capture 'diff -u' output for text files */
-            if (is_text_file(file->peer_file) && is_text_file(file)) {
+            if (is_text_file(ri, file->peer_file) && is_text_file(ri, file)) {
                 diff_head = diff_output = get_file_delta(file->peer_file->fullpath, file->fullpath);
 
                 /* skip the two leading lines */

--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -280,8 +280,10 @@ void free_module_aliases(kernel_alias_data_t *data)
     }
 
     HASH_ITER(hh, data, entry, tmp_entry) {
-        free(entry->alias);
+        HASH_DEL(data, entry);
         list_free(entry->modules, free);
+        free(entry->alias);
+        free(entry);
     }
 
     free(data);

--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -164,11 +164,11 @@ bool compare_module_parameters(const struct kmod_list *before, const struct kmod
         *gain = list_copy(added);
     }
 
-    list_free(added, NULL, true);
-    list_free(difference, NULL, true);
-    list_free(before_parm_list, free, true);
-    list_free(after_parm_list, free, true);
-    list_free(combined, free, true);
+    list_free(added, NULL);
+    list_free(difference, NULL);
+    list_free(before_parm_list, free);
+    list_free(after_parm_list, free);
+    list_free(combined, free);
 
     return result;
 }
@@ -203,16 +203,16 @@ bool compare_module_dependencies(const struct kmod_list *before, const struct km
     if (difference == NULL || TAILQ_EMPTY(difference)) {
         DEBUG_PRINT("no kernel module deps differences\n");
 
-        list_free(difference, NULL, true);
-        list_free(before_depends_list, free, true);
-        list_free(after_depends_list, free, true);
+        list_free(difference, NULL);
+        list_free(before_depends_list, free);
+        list_free(after_depends_list, free);
 
         return true;
     }
 
     /* Otherwise, just free the difference, and return the before and after dependencies */
     DEBUG_PRINT("there are kernel module deps differences\n");
-    list_free(difference, NULL, true);
+    list_free(difference, NULL);
 
     *before_deps = before_depends_list;
     *after_deps = after_depends_list;
@@ -281,8 +281,7 @@ void free_module_aliases(kernel_alias_data_t *data)
 
     HASH_ITER(hh, data, entry, tmp_entry) {
         free(entry->alias);
-        list_free(entry->modules, free, false);
-        HASH_DEL(data, entry);
+        list_free(entry->modules, free);
     }
 
     free(data);
@@ -385,7 +384,7 @@ bool compare_module_aliases(kernel_alias_data_t *before, kernel_alias_data_t *af
                 wildcard_search = true;
             }
 
-            list_free(difference, NULL, true);
+            list_free(difference, NULL);
         }
 
         /* Compare the results */
@@ -398,7 +397,7 @@ bool compare_module_aliases(kernel_alias_data_t *before, kernel_alias_data_t *af
 
         /* If after_modules was created from a wildcard search, free it */
         if (wildcard_search) {
-            list_free(after_modules, NULL, true);
+            list_free(after_modules, NULL);
         }
     }
 

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -550,9 +550,9 @@ void free_koji_task_entry(koji_task_entry_t *entry)
     }
 
     free_koji_task(entry->task);
-    list_free(entry->srpms, free, true);
-    list_free(entry->rpms, free, true);
-    list_free(entry->logs, free, true);
+    list_free(entry->srpms, free);
+    list_free(entry->rpms, free);
+    list_free(entry->logs, free);
     free(entry);
     entry = NULL;
 

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -231,14 +231,14 @@ string_list_t * list_symmetric_difference(const string_list_t *a, const string_l
     b_minus_a = list_difference(b, a);
 
     if (b_minus_a == NULL) {
-        list_free(a_minus_b, NULL, true);
+        list_free(a_minus_b, NULL);
         return NULL;
     }
 
     combination = list_union(a_minus_b, b_minus_a);
 
-    list_free(a_minus_b, NULL, true);
-    list_free(b_minus_a, NULL, true);
+    list_free(a_minus_b, NULL);
+    list_free(b_minus_a, NULL);
 
     return combination;
 }
@@ -247,7 +247,7 @@ string_list_t * list_symmetric_difference(const string_list_t *a, const string_l
  * Helper function to free a string_list_t and each entry->data.  If
  * the free_func is NULL, nothing is done to the entry->data values.
  */
-void list_free(string_list_t *list, list_entry_data_free_func free_func, const bool free_list)
+void list_free(string_list_t *list, list_entry_data_free_func free_func)
 {
     string_entry_t *entry = NULL;
 
@@ -266,10 +266,7 @@ void list_free(string_list_t *list, list_entry_data_free_func free_func, const b
         free(entry);
     }
 
-    if (free_list) {
-        free(list);
-    }
-
+    free(list);
     return;
 }
 
@@ -331,7 +328,7 @@ size_t list_len(const string_list_t *list)
 
 /*
  * Returns a malloc'ed copy of the given list.  Caller must use
- * list_free(list, free, true) on the returned list.
+ * list_free(list, free) on the returned list.
  */
 string_list_t * list_copy(const string_list_t *list)
 {

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -300,9 +300,10 @@ string_list_t *list_sort(const string_list_t *list)
 
     /* build a new string_list_t from the sorted hash table */
     HASH_ITER(hh, map, entry, tmp_entry) {
+        HASH_DEL(map, entry);
         sorted_list = list_add(sorted_list, entry->key);
         free(entry->key);
-        HASH_DEL(map, entry);
+        free(entry);
     }
 
     free(map);

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -131,7 +131,7 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
         if (list_len(fields) != 3) {
             /* not a macro line */
             DEBUG_PRINT("ignoring macro line (possibly a function): '%s'\n", specline->data);
-            list_free(fields, free, true);
+            list_free(fields, free);
             continue;
         }
 
@@ -147,7 +147,7 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
 
         if (strcmp(entry->data, SPEC_MACRO_DEFINE) && strcmp(entry->data, SPEC_MACRO_GLOBAL)) {
             /* ignore complex macros, like a conditional define with a %global */
-            list_free(fields, free, true);
+            list_free(fields, free);
             continue;
         }
 
@@ -155,7 +155,7 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
 
         if (strsuffix(entry->data, ")")) {
             /* ignore macro functions */
-            list_free(fields, free, true);
+            list_free(fields, free);
             continue;
         }
 
@@ -187,7 +187,7 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
     }
 
     /* clean up */
-    list_free(spec, free, true);
+    list_free(spec, free);
     regfree(&macro_regex);
 
     return n;
@@ -250,6 +250,6 @@ string_list_t *get_macros(const char *s)
         }
     }
 
-    list_free(fields, free, true);
+    list_free(fields, free);
     return macros;
 }

--- a/lib/magic.c
+++ b/lib/magic.c
@@ -11,49 +11,47 @@
 
 #include "rpminspect.h"
 
-/*
- * Return the MIME type of the specified file by path.  The caller is
- * responsible for freeing the returned string.
- */
-char *mime_type(const char *path)
+static void init_magic_cookie(struct rpminspect *ri)
 {
-    char *type = NULL;
-    char *pos = NULL;
-    const char *tmp = NULL;
-    magic_t cookie;
+    assert(ri != NULL);
 
-    if (path == NULL) {
-        return NULL;
-    }
+    ri->magic_cookie = magic_open(MAGIC_MIME | MAGIC_CHECK);
 
-    cookie = magic_open(MAGIC_MIME | MAGIC_CHECK);
-
-    if (cookie == NULL) {
+    if (ri->magic_cookie == NULL) {
         warnx(_("*** unable to initialize the magic library"));
+        return;
+    }
+
+    if (magic_load(ri->magic_cookie, NULL) != 0) {
+        warnx(_("*** unable to load the magic database: %s"), magic_error(ri->magic_cookie));
+        magic_close(ri->magic_cookie);
+        return;
+    }
+
+    ri->magic_initialized = true;
+    return;
+}
+
+/*
+ * Get the MIME type of a file specified by path rather than
+ * rpmfile_entry_t and bypass cached types.  It does use the open
+ * libmagic handle if it's available.  Caller should not free the
+ * returned string.
+ */
+const char *mime_type(struct rpminspect *ri, const char *file)
+{
+    assert(ri != NULL);
+
+    if (file == NULL) {
         return NULL;
     }
 
-    if (magic_load(cookie, NULL) != 0) {
-        warnx(_("*** unable to load the magic database: %s"), magic_error(cookie));
-        magic_close(cookie);
-        return NULL;
+    /* only try to initialize libmagic if it hasn't been yet */
+    if (!ri->magic_initialized) {
+        init_magic_cookie(ri);
     }
 
-    if ((tmp = magic_file(cookie, path)) != NULL) {
-        type = strdup(tmp);
-
-        /*
-         * Trim any trailing metadata after the MIME type, such
-         * as 'charset=binary' and stuff like that.
-         */
-        if ((pos = index(type, ';')) != NULL) {
-            *pos = '\0';
-            type = realloc(type, strlen(type) + 1);
-        }
-    }
-
-    magic_close(cookie);
-    return type;
+    return magic_file(ri->magic_cookie, file);
 }
 
 /*
@@ -62,30 +60,79 @@ char *mime_type(const char *path)
  * Otherwise it gets the MIME type, caches it, and returns the value.
  * The caller should not free the pointer returned.
  */
-char *get_mime_type(rpmfile_entry_t *file)
+const char *get_mime_type(struct rpminspect *ri, rpmfile_entry_t *file)
 {
+    const char *tmp = NULL;
+    char *type = NULL;
+    char *pos = NULL;
+    string_hash_t *entry = NULL;
+
+    assert(ri != NULL);
     assert(file != NULL);
 
-    /* MIME type is cached, return it */
-    if (file->type != NULL) {
+    /* no actual file; no actual MIME type */
+    if (file->fullpath == NULL) {
+        return NULL;
+    }
+
+    /* the type may already be cached */
+    if (file->type) {
         return file->type;
     }
 
-    /* Get and cache MIME type */
-    assert(file->fullpath != NULL);
-    file->type = mime_type(file->fullpath);
+    /* only try to initialize libmagic if it hasn't been yet */
+    if (!ri->magic_initialized) {
+        init_magic_cookie(ri);
+    }
 
-    return file->type;
+    /* get the type and see if it needs to be saved */
+    tmp = magic_file(ri->magic_cookie, file->fullpath);
+
+    if (tmp) {
+        type = strdup(tmp);
+        assert(type != NULL);
+    }
+
+    if (type != NULL) {
+        /*
+         * Trim any trailing metadata after the MIME type, such
+         * as 'charset=binary' and stuff like that.
+         */
+        if ((pos = index(type, ';')) != NULL) {
+            *pos = '\0';
+        }
+
+        /* look for the type first, add if not found */
+        HASH_FIND_STR(ri->magic_types, type, entry);
+
+        if (entry == NULL) {
+            /* start a new entry for this type */
+            entry = calloc(1, sizeof(*entry));
+            assert(entry != NULL);
+            entry->data = strdup(type);
+            HASH_ADD_KEYPTR(hh, ri->magic_types, entry->data, strlen(entry->data), entry);
+        }
+    }
+
+    free(type);
+
+    if (entry) {
+        return entry->data;
+    } else {
+        return NULL;
+    }
 }
 
 /* Return true if the named file is a text file according to libmagic */
-bool is_text_file(rpmfile_entry_t *file)
+bool is_text_file(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool ret = false;
-    char *type = NULL;
+    const char *type = NULL;
 
+    assert(ri != NULL);
     assert(file != NULL);
-    type = get_mime_type(file);
+
+    type = get_mime_type(ri, file);
 
     if (strprefix(type, "text/")) {
         ret = true;

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -196,7 +196,7 @@ int extract_peers(struct rpminspect *ri, bool fetchonly)
 
         /* match up file peers between builds */
         if (peer->before_files && peer->after_files) {
-            find_file_peers(peer->before_files, peer->after_files);
+            find_file_peers(ri, peer->before_files, peer->after_files);
         }
     }
 

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -245,7 +245,7 @@ string_list_t *get_elf_section_names(Elf *elf, size_t start)
     while ((scn = elf_nextscn(elf, scn)) != NULL) {
         /* get this header information */
         if (gelf_getshdr(scn, &shdr) != &shdr) {
-            list_free(names, free, true);
+            list_free(names, free);
             return NULL;
         }
 
@@ -516,12 +516,12 @@ static string_list_t *get_elf_symbol_list(Elf *elf, bool (*filter)(const char *)
 
     /* Get the section data */
     if ((data = elf_getdata(scn, NULL)) == NULL) {
-        list_free(list, NULL, true);
+        list_free(list, NULL);
         return NULL;
     }
 
     if ((xndxscn != NULL) && ((xndxdata = elf_getdata(xndxscn, NULL)) == NULL)) {
-        list_free(list, NULL, true);
+        list_free(list, NULL);
         return NULL;
     }
 
@@ -552,7 +552,7 @@ static string_list_t *get_elf_symbol_list(Elf *elf, bool (*filter)(const char *)
  * If filter is not NULL, only the symbol's returned true by the filter will be added.
  *
  * The memory pointed to by the list elements is owned by the Elf* context. The list
- * itself should be freed with list_free(<list>, NULL, true) by the caller.
+ * itself should be freed with list_free(<list>, NULL) by the caller.
  */
 string_list_t * get_elf_imported_functions(Elf *elf, bool (*filter)(const char *))
 {

--- a/lib/release.c
+++ b/lib/release.c
@@ -64,7 +64,7 @@ char *read_release(const rpmfile_t *files)
         }
     }
 
-    list_free(spec, free, true);
+    list_free(spec, free);
 
     return rel;
 }

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -280,7 +280,7 @@ char **build_argv(const char *cmd)
         i++;
     }
 
-    list_free(list, free, true);
+    list_free(list, free);
     return r;
 }
 
@@ -320,7 +320,7 @@ void free_argv_table(struct rpminspect *ri, string_list_map_t *table)
 
     HASH_ITER(hh, table, hentry, tmp_hentry) {
         free(hentry->key);
-        list_free(hentry->value, free, false);
+        list_free(hentry->value, free);
         HASH_DEL(table, hentry);
     }
 

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -319,9 +319,10 @@ void free_argv_table(struct rpminspect *ri, string_list_map_t *table)
     }
 
     HASH_ITER(hh, table, hentry, tmp_hentry) {
-        free(hentry->key);
-        list_free(hentry->value, free);
         HASH_DEL(table, hentry);
+        list_free(hentry->value, free);
+        free(hentry->key);
+        free(hentry);
     }
 
     return;

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -275,6 +275,7 @@ static char *get_product_release(string_map_t *products, const favor_release_t f
         free(after_product);
     }
 
+    free(before_product);
     return r;
 }
 

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -767,7 +767,7 @@ int main(int argc, char **argv)
             }
 
             if (!found) {
-                list_free(valid_arches, free, true);
+                list_free(valid_arches, free);
                 free_rpminspect(ri);
                 rpmFreeMacros(NULL);
                 rpmFreeRpmrc();
@@ -781,7 +781,7 @@ int main(int argc, char **argv)
 
         /* clean up */
         free(archopt);
-        list_free(valid_arches, free, true);
+        list_free(valid_arches, free);
     }
 
     /* create the working directory */
@@ -871,7 +871,7 @@ int main(int argc, char **argv)
     add_result_entry(&ri->results, &params);
     free(params.msg);
     free(params.details);
-    list_free(diags, free, true);
+    list_free(diags, free);
 
     /* add command line information to the results output */
     xasprintf(&params.msg, _("Command line arguments used to invoke %s."), COMMAND_NAME);

--- a/test/lib/test-badwords.c
+++ b/test/lib/test-badwords.c
@@ -55,7 +55,7 @@ int init_test_badwords(void) {
 }
 
 int clean_test_badwords(void) {
-    list_free(forbidden_words, free, true);
+    list_free(forbidden_words, free);
     return 0;
 }
 

--- a/test/test_changedfiles.py
+++ b/test/test_changedfiles.py
@@ -80,7 +80,7 @@ class GzipFileChangesRPMs(TestCompareRPMs):
         )
 
         self.inspection = "changedfiles"
-        self.result = "OK"
+        self.result = "INFO"
 
 
 class GzipFileChangesKoji(TestCompareKoji):
@@ -103,7 +103,7 @@ class GzipFileChangesKoji(TestCompareKoji):
         )
 
         self.inspection = "changedfiles"
-        self.result = "OK"
+        self.result = "INFO"
 
 
 # bzip2 file does not change between builds despite having different
@@ -175,7 +175,7 @@ class Bzip2FileChangesRPMs(TestCompareRPMs):
         )
 
         self.inspection = "changedfiles"
-        self.result = "OK"
+        self.result = "INFO"
 
 
 class Bzip2FileChangesKoji(TestCompareKoji):
@@ -198,7 +198,7 @@ class Bzip2FileChangesKoji(TestCompareKoji):
         )
 
         self.inspection = "changedfiles"
-        self.result = "OK"
+        self.result = "INFO"
 
 
 # xz file does not change between builds despite having different
@@ -270,7 +270,7 @@ class XzFileChangesRPMs(TestCompareRPMs):
         )
 
         self.inspection = "changedfiles"
-        self.result = "OK"
+        self.result = "INFO"
 
 
 class XzFileChangesKoji(TestCompareKoji):
@@ -293,4 +293,4 @@ class XzFileChangesKoji(TestCompareKoji):
         )
 
         self.inspection = "changedfiles"
-        self.result = "OK"
+        self.result = "INFO"


### PR DESCRIPTION
A lot of changes here, but the main things are:

- Introduction of string_hash_t
- Caching of MIME type strings and storing pointers to the strings for each rpmfile_entry_t rather than a duplicated string
- Handling of libmagic giving us NULL
- Closing leaks that were (slooooooooooowly) found by valgrind