### PR TITLE
Portability fixes for packaging on NixOS

### DIFF
--- a/lib/pic_bits.sh
+++ b/lib/pic_bits.sh
@@ -32,7 +32,9 @@
 # reloc types are in the R_<arch>_<type> #define's. The only case we (sort of)
 # care about where the arch's don't match is ia64: it's EM_IA_64 but R_IA64_*.
 
-if ! cpp_output="$(cpp -dM /usr/include/elf.h)"; then
+elf_h_path="${ELF_H_PATH:-/usr/include/elf.h}"
+
+if ! cpp_output="$(cpp -dM "$elf_h_path")"; then
     echo "Unable to read elf.h" >&2
     echo "Ensure glibc-headers is installed" >&2
     exit 1

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,8 @@ project('rpminspect',
         ],
         license : 'GPL-3.0-or-later AND LGPL-3.0-or-later AND Apache-2.0 AND MIT')
 
+fs = import('fs')
+
 cc = meson.get_compiler('c')
 
 # Define the program version
@@ -30,10 +32,17 @@ search_dirs = [ '/usr/local/lib', '/usr/pkg/lib', '/usr/lib64', '/usr/lib' ]
 
 # Header search dirs
 if build_machine.system() == 'netbsd'
-    inc = include_directories( '/usr/local/include', '/usr/pkg/include', '/usr/include' )
+    include_dirs = [ '/usr/local/include', '/usr/pkg/include', '/usr/include' ]
 else
-    inc = include_directories( '/usr/local/include', '/usr/include' )
+    include_dirs = [ '/usr/local/include', '/usr/include' ]
 endif
+existing_include_dirs = []
+foreach dir : include_dirs
+    if fs.is_dir(dir)
+        existing_include_dirs += dir
+    endif
+endforeach
+inc = include_directories(existing_include_dirs)
 
 # See if we have reallocarray in libc
 if cc.has_function('reallocarray')


### PR DESCRIPTION
I'm working on packaging rpminspect for NixOS (https://github.com/NixOS/nixpkgs/compare/master...evan-goode:nixpkgs:evan-goode/rpminspect) and ran into a couple things that I had to tweak.

1. For systems that don't have /usr/, the path to elf.h should be overrideable by an environment variable. Though who know whether any of pic_bits.sh will work/be relevant on NixOS :)
2. We should add additional include directories only if they exist on the system. Nix has its own way of telling Meson the right include paths to search.