### PR TITLE
[lib] In module package builds check for a Release tag value substring

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -282,6 +282,15 @@ modularity:
     #                  will recommend its addition.
     #static_context: required
 
+    # Release tag value substrings that should be present in modular
+    # RPMs.  Define a regular expression that rpminspect should run on
+    # the Release tag value.  One regular expression per product
+    # release substring.  If you do not define a regexp here for a
+    # product release, the modularity inspection will skip this check
+    # when inspecting RPMs for that product.
+    #release_regexp:
+    #    fc31: \+module\.fc31\.[0-9]+
+
 elf:
     # File paths to include in or exclude from specific tests. Each
     # value is a POSIX extended regular expression (man 7

--- a/include/results.h
+++ b/include/results.h
@@ -246,11 +246,18 @@
  */
 
 /**
- * @def REMEDY_MODULARITY
+ * @def REMEDY_MODULARITY_LABEL
  *
  * How to address modularity problems in RPMs that are built as part of modules.
  */
-#define REMEDY_MODULARITY _("This package is part of a module but is missing the %{modularitylabel} header tag.  Add this as a %define in the spec file and rebuild.")
+#define REMEDY_MODULARITY_LABEL _("This package is part of a module but is missing the %{modularitylabel} header tag.  Add this as a %define in the spec file and rebuild.")
+
+/**
+ * @def REMEDY_MODULARITY_RELEASE
+ *
+ * How to address a non-conformant Release value in RPMs that are build as part of modules.
+ */
+#define REMEDY_MODULARITY_RELEASE _("This package is part of a module but lacks a conformant Release tag value.  A Release tag in a modular RPM needs to carry a substring that is more specific than a major release dist tag (e.g., el8.9.0 rather than el8) and must carry '+module' as a substring before that specific dist tag.")
 
 /**
  * @def REMEDY_MODULARITY_STATIC_CONTEXT

--- a/include/types.h
+++ b/include/types.h
@@ -517,6 +517,9 @@ struct rpminspect {
 #ifdef _HAVE_MODULARITYLABEL
     /* Modularity values */
     static_context_t modularity_static_context;
+
+    /* Release substring regular expressions */
+    string_map_t *modularity_release;
 #endif
 
     /* Required subdomain for buildhosts -- multiple subdomains allowed */

--- a/lib/free.c
+++ b/lib/free.c
@@ -246,6 +246,10 @@ void free_rpminspect(struct rpminspect *ri)
 #endif
     free(ri->commands.udevadm);
 
+#ifdef _HAVE_MODULARITYLABEL
+    free_string_map(ri->modularity_release);
+#endif
+
     list_free(ri->buildhost_subdomain, free);
     list_free(ri->macrofiles, free);
     list_free(ri->security_path_prefix, free);

--- a/lib/init.c
+++ b/lib/init.c
@@ -655,6 +655,8 @@ static void read_cfgfile(struct rpminspect *ri, const char *filename)
 
         free(s);
     }
+
+    tabledict(p, ctx, "modularity", "release_regexp", &ri->modularity_release, false, false);
 #endif
 
     ADD_INCL_EXCL(elf);

--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -880,7 +880,7 @@ class TestCompareKoji(TestCompareRPMs):
 
 # Base test case class that tests a fake module build
 class TestModule(TestKoji):
-    def setUp(self, modularitylabel=True, static_context=True):
+    def setUp(self, modularitylabel=True, static_context=True, release_substring=True):
         super().setUp()
         self.buildtype = "module"
 
@@ -902,11 +902,20 @@ class TestModule(TestKoji):
             f.write("   static_context: true\n")
         f.close()
 
+        # set the Release tag correctly
+        if release_substring:
+            self.rpm.release = "%s+module%%{?dist}.1.0" % AFTER_REL
+
 
 # Base test case class that compares before and after module builds
 class TestCompareModules(TestCompareKoji):
     def setUp(
-        self, rebase=False, same=False, modularitylabel=True, static_context=True
+        self,
+        rebase=False,
+        same=False,
+        modularitylabel=True,
+        static_context=True,
+        release_substring=True,
     ):
         super().setUp(rebase=rebase, same=same)
         self.buildtype = "module"
@@ -933,3 +942,8 @@ class TestCompareModules(TestCompareKoji):
         f.close()
 
         shutil.copy(modulemd, afterfilesdir)
+
+        # set the Release tag correctly
+        if release_substring:
+            self.before_rpm.release = "%s+module%%{?dist}.1.0" % BEFORE_REL
+            self.after_rpm.release = "%s+module%%{?dist}.2.0" % AFTER_REL

--- a/test/test_modularity.py
+++ b/test/test_modularity.py
@@ -184,3 +184,77 @@ class ModulesHaveStaticContextWithNoRule(TestCompareModules):
 
         self.inspection = "modularity"
         self.result = "OK"
+
+
+# Module has correct Release tag value (OK)
+class ModuleHasReleaseTagSubstring(TestModule):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
+    def setUp(self):
+        super().setUp(release_substring=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["release_regexp"] = {}
+        self.extra_cfg["modularity"]["release_regexp"][
+            "GENERIC"
+        ] = "\+module\.[a-z0-9]+\.[0-9]+\.[0-9]+"  # noqa: W605
+
+        self.inspection = "modularity"
+        self.result = "OK"
+        self.waiverauth = "Anyone"
+
+
+class ModulesHaveReleaseTagSubstring(TestCompareModules):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
+    def setUp(self):
+        super().setUp(release_substring=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["release_regexp"] = {}
+        self.extra_cfg["modularity"]["release_regexp"][
+            "GENERIC"
+        ] = "\+module\.[a-z0-9]+\.[0-9]+\.[0-9]+"  # noqa: W605
+
+        self.inspection = "modularity"
+        self.result = "OK"
+        self.waiverauth = "Anyone"
+
+
+# Module has non-conformant Release tag value (BAD)
+class ModuleHasBadReleaseTagSubstring(TestModule):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
+    def setUp(self):
+        super().setUp(release_substring=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["release_regexp"] = {}
+        self.extra_cfg["modularity"]["release_regexp"]["GENERIC"] = "foobar"
+
+        self.inspection = "modularity"
+        self.result = "BAD"
+        self.waiverauth = "Anyone"
+
+
+class ModulesHaveBadReleaseTagSubstring(TestCompareModules):
+    @unittest.skipUnless(
+        have_modularitylabel, "rpm lacks RPMTAG_MODULARITYLABEL support"
+    )
+    def setUp(self):
+        super().setUp(release_substring=True)
+
+        self.extra_cfg = {}
+        self.extra_cfg["modularity"] = {}
+        self.extra_cfg["modularity"]["release_regexp"] = {}
+        self.extra_cfg["modularity"]["release_regexp"]["GENERIC"] = "foobar"
+
+        self.inspection = "modularity"
+        self.result = "BAD"
+        self.waiverauth = "Anyone"


### PR DESCRIPTION
In module package builds it is possible that Release tag values will be constructed in a specific way that embeds module-specific substrings.  This commit extends the modularity inspection to handle this if the config file contains regular expressions for the Release tag per product release.

For example, if the product release you have builds for is 'el8', then the rpminspect configuration needs to carry:

    modularity:
        release_regexp:
            el8: \.module+el8\.[0-9]+\.[0-9]+

Or whatever the appropriate regular expression would be.  The modularity inspection will then check RPMTAG_RELEASE on modular package builds to ensure they generate a match on the regular expression.  Those that fail will be reported as having a non-conformant Release tag value.

Resolves: #801