### PR TITLE
CI job fixes for recent modularity inspection update

### DIFF
--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -2,6 +2,9 @@
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
+# Alpine Linux does not define an RPM dist tag
+echo '%dist .ri47' > ${HOME}/.rpmmacros
+
 # The mandoc package in Alpine Linux lacks the library
 if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz

--- a/osdeps/arch/defs.mk
+++ b/osdeps/arch/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = pacman --noconfirm -S
-PIP_CMD = pip3 install
+PIP_CMD = pip3 install --break-system-packages

--- a/osdeps/arch/post.sh
+++ b/osdeps/arch/post.sh
@@ -2,6 +2,9 @@
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
+# Arch Linux does not define an RPM dist tag
+echo '%dist .ri47' > ${HOME}/.rpmmacros
+
 # There is no mandoc package in Arch Linux
 if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz

--- a/osdeps/debian-stable/post.sh
+++ b/osdeps/debian-stable/post.sh
@@ -2,6 +2,9 @@
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 CWD="$(pwd)"
 
+# Debian Linux stable does not define an RPM dist tag
+echo '%dist .ri47' > ${HOME}/.rpmmacros
+
 # Install 32-bit development files on 64-bit systems when available
 case "$(uname -m)" in
     x86_64)

--- a/osdeps/debian-testing/post.sh
+++ b/osdeps/debian-testing/post.sh
@@ -2,6 +2,9 @@
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 CWD="$(pwd)"
 
+# Debian Linux testing does not define an RPM dist tag
+echo '%dist .ri47' > ${HOME}/.rpmmacros
+
 # Install 32-bit development files on 64-bit systems when available
 case "$(uname -m)" in
     x86_64)

--- a/osdeps/slackware/post.sh
+++ b/osdeps/slackware/post.sh
@@ -2,6 +2,9 @@
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
+# Slackware Linux does not define an RPM dist tag
+echo '%dist .ri47' > ${HOME}/.rpmmacros
+
 # Install rust.  Slackware comes with Rust, but it's too old to build
 # clamav, which we also need.
 curl --proto '=https' --tlsv1.2 -sSf -o rustup.sh https://sh.rustup.rs

--- a/osdeps/ubuntu/post.sh
+++ b/osdeps/ubuntu/post.sh
@@ -2,6 +2,9 @@
 PATH=/usr/bin
 CWD="$(pwd)"
 
+# Ubuntu Linux does not define an RPM dist tag
+echo '%dist .ri47' > ${HOME}/.rpmmacros
+
 # The mandoc package on Ubuntu lacks libmandoc.a and
 # header files, which we need to build rpminspect
 if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then


### PR DESCRIPTION
Non-Fedora derived systems probably lack a %dist tag defined for rpmbuild, so simulate one via ~/.rpmmacros for the purposes of running the test suite.  This PR should fix all but the Gentoo Linux CI jobs.  Gentoo is failing for another reason right now and it appears to be their own emerge dependency stuff.