### PR TITLE
[fix] Adjust DEBUGINFO_SUFFIX and DEBUGSOURCE_SUFFIX

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -449,14 +449,14 @@
  *
  * The debuginfo package name substring.
  */
-#define DEBUGINFO_SUBSTRING "-debuginfo"
+#define DEBUGINFO_SUBSTRING "-debuginfo-"
 
 /**
  * @def DEBUGSOURCE_SUBSTRING
  *
  * The debugsource package name substring.
  */
-#define DEBUGSOURCE_SUBSTRING "-debugsource"
+#define DEBUGSOURCE_SUBSTRING "-debugsource-"
 
 /**
  * @def DEBUG_PATH


### PR DESCRIPTION
Small change when identifying debuginfo and debugsource packages.  The substring should begin and end with hyphens, otherwise we will pick up elfutils-debuginfod-client as a debuginfo package and that's incorrect.

Fixes: #1209