### PR TITLE
[fix] Check for debuginfo and debugsource package name suffixes

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -445,18 +445,18 @@
 #define DEBUGINFO_PROVIDE "debuginfo(build-id)"
 
 /**
- * @def DEBUGINFO_SUBSTRING
+ * @def DEBUGINFO_SUFFIX
  *
- * The debuginfo package name substring.
+ * The debuginfo package name suffix.
  */
-#define DEBUGINFO_SUBSTRING "-debuginfo-"
+#define DEBUGINFO_SUFFIX "-debuginfo"
 
 /**
- * @def DEBUGSOURCE_SUBSTRING
+ * @def DEBUGSOURCE_SUFFIX
  *
- * The debugsource package name substring.
+ * The debugsource package name suffix.
  */
-#define DEBUGSOURCE_SUBSTRING "-debugsource-"
+#define DEBUGSOURCE_SUFFIX "-debugsource"
 
 /**
  * @def DEBUG_PATH

--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -117,8 +117,8 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
 
             /* skip some rules types */
             if (!strcmp(r, DEBUGINFO_PROVIDE)
-                || strstr(r, DEBUGSOURCE_SUBSTRING)
-                || strstr(r, DEBUGINFO_SUBSTRING)
+                || strsuffix(r, DEBUGSOURCE_SUFFIX)
+                || strsuffix(r, DEBUGINFO_SUFFIX)
                 || ((strprefix(r, "rpmlib(") || strprefix(r, "rtld(")) && strsuffix(r, ")"))
                 || ((strprefix(r, "kernel(") || strprefix(r, "modalias(") || strprefix(r, "ksym(") || strprefix(r, "kmod(")) && strsuffix(r, ")"))) {
                 continue;

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -453,7 +453,7 @@ cleanup:
 #endif
 }
 
-static bool _is_debug_rpm_helper(Header hdr, const char *provide, const char *substring)
+static bool _is_debug_rpm_helper(Header hdr, const char *provide, const char *suffix)
 {
     rpmtd req = NULL;
     rpmFlags flags = HEADERGET_MINMEM | HEADERGET_EXT | HEADERGET_ARGV;
@@ -475,7 +475,7 @@ static bool _is_debug_rpm_helper(Header hdr, const char *provide, const char *su
                 break;
             }
 
-            if (substring && strstr(p, substring)) {
+            if (suffix && strsuffix(p, suffix)) {
                 r = true;
                 break;
             }
@@ -494,7 +494,7 @@ static bool _is_debug_rpm_helper(Header hdr, const char *provide, const char *su
  */
 bool is_debuginfo_rpm(Header hdr)
 {
-    return _is_debug_rpm_helper(hdr, DEBUGINFO_PROVIDE, DEBUGINFO_SUBSTRING);
+    return _is_debug_rpm_helper(hdr, DEBUGINFO_PROVIDE, DEBUGINFO_SUFFIX);
 }
 
 /*
@@ -503,5 +503,5 @@ bool is_debuginfo_rpm(Header hdr)
  */
 bool is_debugsource_rpm(Header hdr)
 {
-    return _is_debug_rpm_helper(hdr, NULL, DEBUGSOURCE_SUBSTRING);
+    return _is_debug_rpm_helper(hdr, NULL, DEBUGSOURCE_SUFFIX);
 }


### PR DESCRIPTION
Commit 6eb60aa8332c4d8a9d02f885df26d112f7beb5e5 was almost correct. Still check these as suffixes, but change it over to strsuffix() rather than strstr().