### PR TITLE
[lib] Use execvp() rather than execvpe() in run_cmd()

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -305,7 +305,7 @@ char *compute_checksum(const char *, mode_t *, int);
 char *checksum(rpmfile_entry_t *);
 
 /* runcmd.c */
-char *run_cmd_vpe(int *exitcode, const char *workdir, char **argv);
+char *run_cmd_vp(int *exitcode, const char *workdir, char **argv);
 char *run_cmd(int *, const char *, const char *, ...) __attribute__((__sentinel__));
 void free_argv_table(struct rpminspect *ri, string_list_map_t *table);
 char **build_argv(const char *cmd);
@@ -379,6 +379,7 @@ const char *get_debuginfo_path(struct rpminspect *ri, const rpmfile_entry_t *fil
 
 bool usable_path(const char *path);
 bool match_path(const char *pattern, const char *root, const char *path);
+char *find_cmd(const char *cmd);
 
 /**
  * @brief Given a path and struct rpminspect, determine if the path

--- a/lib/init.c
+++ b/lib/init.c
@@ -691,6 +691,7 @@ static void read_cfgfile(struct rpminspect *ri, const char *filename)
         if (!strcasecmp(s, "info") || !strcasecmp(s, "info-only") || !strcasecmp(s, "info_only")) {
             ri->size_threshold = -1;
         } else {
+            errno = 0;
             ri->size_threshold = strtol(s, 0, 10);
 
             if ((ri->size_threshold == LONG_MIN || ri->size_threshold == LONG_MAX) && errno == ERANGE) {
@@ -778,6 +779,7 @@ static void read_cfgfile(struct rpminspect *ri, const char *filename)
     s = p->getstr(ctx, "abdiff", "security_level_threshold");
 
     if (s != NULL) {
+        errno = 0;
         ri->abi_security_threshold = strtol(s, 0, 10);
 
         if ((ri->abi_security_threshold == LONG_MIN ||

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -244,7 +244,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* run abidiff */
     argv = build_argv(cmd);
-    output = run_cmd_vpe(&exitcode, NULL, argv);
+    output = run_cmd_vp(&exitcode, NULL, argv);
     free_argv(argv);
 
     /* determine if this is a rebase build */

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -535,7 +535,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         /* Run the test on the file */
         after_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, annocheck_profile, get_debuginfo_path(ri, file, arch, AFTER_BUILD), file->fullpath);
         argv = build_argv(after_cmd);
-        after_out = run_cmd_vpe(&after_exit, ri->worksubdir, argv);
+        after_out = run_cmd_vp(&after_exit, ri->worksubdir, argv);
         free_argv(argv);
 
         /* If we have a before build, run the command on that */
@@ -543,7 +543,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             if (file->peer_file) {
                 before_cmd = build_annocheck_cmd(ri->commands.annocheck, hentry->value, annocheck_profile, get_debuginfo_path(ri, file, arch, BEFORE_BUILD), file->peer_file->fullpath);
                 argv = build_argv(before_cmd);
-                before_out = run_cmd_vpe(&before_exit, ri->workdir, argv);
+                before_out = run_cmd_vp(&before_exit, ri->workdir, argv);
                 free_argv(argv);
 
                 /* Build a reporting message if we need to */

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -268,6 +268,7 @@ bool inspect_javabytecode(struct rpminspect *ri)
         return false;
     }
 
+    errno = 0;
     supported_major = strtol(hentry->value, NULL, 10);
 
     if (errno == ERANGE) {

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -224,7 +224,7 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* run kmidiff */
     argv = build_argv(cmd);
-    output = run_cmd_vpe(&exitcode, ri->worksubdir, argv);
+    output = run_cmd_vp(&exitcode, ri->worksubdir, argv);
     free_argv(argv);
 
     /* determine if this is a rebase build */

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -745,10 +745,10 @@ bool inspect_patches(struct rpminspect *ri)
                         hentry = calloc(1, sizeof(*hentry));
                         assert(hentry != NULL);
                         hentry->patch = strdup(patchfile);
+                        errno = 0;
                         hentry->num = strtoll(buf, NULL, 10);
 
                         if (errno == ERANGE || errno == EINVAL) {
-                            warn("*** strtoll");
                             hentry->num = -1;
                         }
 
@@ -831,10 +831,10 @@ bool inspect_patches(struct rpminspect *ri)
 
                         aentry = calloc(1, sizeof(*aentry));
                         assert(aentry != NULL);
+                        errno = 0;
                         aentry->num = strtoll(buf, NULL, 10);
 
                         if (errno == ERANGE || errno == EINVAL) {
-                            warn("*** strtoll");
                             aentry->num = -1;
                         }
 

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -30,7 +30,7 @@
 #endif
 
 /*
- * Given a command name, try to find it in the pATH.  Returns an
+ * Given a command name, try to find it in the PATH.  Returns an
  * allocated string that the caller is responsible for freeing.
  */
 char *find_cmd(const char *cmd)

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -51,6 +51,13 @@ char *find_cmd(const char *cmd)
         return NULL;
     }
 
+    /* if cmd contains a '/', use as-is */
+    if (strchr(cmd, '/')) {
+        r = strdup(cmd);
+        assert(r != NULL);
+        return r;
+    }
+
     /* get the effective UID and GID */
     u = geteuid();
     g = getegid();

--- a/osdeps/fedora-rawhide.i686/post.sh
+++ b/osdeps/fedora-rawhide.i686/post.sh
@@ -11,5 +11,14 @@ case "$(uname -m)" in
         ;;
 esac
 
+# Remove any potentially bad udev rules files
+if [ -d /usr/lib/udev/rules.d ]; then
+    for rulefile in /usr/lib/udev/rules.d/*.rules ; do
+        if ! udevadm verify ${rulefile} >/dev/null 2>&1 ; then
+            rm -f ${rulefile}
+        fi
+    done
+fi
+
 # Update the clamav database
 freshclam

--- a/osdeps/fedora-rawhide/post.sh
+++ b/osdeps/fedora-rawhide/post.sh
@@ -11,5 +11,14 @@ case "$(uname -m)" in
         ;;
 esac
 
+# Remove any potentially bad udev rules files
+if [ -d /usr/lib/udev/rules.d ]; then
+    for rulefile in /usr/lib/udev/rules.d/*.rules ; do
+        if ! udevadm verify ${rulefile} >/dev/null 2>&1 ; then
+            rm -f ${rulefile}
+        fi
+    done
+fi
+
 # Update the clamav database
 freshclam


### PR DESCRIPTION
This is a portability change.  I have run in to some systems that have execvp() but not execvpe().  That's easy enough to deal with, so don't assume we have execvpe().