### PR TITLE
[lib] Ignore missing optional commands in gather_diags()

### DIFF
--- a/TODO
+++ b/TODO
@@ -351,12 +351,6 @@ General functionality
     added       auditwheel-5.0.0.tar.gz
     S.5.......T auditwheel.spec
 
-* Migrate to a TOML config file format--or a config file format that
-  looks similar to something you would see in /etc but that we have
-  our own parser for.  YAML is not ideal.  Though support for YAML
-  must remain as it is already established and supported.  It would be
-  nice to move the defaults over to not YAML.
-
 * Drop the need to fork/exec msgunfmt and just read in the po files
   directly.  This should be possible and will give us the information
   necessary for comparison purposes.

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -192,85 +192,100 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     /* msgunfmt */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.msgunfmt, "--version", NULL);
-    details = strsplit(tmp, "\n");
-    free(tmp);
 
-    entry = TAILQ_FIRST(details);
-    ver = strdup(entry->data);
-    list_free(details, free);
+    if (exitcode == 0) {
+        details = strsplit(tmp, "\n");
+        free(tmp);
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
-    xasprintf(&entry->data, "%s", ver);
-    TAILQ_INSERT_TAIL(list, entry, items);
+        entry = TAILQ_FIRST(details);
+        ver = strdup(entry->data);
+        list_free(details, free);
 
-    free(ver);
+        entry = calloc(1, sizeof(*entry));
+        assert(entry != NULL);
+        xasprintf(&entry->data, "%s", ver);
+        TAILQ_INSERT_TAIL(list, entry, items);
+
+        free(ver);
+    }
 
 #ifdef _WITH_ANNOCHECK
     /* annocheck */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.annocheck, "--version", NULL);
-    details = strsplit(tmp, "\n");
-    free(tmp);
 
-    entry = TAILQ_FIRST(details);
-    ver = strreplace(entry->data, ": Version ", " version ");
-    list_free(details, free);
+    if (exitcode == 0) {
+        details = strsplit(tmp, "\n");
+        free(tmp);
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
-    xasprintf(&entry->data, "%s", ver);
-    TAILQ_INSERT_TAIL(list, entry, items);
+        entry = TAILQ_FIRST(details);
+        ver = strreplace(entry->data, ": Version ", " version ");
+        list_free(details, free);
 
-    free(ver);
+        entry = calloc(1, sizeof(*entry));
+        assert(entry != NULL);
+        xasprintf(&entry->data, "%s", ver);
+        TAILQ_INSERT_TAIL(list, entry, items);
+
+        free(ver);
+    }
 #endif
 
     /* abidiff */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.abidiff, "--version", NULL);
-    details = strsplit(tmp, "\n");
-    free(tmp);
 
-    entry = TAILQ_FIRST(details);
-    ver = strreplace(entry->data, ": ", " version ");
-    list_free(details, free);
+    if (exitcode == 0) {
+        details = strsplit(tmp, "\n");
+        free(tmp);
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
-    xasprintf(&entry->data, "%s", ver);
-    TAILQ_INSERT_TAIL(list, entry, items);
+        entry = TAILQ_FIRST(details);
+        ver = strreplace(entry->data, ": ", " version ");
+        list_free(details, free);
 
-    free(ver);
+        entry = calloc(1, sizeof(*entry));
+        assert(entry != NULL);
+        xasprintf(&entry->data, "%s", ver);
+        TAILQ_INSERT_TAIL(list, entry, items);
+
+        free(ver);
+    }
 
     /* kmidiff */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.kmidiff, "--version", NULL);
-    details = strsplit(tmp, "\n");
-    free(tmp);
 
-    entry = TAILQ_FIRST(details);
-    ver = strreplace(entry->data, ": ", " version ");
-    list_free(details, free);
+    if (exitcode == 0) {
+        details = strsplit(tmp, "\n");
+        free(tmp);
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
-    xasprintf(&entry->data, "%s", ver);
-    TAILQ_INSERT_TAIL(list, entry, items);
+        entry = TAILQ_FIRST(details);
+        ver = strreplace(entry->data, ": ", " version ");
+        list_free(details, free);
 
-    free(ver);
+        entry = calloc(1, sizeof(*entry));
+        assert(entry != NULL);
+        xasprintf(&entry->data, "%s", ver);
+        TAILQ_INSERT_TAIL(list, entry, items);
+
+        free(ver);
+    }
 
     /* udevadm */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.udevadm, "--version", NULL);
-    details = strsplit(tmp, "\n");
-    free(tmp);
 
-    entry = TAILQ_FIRST(details);
-    ver = strdup(entry->data);
-    list_free(details, free);
+    if (exitcode == 0) {
+        details = strsplit(tmp, "\n");
+        free(tmp);
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
-    xasprintf(&entry->data, "udevadm version %s", ver);
-    TAILQ_INSERT_TAIL(list, entry, items);
+        entry = TAILQ_FIRST(details);
+        ver = strdup(entry->data);
+        list_free(details, free);
 
-    free(ver);
+        entry = calloc(1, sizeof(*entry));
+        assert(entry != NULL);
+        xasprintf(&entry->data, "udevadm version %s", ver);
+        TAILQ_INSERT_TAIL(list, entry, items);
+
+        free(ver);
+    }
 
     return list;
 }

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -197,9 +197,22 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
         details = strsplit(tmp, "\n");
         free(tmp);
 
-        entry = TAILQ_FIRST(details);
-        ver = strdup(entry->data);
-        list_free(details, free);
+        if (details) {
+            entry = TAILQ_FIRST(details);
+
+            if (entry && entry->data) {
+                ver = strdup(entry->data);
+            } else {
+                ver = NULL;
+            }
+
+            list_free(details, free);
+        }
+
+        if (ver == NULL) {
+            ver = realpath(ri->commands.msgunfmt, NULL);
+            assert(ver != NULL);
+        }
 
         entry = calloc(1, sizeof(*entry));
         assert(entry != NULL);
@@ -217,9 +230,22 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
         details = strsplit(tmp, "\n");
         free(tmp);
 
-        entry = TAILQ_FIRST(details);
-        ver = strreplace(entry->data, ": Version ", " version ");
-        list_free(details, free);
+        if (details) {
+            entry = TAILQ_FIRST(details);
+
+            if (entry && entry->data) {
+                ver = strreplace(entry->data, ": Version ", " version ");
+            } else {
+                ver = NULL;
+            }
+
+            list_free(details, free);
+        }
+
+        if (ver == NULL) {
+            ver = realpath(ri->commands.annocheck, NULL);
+            assert(ver != NULL);
+        }
 
         entry = calloc(1, sizeof(*entry));
         assert(entry != NULL);
@@ -237,9 +263,22 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
         details = strsplit(tmp, "\n");
         free(tmp);
 
-        entry = TAILQ_FIRST(details);
-        ver = strreplace(entry->data, ": ", " version ");
-        list_free(details, free);
+        if (details) {
+            entry = TAILQ_FIRST(details);
+
+            if (entry && entry->data) {
+                ver = strreplace(entry->data, ": ", " version ");
+            } else {
+                ver = NULL;
+            }
+
+            list_free(details, free);
+        }
+
+        if (ver == NULL) {
+            ver = realpath(ri->commands.abidiff, NULL);
+            assert(ver != NULL);
+        }
 
         entry = calloc(1, sizeof(*entry));
         assert(entry != NULL);
@@ -256,9 +295,22 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
         details = strsplit(tmp, "\n");
         free(tmp);
 
-        entry = TAILQ_FIRST(details);
-        ver = strreplace(entry->data, ": ", " version ");
-        list_free(details, free);
+        if (details) {
+            entry = TAILQ_FIRST(details);
+
+            if (entry && entry->data) {
+                ver = strreplace(entry->data, ": ", " version ");
+            } else {
+                ver = NULL;
+            }
+
+            list_free(details, free);
+        }
+
+        if (ver == NULL) {
+            ver = realpath(ri->commands.kmidiff, NULL);
+            assert(ver != NULL);
+        }
 
         entry = calloc(1, sizeof(*entry));
         assert(entry != NULL);
@@ -275,9 +327,22 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
         details = strsplit(tmp, "\n");
         free(tmp);
 
-        entry = TAILQ_FIRST(details);
-        ver = strdup(entry->data);
-        list_free(details, free);
+        if (details) {
+            entry = TAILQ_FIRST(details);
+
+            if (entry && entry->data) {
+                ver = strdup(entry->data);
+            } else {
+                ver = NULL;
+            }
+
+            list_free(details, free);
+        }
+
+        if (ver == NULL) {
+            ver = realpath(ri->commands.udevadm, NULL);
+            assert(ver != NULL);
+        }
 
         entry = calloc(1, sizeof(*entry));
         assert(entry != NULL);


### PR DESCRIPTION
Some commands are optional, so if they error out trying to get information just skip listing them in the diagnostics output.