### PR TITLE
Get file modes from the RPM header and not the cpio stream

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -233,7 +233,7 @@ char *get_nevr(Header);
 char *get_nevra(Header);
 const char *get_rpm_header_arch(Header);
 string_list_t *get_rpm_header_string_array(Header h, rpmTagVal tag);
-char *get_rpm_header_value(const rpmfile_entry_t *file, rpmTag tag);
+char *get_rpm_header_string_array_value(const rpmfile_entry_t *file, rpmTag tag);
 char *extract_rpm_payload(const char *rpm);
 bool is_debuginfo_rpm(Header hdr);
 bool is_debugsource_rpm(Header hdr);

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -234,6 +234,7 @@ char *get_nevra(Header);
 const char *get_rpm_header_arch(Header);
 string_list_t *get_rpm_header_string_array(Header h, rpmTagVal tag);
 char *get_rpm_header_string_array_value(const rpmfile_entry_t *file, rpmTag tag);
+uint64_t get_rpm_header_num_array_value(const rpmfile_entry_t *file, rpmTag tag);
 char *extract_rpm_payload(const char *rpm);
 bool is_debuginfo_rpm(Header hdr);
 bool is_debugsource_rpm(Header hdr);

--- a/lib/files.c
+++ b/lib/files.c
@@ -286,9 +286,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         assert(file_entry != NULL);
 
         file_entry->rpm_header = hdr;
-        memcpy(&file_entry->st, archive_entry_stat(entry), sizeof(struct stat));
         file_entry->idx = path_entry->index;
-
         file_entry->localpath = strdup(archive_path);
         assert(file_entry->localpath);
 
@@ -298,6 +296,10 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
 #ifdef _WITH_LIBCAP
         file_entry->cap = NULL;
 #endif
+
+        memset(&(file_entry->st), 0, sizeof(file_entry->st));
+        file_entry->st.st_mode = get_rpm_header_num_array_value(file_entry, RPMTAG_FILEMODES);
+        file_entry->st.st_size = archive_entry_size(entry);
 
         TAILQ_INSERT_TAIL(file_list, file_entry, items);
 

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -44,7 +44,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Get the cap values */
-    after = get_rpm_header_value(file, RPMTAG_FILECAPS);
+    after = get_rpm_header_string_array_value(file, RPMTAG_FILECAPS);
 
     if (after && strcmp(after, "")) {
         aftercap = cap_from_text(after);
@@ -54,7 +54,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     if (file->peer_file) {
-        before = get_rpm_header_value(file->peer_file, RPMTAG_FILECAPS);
+        before = get_rpm_header_string_array_value(file->peer_file, RPMTAG_FILECAPS);
 
         if (before && strcmp(before, "")) {
             beforecap = cap_from_text(before);

--- a/lib/inspect_ownership.c
+++ b/lib/inspect_ownership.c
@@ -59,8 +59,8 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     arch = get_rpm_header_arch(file->rpm_header);
 
     /* Get the owner and group of the file */
-    owner = get_rpm_header_value(file, RPMTAG_FILEUSERNAME);
-    group = get_rpm_header_value(file, RPMTAG_FILEGROUPNAME);
+    owner = get_rpm_header_string_array_value(file, RPMTAG_FILEUSERNAME);
+    group = get_rpm_header_string_array_value(file, RPMTAG_FILEGROUPNAME);
 
     /* Set up result parameters */
     init_result_params(&params);
@@ -133,7 +133,7 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             if (strcmp(group, ri->bin_group)) {
 #ifdef _WITH_LIBCAP
                 /* Gather capabilities(7) for the file we need */
-                captext = get_rpm_header_value(file, RPMTAG_FILECAPS);
+                captext = get_rpm_header_string_array_value(file, RPMTAG_FILECAPS);
 
                 if (captext && strcmp(captext, "")) {
                     cap = cap_from_text(captext);
@@ -219,8 +219,8 @@ static bool ownership_driver(struct rpminspect *ri, rpmfile_entry_t *file)
      */
     if (!ignore && file->peer_file && (ri->tests & INSPECT_OWNERSHIP)) {
         /* Get the before file values */
-        before_owner = get_rpm_header_value(file->peer_file, RPMTAG_FILEUSERNAME);
-        before_group = get_rpm_header_value(file->peer_file, RPMTAG_FILEGROUPNAME);
+        before_owner = get_rpm_header_string_array_value(file->peer_file, RPMTAG_FILEUSERNAME);
+        before_group = get_rpm_header_string_array_value(file->peer_file, RPMTAG_FILEGROUPNAME);
 
         /* Determine if anything changed */
         if (strcmp(before_owner, owner)) {

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -285,6 +285,35 @@ char *get_rpm_header_string_array_value(const rpmfile_entry_t *file, rpmTag tag)
     return ret;
 }
 
+/*
+ * Given an RPM header tag, get that header tag array and return the
+ * string that matches the index value for this file.  That's complex,
+ * but some tags are arrays of strings (or ints) and what we need to
+ * do is first get the array, then knowing the index entry for the file
+ * we have, pull that array index out and return it.  NULL return means
+ * an empty value or the tag was not present in the header.
+ *
+ * Limitations:
+ * "tag" must refer to an h[] tag (see rpmtag.h from librpm)
+ * "file" must have a usable array index value (idx)
+ */
+uint64_t get_rpm_header_num_array_value(const rpmfile_entry_t *file, rpmTag tag)
+{
+    rpmtd td = NULL;
+    uint64_t ret = 0;
+
+    /* new header transaction */
+    if (_get_rpm_header_array_value_helper(&td, file, tag) != 0) {
+        return 0;
+    }
+
+    /* get the tag we are looking for and copy the value */
+    ret = rpmtdGetNumber(td);
+    rpmtdFree(td);
+
+    return ret;
+}
+
 /**
  * Given a path to an RPM package, extract the payload to a tar file
  * for later use with extract_rpm().  This happens in cases where


### PR DESCRIPTION
I was doing this for the owner and group, but not the modes.  I was just lifting that from the cpio stream.  But RPM keeps the file modes in the RPM header under the RPMTAG_FILEMODES array.  So read those and use that value for st.st_mode in extract_rpm().

Fixes: #1219 