### PR TITLE
[fix] Skip debuginfo and debugsource packages for explicit deps

### DIFF
--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -370,7 +370,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
             }
 
             /* report missing explicit package requires */
-            if (!found && potential_prov) {
+            if (!found && potential_prov && !is_debuginfo_rpm(h) && !is_debugsource_rpm(h)) {
                 r = strdeprule(req);
                 pn = headerGetString(potential_prov->after_hdr, RPMTAG_NAME);
 


### PR DESCRIPTION
When checking for explicit named Requires in packages when an autogenerated shared library dependency was found, skip debuginfo and debugsource packages since those are all automated anyway.  We only care about the explicit named Requires for the regular packages.

Fixes: #1208