### PR TITLE
Ignore 'unicode' config file section from user config files and display a warning

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -25,6 +25,9 @@ typedef bool (*parser_parse_file_fn)(parser_context **countext_out, const char *
 /* Deinitialize/deallocate a parser context. */
 typedef void (*parser_fini_fn)(parser_context *context);
 
+/* Returns true if the named section is present. */
+typedef bool (*parser_have_section_fn)(parser_context *context, const char *section);
+
 /*
  * Return a copy of the string at the specified position in the parsed
  * structure.  All structures are dictionary-like.  Pass NULL for the second
@@ -59,6 +62,7 @@ typedef struct {
     parser_parse_file_fn parse_file;
     parser_fini_fn fini;
 
+    parser_have_section_fn havesection;
     parser_getstr_fn getstr;
     parser_strarray_foreach_fn strarray_foreach;
     parser_strdict_foreach_fn strdict_foreach;

--- a/lib/parse_dson.c
+++ b/lib/parse_dson.c
@@ -93,6 +93,28 @@ static char *as_str(dson_value *v)
     return NULL;
 }
 
+static bool dson_have_section(parser_context *context, const char *section)
+{
+    size_t i = 0;
+    dson_value *tree = (dson_value *) context;
+
+    if (tree == NULL || section == NULL) {
+        return false;
+    }
+
+    if (tree->type != DSON_DICT) {
+        return false;
+    }
+
+    for (i = 0; tree->dict->keys[i] != NULL; i++) {
+        if (!strcmp(section, tree->dict->keys[i])) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static char *dson_getstr(parser_context *context, const char *key1, const char *key2)
 {
     dson_value *tree = (dson_value *) context;
@@ -188,6 +210,7 @@ parser_plugin dson_parser = {
     .name = "dson",
     .parse_file = dson_parse_file,
     .fini = dson_fini,
+    .havesection = dson_have_section,
     .getstr = dson_getstr,
     .strarray_foreach = dson_strarray_foreach,
     .strdict_foreach = dson_strdict_foreach,

--- a/lib/parse_json.c
+++ b/lib/parse_json.c
@@ -92,6 +92,26 @@ static json_object *getobj(json_object *jo, const char *key1, const char *key2)
     return getobj(cont, key2, NULL);
 }
 
+static bool json_have_section(parser_context *context, const char *section)
+{
+    json_object *jo = (json_object *) context;
+    json_object *cont = NULL;
+
+    if (jo == NULL || section == NULL) {
+        return false;
+    }
+
+    if (!json_object_is_type(jo, json_type_object)) {
+        return false;
+    }
+
+    if (json_object_object_get_ex(jo, section, &cont)) {
+        return true;
+    }
+
+    return false;
+}
+
 static char *json_getstr(parser_context *context, const char *key1, const char *key2)
 {
     json_object *jo = (json_object *) context;
@@ -193,6 +213,7 @@ parser_plugin json_parser = {
     .name = "json",
     .parse_file = json_parse_file,
     .fini = json_fini,
+    .havesection = json_have_section,
     .getstr = json_getstr,
     .strarray_foreach = json_strarray_foreach,
     .strdict_foreach = json_strdict_foreach,

--- a/lib/parse_yaml.c
+++ b/lib/parse_yaml.c
@@ -417,6 +417,24 @@ static y_value *getobj(y_value *y, const char *key1, const char *key2)
     return NULL;
 }
 
+static bool yaml_have_section(parser_context *context, const char *section)
+{
+    size_t i = 0;
+    y_value *y = (y_value *) context;
+
+    if (y == NULL || section == NULL) {
+        return false;
+    }
+
+    for (i = 0; y->v.dict.keys[i] != NULL; i++) {
+        if (!strcmp(section, y->v.dict.keys[i])) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static char *yaml_getstr(parser_context *context, const char *key1, const char *key2)
 {
     y_value *y = (y_value *) context;
@@ -544,6 +562,7 @@ parser_plugin yaml_parser = {
     .name = "yaml",
     .parse_file = yaml_parse_file,
     .fini = yaml_fini,
+    .havesection = yaml_have_section,
     .getstr = yaml_getstr,
     .strarray_foreach = yaml_strarray_foreach,
     .strdict_foreach = yaml_strdict_foreach,


### PR DESCRIPTION
Add a .havesection function to the config file parsers and extend read_cfgfile() to know if it is reading a system-wide config file or a user config file.

Fixes: #1150