### PR TITLE
[lib] Drop debugging warnx() from json_parse_file()

### DIFF
--- a/lib/parse_json.c
+++ b/lib/parse_json.c
@@ -27,7 +27,6 @@ static bool json_parse_file(parser_context **context_out, const char *filepath)
     jerr = json_tokener_get_error(tok);
 
     if (jerr != json_tokener_success) {
-        warnx("*** buf=|%s|\n", buf);
         warnx("*** json_tokener_parse_ex: %s", json_tokener_error_desc(jerr));
         goto done;
     }


### PR DESCRIPTION
This was a temporary thing that I did not mean to commit.