### PR TITLE
[fix] Set missing result params header in the runpath inspection

### DIFF
--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -261,6 +261,7 @@ static bool runpath_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         assert(arch != NULL);
 
         init_result_params(&params);
+        params.header = NAME_RUNPATH;
         params.severity = RESULT_BAD;
         params.waiverauth = NOT_WAIVABLE;
         params.remedy = REMEDY_RUNPATH_BOTH;


### PR DESCRIPTION
There was one result finding in the runpath inspection that was not setting the header field.  That led to a SIGSEGV in add_result_entry().

Fixes: #1239