### PR TITLE
[lib] Add support for 'wrapperRPM' builds in Koji

### DIFF
--- a/lib/builds.c
+++ b/lib/builds.c
@@ -760,8 +760,13 @@ static struct koji_build *get_koji_task_as_build(const struct koji_task *task)
 
     srpm = strdup(entry->data);
     assert(srpm != NULL);
-    nvr = strrchr(srpm, '/');
-    nvr++;
+
+    if (strrchr(srpm, '/')) {
+        nvr = strrchr(srpm, '/');
+        nvr++;
+    } else {
+        nvr = srpm;
+    }
 
     if (nvr == NULL) {
         free(srpm);


### PR DESCRIPTION
wrapperRPM build types are new to me, but one was reported and after digging in to the specifics it looked like something rpminspect can support.  From what I can see, a wrapperRPM build is a build submitted to Koji where the source is a git repo URL (like with a commit ID or tag).  The git repo contains a spec file and the other content for the RPM and Koji will construct the SRPM and do the mock build from that. The example I was given is for a qcow2 image in an RPM.  I don't know what we're using these for, but it's an RPM and rpminspect can read those.  The trick was extending the Koji XML-RPC communication in librpminspect to handle wrapperRPM builds.

Fixes: #1241