### PR TITLE
[fix] Improve the shellsyntax noun/verb result messages

### DIFF
--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -121,8 +121,6 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.header = NAME_SHELLSYNTAX;
     params.arch = arch;
     params.file = file->localpath;
-    params.verb = VERB_FAILED;
-    params.noun = _("invalid shell script ${FILE} on ${ARCH}");
 
     if (file->peer_file) {
         before_shell = get_shell(ri, file->peer_file->fullpath);
@@ -139,6 +137,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.waiverauth = NOT_WAIVABLE;
             params.remedy = REMEDY_SHELLSYNTAX_GAINED_SHELL;
             params.verb = VERB_OK;
+            params.noun = _("changed shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
         }
@@ -183,6 +182,8 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.waiverauth = WAIVABLE_BY_ANYONE;
             params.remedy = REMEDY_SHELLSYNTAX_BAD;
             params.details = errors;
+            params.verb = VERB_FAILED;
+            params.noun = _("invalid shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
             result = false;
@@ -198,6 +199,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.details = before_errors;
             params.remedy = NULL;
             params.verb = VERB_OK;
+            params.noun = _("valid shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
         } else if ((before_exitcode || before_errors) && (exitcode || errors)) {
@@ -206,6 +208,8 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.waiverauth = WAIVABLE_BY_ANYONE;
             params.remedy = REMEDY_SHELLSYNTAX_BAD;
             params.details = errors;
+            params.verb = VERB_FAILED;
+            params.noun = _("invalid shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
             result = false;
@@ -218,6 +222,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.details = NULL;
             params.remedy = NULL;
             params.verb = VERB_OK;
+            params.noun = _("valid shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
         } else if (exitcode || errors) {
@@ -226,6 +231,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.waiverauth = WAIVABLE_BY_ANYONE;
             params.details = errors;
             params.remedy = REMEDY_SHELLSYNTAX_BAD;
+            params.noun = _("invalid shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);
             result = false;


### PR DESCRIPTION
Some of these were too generic or copied from another result type. Make these more specific so you know what you're looking at in the results.  These are only for the 'summary' output format.