### PR TITLE
[fix] Assertion in modularity inspection when a package is removed

### DIFF
--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -310,7 +310,7 @@ bool inspect_modularity(struct rpminspect *ri)
      * - a conforming Release tag value
      */
     TAILQ_FOREACH(peer, ri->peers, items) {
-        if (!check_modularitylabel(ri, peer->after_hdr)) {
+        if (peer->after_hdr && !check_modularitylabel(ri, peer->after_hdr)) {
             tag_result = false;
         }
 


### PR DESCRIPTION
Ensure that the header passed to check_modularitylabel is not NULL. This can happen in comparative runs if the before build contains a package that the after build doesn't (due to removal). In such case a segfault would occur.

Fixes: #1238