### PR TITLE
[fix] Skip peers missing an after build in rpmdeps

### DIFF
--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -494,6 +494,10 @@ static bool check_explicit_epoch(struct rpminspect *ri, Header h, deprule_list_t
 
         /* find the package providing this deprule */
         TAILQ_FOREACH(peer, ri->peers, items) {
+            if (!peer->after_hdr) {
+                continue;
+            }
+
             name = headerGetString(peer->after_hdr, RPMTAG_NAME);
             assert(name != NULL);
 


### PR DESCRIPTION
I had this in place but lost it in the refactoring.