### PR TITLE
[fix] Memory leak fix in run_cmd_vp()

### DIFF
--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -180,9 +180,6 @@ char *run_cmd_vp(int *exitcode, const char *workdir, char **argv)
         return NULL;
     }
 
-    /* find the command */
-    cmd = find_cmd(argv[0]);
-
     /* run the command */
     proc = fork();
 
@@ -201,6 +198,9 @@ char *run_cmd_vp(int *exitcode, const char *workdir, char **argv)
 
         setlinebuf(stdout);
         setlinebuf(stderr);
+
+        /* find the command */
+        cmd = find_cmd(argv[0]);
 
         /* run the command */
         if (execvp(cmd, argv) == -1) {


### PR DESCRIPTION
Move the find_cmd() call in to the child process so we don't leak in the parent.