### PR TITLE
Use rpm_macro(autorelease) for Recommends

### DIFF
--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -86,7 +86,7 @@ Recommends:     html401-dtds
 
 # Required to support things like %%autorelease in spec files
 %if 0%{?fedora} >= 33
-Recommends:     rpmautospec-rpm-macros
+Recommends:     rpm_macro(autorelease)
 %endif
 
 # These programs are only required for the 'shellsyntax' functionality.


### PR DESCRIPTION
The %autorelease macro has moved in Fedora 39+ and rpminspect is failing the %{dist} check as a result. Use the generic form of the Provides instead of depending on the package name.

See also https://src.fedoraproject.org/rpms/rpminspect/pull-request/2