### PR TITLE
[fix] Allow %autorelease as the value in a Release tag

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -768,6 +768,14 @@
  */
 #define SPEC_DISTTAG           "%{?dist}"
 
+/**
+ * @def SPEC_AUTORELEASE
+ *
+ * The Release tag in a spec file may contain this token in place of
+ * an explicit release value and SPEC_DISTTAG.
+ */
+#define SPEC_AUTORELEASE       "%autorelease"
+
 /** @} */
 
 /**

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -166,6 +166,12 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         release++;
     }
 
+    /* Allow %autorelease as the Release tag value */
+    if (release && !strcmp(release, SPEC_AUTORELEASE)) {
+        list_free(contents, free);
+        return true;
+    }
+
     /* Expand macros in the release value */
     expanded_release = rpmExpand(release, NULL);
 


### PR DESCRIPTION
This is now a thing that is allowed in Release tags in spec files, so look for it and if we find it, be ok with it.

Fixes: #1258