### PR TITLE
[lib] Expand the desktop inspection with more configuration opts

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -361,6 +361,26 @@ desktop:
     # Where desktop entry files live
     desktop_entry_files_dir: /usr/share/applications
 
+    # Optional list of full paths to desktop files to skip the Exec=
+    # check for.  The Exec= check looks for the name value appearing
+    # as an executable in a subpackage for the build.  This is useful
+    # for some packages that provide both the application and desktop
+    # launcher, but some packages are theme oriented and may include a
+    # bunch of desktop files but no actual executables.  That is also
+    # allowed.  In those cases, the Exec= check can be skipped.
+    #skip_exec_check:
+    #    - /usr/share/applications/evolution-calendar.desktop
+
+    # Optional list of full paths to desktop files to skip the Icon=
+    # check for.  The Icon= check looks for the name value appearing
+    # as an icon image file in a subpackage for the build.  This is
+    # useful for some packages that provide both the icon and desktop
+    # launcher, but some packages are theme oriented and may include a
+    # bunch of desktop files but no actual icons.  That is also
+    # allowed.  In those cases, the Icon= check can be skipped.
+    #skip_icon_check:
+    #    - /usr/share/applications/evolution-calendar.desktop
+
     # Optional list of glob(7) specifications or path prefixes to
     # match files to ignore for this inspection.  The format of this
     # list is the same as the global 'ignore' list.  The difference is

--- a/include/init.h
+++ b/include/init.h
@@ -33,6 +33,8 @@
 #define RI_DESKTOP                  "desktop"
 #define RI_DESKTOP_ENTRY_FILES_DIR  "desktop_entry_files_dir"
 #define RI_DESKTOP_FILE_VALIDATE    "desktop-file-validate"
+#define RI_DESKTOP_SKIP_EXEC_CHECK  "skip_exec_check"
+#define RI_DESKTOP_SKIP_ICON_CHECK  "skip_icon_check"
 #define RI_DOC                      "doc"
 #define RI_DOWNLOAD_MBS             "download_mbs"
 #define RI_DOWNLOAD_URSINE          "download_ursine"

--- a/include/types.h
+++ b/include/types.h
@@ -462,6 +462,19 @@ typedef struct _applied_patches_t {
 } applied_patches_t;
 
 /*
+ * Hash table used to hold desktop files and what checks to skip.  And
+ * the flag values.
+ */
+#define SKIP_EXEC (1 << 1)
+#define SKIP_ICON (1 << 2)
+
+typedef struct _desktop_skips_t {
+    char *path;
+    unsigned int flags;
+    UT_hash_handle hh;
+} desktop_skips_t;
+
+/*
  * Configuration and state instance for librpminspect run.
  * Applications using librpminspect should initialize the
  * library and retain this structure through the run of
@@ -587,6 +600,9 @@ struct rpminspect {
 
     /* Where desktop entry files live */
     char *desktop_entry_files_dir;
+
+    /* Hash table of file paths and the desktop inspection checks to skip */
+    desktop_skips_t *desktop_skips;
 
     /* Executable path prefixes and required ownership */
     string_list_t *bin_paths;

--- a/lib/free.c
+++ b/lib/free.c
@@ -108,6 +108,8 @@ void free_rpminspect(struct rpminspect *ri)
     security_entry_t *sentry = NULL;
     secrule_t *srentry = NULL;
     secrule_t *tmp_srentry = NULL;
+    desktop_skips_t *dentry = NULL;
+    desktop_skips_t *tmp_dentry = NULL;
 
     if (ri == NULL) {
         return;
@@ -233,10 +235,15 @@ void free_rpminspect(struct rpminspect *ri)
     free(ri->manpage_path_exclude_pattern);
     free(ri->xml_path_include_pattern);
     free(ri->xml_path_exclude_pattern);
-
     free(ri->desktop_entry_files_dir);
-    free(ri->vendor);
 
+    HASH_ITER(hh, ri->desktop_skips, dentry, tmp_dentry) {
+        HASH_DEL(ri->desktop_skips, dentry);
+        free(dentry->path);
+        free(dentry);
+    }
+
+    free(ri->vendor);
     free(ri->commands.msgunfmt);
     free(ri->commands.desktop_file_validate);
     free(ri->commands.abidiff);


### PR DESCRIPTION
Allow the desktop configuration block to allow users to list paths to .desktop files to skip either the Exec= check or Icon= check.  This allows the desktop inspection to still run desktop-file-validate but skip the Exec and Icon checks when the subpackages do not carry either the application or icon file.