### PR TITLE
[fix] Read and cache the st_size for hard links

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -300,6 +300,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         memset(&(file_entry->st), 0, sizeof(file_entry->st));
         file_entry->st.st_mode = get_rpm_header_num_array_value(file_entry, RPMTAG_FILEMODES);
         file_entry->st.st_size = archive_entry_size(entry);
+        file_entry->st.st_nlink = archive_entry_nlink(entry);
 
         TAILQ_INSERT_TAIL(file_list, file_entry, items);
 
@@ -344,7 +345,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         archive_entry_set_perm(entry, archive_perm);
 
         /* If this is a hard link, update the hardlink destination path */
-        if (archive_entry_nlink(entry) > 1) {
+        if (file_entry->st.st_nlink > 1) {
             xasprintf(&hardlinkpath, "%s/%s", *output_dir, archive_entry_hardlink(entry));
             archive_entry_set_link(entry, hardlinkpath);
             free(hardlinkpath);


### PR DESCRIPTION
When extracting the RPM payload, hard links will have a zero length but a link count > 1.  In the filesize inspection, the size of hard links is incorrectly read as 0.  In the case of hard links, stat(2) the file to pick up the actual size and store that in the rpmfile_entry_t for use in other inspections.  Only give it one try as the actual extracted file may also be zero length.

Fixes: #1252