### PR TITLE
[cfg] Drop entries from the example global ignore list

### DIFF
--- a/data/generic.dson
+++ b/data/generic.dson
@@ -15,9 +15,6 @@ such "common" is such "workdir" is "/var/tmp/rpminspect",
                         "/etc/rpm/macros.*" and
                         "/etc/rpm/macros" and
                         "/etc/rpm/%{_target}/macros" many,
-     "ignore" is so "/usr/lib*/python?.?/site-packages/__pycache__" and
-                     "/usr/lib*/python?.?/site-packages/*/*.pyc" and
-                     "/usr/lib*/python?.?/site-packages/*/*.pyo" many,
      "security_path_prefix" is so "/etc/sudoers.d/" also
                                   "/etc/polkit-1/" also
                                   "/usr/share/polkit-1/actions/" many,

--- a/data/generic.json
+++ b/data/generic.json
@@ -26,11 +26,6 @@
     "/etc/rpm/macros",
     "/etc/rpm/%{_target}/macros"
   ],
-  "ignore": [
-    "/usr/lib*/python?.?/site-packages/__pycache__",
-    "/usr/lib*/python?.?/site-packages/*/*.pyc",
-    "/usr/lib*/python?.?/site-packages/*/*.pyo"
-  ],
   "security_path_prefix": [
     "/etc/sudoers.d/",
     "/etc/polkit-1/",

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -218,9 +218,7 @@ ignore:
     #
     # You can also add an entry that ends with a slash '/' and
     # rpminspect will treat it as a path prefix.
-    - /usr/lib*/python?.?/site-packages/__pycache__
-    - /usr/lib*/python?.?/site-packages/*/*.pyc
-    - /usr/lib*/python?.?/site-packages/*/*.pyo
+    #- /path/to/ignore
 
 security_path_prefix:
     # Optional: Path prefixes for files with security concerns.  This


### PR DESCRIPTION
These were the __pycache__, *.pyc, and *.pyo globs.  But now the block is empty in the example config files.