### PR TITLE
Use N_() for result strings in the patches inspection

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -67,7 +67,7 @@ extern volatile sig_atomic_t terminal_resized;
 #define N_(MSGID, MSGID_PLURAL, N) ngettext((MSGID), (MSGID_PLURAL), (N))
 #else
 #define _(MSGID) (MSGID)
-#define N_(MSGID, MSGID_PLURAL, N) (MSGID)
+#define N_(MSGID, MSGID_PLURAL, N) ((MSGID_PLURAL))
 #endif
 
 /*

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -63,11 +63,11 @@ extern volatile sig_atomic_t terminal_resized;
 #include <libintl.h>
 #include <locale.h>
 
-#define _(STRING) gettext(STRING)
-#define N_(STRING) ngettext(STRING)
+#define _(MSGID) gettext((MSGID))
+#define N_(MSGID, MSGID_PLURAL, N) ngettext((MSGID), (MSGID_PLURAL), (N))
 #else
-#define _(STRING) STRING
-#define N_(STRING) STRING
+#define _(MSGID) (MSGID)
+#define N_(MSGID, MSGID_PLURAL, N) (MSGID)
 #endif
 
 /*

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -552,11 +552,11 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.file = file->localpath;
 
     if (ps.files == 0 && ps.lines > 0) {
-        xasprintf(&params.msg, _("%s touches as many as %ld line%s"), file->localpath, ps.lines, (ps.lines > 1) ? "s" : "");
+        xasprintf(&params.msg, N_("%s touches %ld line", "%s touches as many as %ld lines", ps.lines), file->localpath, ps.lines);
     } else if (ps.files > 0 && ps.lines == 0) {
-        xasprintf(&params.msg, _("%s touches %ld file%s"), file->localpath, ps.files, (ps.files > 1) ? "s" : "");
+        xasprintf(&params.msg, N_("%s touches %ld file", "%s touches %ld files", ps.files), file->localpath, ps.files);
     } else {
-        xasprintf(&params.msg, _("%s touches %ld file%s and %s%ld line%s"), file->localpath, ps.files, (ps.files > 1) ? "s" : "", (ps.lines > 1) ? _("as many as ") : "", ps.lines, (ps.lines > 1) ? "s" : "");
+        xasprintf(&params.msg, _("%s touches %ld files and as many as %ld lines"), file->localpath, ps.files, ps.lines);
     }
 
     add_result(ri, &params);


### PR DESCRIPTION
The reporting in the patches inspection notes how many file(s) and/or line(s) a particular patch touches.  Handle the plural form of the result strings with the ngettext() function so that other languages can be translated correctly.
    
Fixes: #1268
