### PR TITLE
FreeBSD CI fixes and skip test_capabilities tests if rpm lacks %caps

### DIFF
--- a/osdeps/freebsd/defs.mk
+++ b/osdeps/freebsd/defs.mk
@@ -1,1 +1,1 @@
-PKG_CMD = pkg install -q -y
+PKG_CMD = env IGNORE_OSVERSION=yes pkg install -q -y

--- a/osdeps/freebsd/post.sh
+++ b/osdeps/freebsd/post.sh
@@ -7,12 +7,6 @@ rm -rf /usr/ports || :
 git clone https://git.freebsd.org/ports.git /usr/ports
 echo "DEFAULT_VERSIONS+=ssl=openssl" >> /etc/make.conf
 
-# Build rpm4 from ports since the binary package lacks 'elfdeps'
-cd /usr/ports/archivers/rpm4 || exit 1
-printf "Installing /usr/ports/archivers/rpm4 (logging to /root/rpm4.log)..."
-make BATCH=yes install >/root/rpm4.log 2>&1
-printf "done.\n"
-
 # https://github.com/rpm-software-management/rpm/pull/2459
 RPMTAG_HDR="/usr/local/include/rpm/rpmtag.h"
 grep RPM_MASK_RETURN_TYPE ${RPMTAG_HDR} 2>/dev/null | grep -q 0xffff0000 >/dev/null 2>&1

--- a/osdeps/freebsd/pre.sh
+++ b/osdeps/freebsd/pre.sh
@@ -5,4 +5,4 @@ PATH=/usr/bin:/usr/sbin
 echo "DEFAULT_VERSIONS+=ssl=openssl" >> /etc/make.conf
 
 # Bootstrap the pkg command
-pkg bootstrap -y
+env IGNORE_OSVERSION=yes pkg bootstrap -y

--- a/osdeps/freebsd/reqs.txt
+++ b/osdeps/freebsd/reqs.txt
@@ -37,6 +37,7 @@ pkgconf
 popt
 python3
 rc
+rpm4
 rust
 sqlite
 valgrind

--- a/test/test_capabilities.py
+++ b/test/test_capabilities.py
@@ -1059,12 +1059,14 @@ class ApprovedCapabilitiesBadOwnerCompareKoji(TestCompareKoji):
 
 
 class CapabilitiesFileOwnerChangedCompareRPMs(FileOwnerChangedCompareRPMs):
+    @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
         super().setUp()
         self.inspection = "capabilities"
 
 
 class CapabilitiesFileOwnerChangedCompareKoji(FileOwnerChangedCompareKoji):
+    @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
         super().setUp()
         self.inspection = "capabilities"
@@ -1074,12 +1076,14 @@ class CapabilitiesFileOwnerChangedCompareKoji(FileOwnerChangedCompareKoji):
 
 
 class CapabilitiesFileGroupChangedCompareRPMs(FileGroupChangedCompareRPMs):
+    @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
         super().setUp()
         self.inspection = "capabilities"
 
 
 class CapabilitiesFileGroupChangedCompareKoji(FileGroupChangedCompareKoji):
+    @unittest.skipUnless(have_caps_support, lack_caps_msg)
     def setUp(self):
         super().setUp()
         self.inspection = "capabilities"


### PR DESCRIPTION
FreeBSD CI job needed some updates.

There were some tests in test_capabilities.py that were not guarded by the skipUnless check to see that rpm has %caps support.