### PR TITLE
[ci] Small fixes for the CentOS 7 job

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -59,6 +59,7 @@ jobs:
                           dnf install -y epel-release git
                           ;;
                       *centos7)
+                          yum upgrade -y
                           yum install -y epel-release git
                           ;;
                   esac

--- a/osdeps/centos7/post.sh
+++ b/osdeps/centos7/post.sh
@@ -29,10 +29,10 @@ rpm -Uvh "${SRPM}" 2>/dev/null
 rm -f "${SRPM}"
 cd ~/rpmbuild/SPECS || exit 1
 sed -i -e 's|^Name:.*$|Name: python3-rpm-rebuild|g' python3-rpm.spec
-sed -i -e '/^test \-f.*\.egg-info$/ s/test\ \-f/test -d/' python3-rpm.spec
 # shellcheck disable=SC2046
 yum install -y $(rpmspec -q --buildrequires python3-rpm.spec)
 rpmbuild -ba \
+         --nocheck \
          --define "__python3 /usr/local/bin/python${PYTHON_VER}" \
          --define "python3_version ${PYTHON_VER}" \
          --define "python3_sitearch /usr/local/lib/python${PYTHON_VER}/site-packages" \

--- a/osdeps/centos7/reqs.txt
+++ b/osdeps/centos7/reqs.txt
@@ -28,6 +28,7 @@ libffi-devel
 libicu-devel
 libtool
 libxml2-devel
+libxslt-devel
 libyaml-devel
 make
 meson


### PR DESCRIPTION
Needed some more build dependencies for installation of Python modules.  And the python3-rpm rebuild stopped working, so simplify that so we get it installed in the test environment against a more recent Python.