### PR TITLE
[ci] Can't use distutils with Python 3.12 on CentOS 7

### DIFF
--- a/osdeps/centos7/post.sh
+++ b/osdeps/centos7/post.sh
@@ -29,6 +29,7 @@ rpm -Uvh "${SRPM}" 2>/dev/null
 rm -f "${SRPM}"
 cd ~/rpmbuild/SPECS || exit 1
 sed -i -e 's|^Name:.*$|Name: python3-rpm-rebuild|g' python3-rpm.spec
+sed -i -e "/%py3_build/a sed -i -e 's|distutils\.core|setuptools|g' setup.py" python3-rpm.spec
 # shellcheck disable=SC2046
 yum install -y $(rpmspec -q --buildrequires python3-rpm.spec)
 rpmbuild -ba \


### PR DESCRIPTION
The CentOS 7 job installs a newer Python in to /usr/local.  That's now 3.12, which has removed distutils.  Since the python3-rpm package on CentOS 7 uses rpm-4.11, the Python bindings have "from distutils.core" in the setup.py, we need to patch that so it builds with Python 3.12.