### PR TITLE
[lib] Note the summary output mode is now deprecated

### DIFF
--- a/lib/output_summary.c
+++ b/lib/output_summary.c
@@ -24,6 +24,8 @@ void output_summary(const results_t *results, const char *dest, __attribute__((u
     char *tmp = NULL;
     size_t width = tty_width();
 
+    fprintf(stderr, "*** DEPRECATION WARNING: the '-F summary' or '--format=summary' output mode is deprecated and will be removed in a future release.\n");
+
     /* output the results */
     TAILQ_FOREACH(result, results, items) {
         /* skip conditions */


### PR DESCRIPTION
The 'summary' output format is deprecated and will be removed in a future release.  I never really finished this output mode and no one seems to care, so I am going to remove it.