### PR TITLE
[bld] Allow vendor data dir and work dir to be set at build time

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -84,11 +84,16 @@
 #define SOFTWARE_NAME "librpminspect"
 
 /**
- * @def CFGFILE_DIR
+ * @def VENDOR_DATA_DIR
  *
- * Configuration file directory.
+ * Configuration file directory.  This is the location of the vendor
+ * data configuration files used by rpminspect.  There will be the
+ * main vendor configuration file followed by individual files in the
+ * subdirectories for different types of data.
  */
-#define CFGFILE_DIR "/usr/share/rpminspect"
+#ifndef VENDOR_DATA_DIR
+#define VENDOR_DATA_DIR "/usr/share/rpminspect"
+#endif
 
 /**
  * @def CFGFILE
@@ -116,7 +121,9 @@
  * subdirectories within this directory so multiple concurrent jobs
  * can run.
  */
+#ifndef DEFAULT_WORKDIR
 #define DEFAULT_WORKDIR "/var/tmp/rpminspect"
+#endif
 
 /**
  * @def ROOT_SUBDIR
@@ -140,14 +147,6 @@
  * The name of the after build subdirectory in the working directory.
  */
 #define AFTER_SUBDIR "after"
-
-/**
- * @def VENDOR_DATA_DIR
- *
- * Default location for the vendor-specific data.  These files should
- * be provided by the vendor-specific rpminspect-data package.
- */
-#define VENDOR_DATA_DIR "/usr/share/rpminspect"
 
 /**
  * @def INSPECTIONS
@@ -883,42 +882,42 @@
 /**
  * @def ELF_SYMTAB
  *
- * The '.symtab' ELF section.
+ * The '.symtab' ELF section name.
  */
 #define ELF_SYMTAB ".symtab"
 
 /**
  * @def ELF_GDB_INDEX
  *
- * The '.gdb_index' ELF section.
+ * The '.gdb_index' ELF section name.
  */
 #define ELF_GDB_INDEX ".gdb_index"
 
 /**
  * @def ELF_GNU_DEBUGDATA
  *
- * The '.gnu_debugdata' ELF section.
+ * The '.gnu_debugdata' ELF section name.
  */
 #define ELF_GNU_DEBUGDATA ".gnu_debugdata"
 
 /**
  * @def ELF_GNU_DEBUGLINK
  *
- * The '.gnu_debuglink' ELF section.
+ * The '.gnu_debuglink' ELF section name.
  */
 #define ELF_GNU_DEBUGLINK ".gnu_debuglink"
 
 /**
  * @def ELF_DEBUG_INFO
  *
- * The '.debug_info' ELF section.
+ * The '.debug_info' ELF section name.
  */
 #define ELF_DEBUG_INFO ".debug_info"
 
 /**
  * @def ELF_GOSYMTAB
  *
- * The '.gosymtab' ELF section.
+ * The '.gosymtab' ELF section name.
  */
 #define ELF_GOSYMTAB ".gosymtab"
 

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,9 @@ if build_machine.system() == 'netbsd'
     add_global_arguments('-Wno-pedantic', language : 'c')
 endif
 
+# Vendor data directory
+add_global_arguments('-DVENDOR_DATA_DIR="@0@"'.format(get_option('vendor_data_dir')), language : 'c')
+
 # Library search dirs
 search_dirs = [ '/usr/local/lib', '/usr/pkg/lib', '/usr/lib64', '/usr/lib' ]
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,7 +6,7 @@ option('tests',
 option('python_program',
        type : 'string',
        value : 'python3',
-       description : ' The basename of the Python 3 executable the build system should use')
+       description : 'The basename of the Python 3 executable the build system should use.')
 
 option('nls',
        type : 'boolean',
@@ -32,3 +32,13 @@ option('with_libannocheck',
        type : 'boolean',
        value : false,
        description : 'Enable libannocheck support for binary file analysis.  Disabling libannocheck support will also disable the annocheck inspection.')
+
+option('vendor_data_dir',
+       type : 'string',
+       value : '/usr/share/rpminspect',
+       description : 'The location of vendor data files for rpminspect.')
+
+option('default_workdir',
+       type : 'string',
+       value : '/var/tmp/rpminspect',
+       description : 'Default working directory used by rpminspect.')

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -616,7 +616,7 @@ int main(int argc, char **argv)
      * This loop also handles reading in multiple configuration files
      * for overrides.
      */
-    xasprintf(&tmp_cfgfile, "%s/%s", CFGFILE_DIR, CFGFILE);
+    xasprintf(&tmp_cfgfile, "%s/%s", VENDOR_DATA_DIR, CFGFILE);
 
     if (cfgfile == NULL && (access(tmp_cfgfile, F_OK|R_OK) == 0)) {
         /* /usr/share/rpminspect/rpminspect.yaml exists */


### PR DESCRIPTION
Previously the vendor data directory and the working directory were hardcoded and defined in the constants.h file.  The vendor data directory was set to /usr/share/rpminspect and the working directory was set to /var/tmp/rpminspect.  Those are still the defaults, but allow those locations to change at build time.