### PR TITLE
[fix] Fix a small error in the strtrim() function

### DIFF
--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -657,6 +657,8 @@ char *strtrim(char *s)
         i++;
     }
 
+    r[i] = '\0';
+
     /* go to the end and remove trailing whitespace */
     i = strlen(s);
 


### PR DESCRIPTION
In some cases the strtrim() function would not clear out characters as it shifted everything to the left.