### PR TITLE
[fix] Recognize source RPM packages in subpackages test

### DIFF
--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -38,13 +38,13 @@ bool inspect_subpackages(struct rpminspect *ri)
     TAILQ_FOREACH(peer, ri->peers, items) {
         if (peer->before_hdr) {
             entry = calloc(1, sizeof(*entry));
-            xasprintf(&entry->data, "%s %s", headerGetString(peer->before_hdr, RPMTAG_NAME), headerGetString(peer->before_hdr, RPMTAG_ARCH));
+            xasprintf(&entry->data, "%s %s", headerGetString(peer->before_hdr, RPMTAG_NAME), get_rpm_header_arch(peer->before_hdr));
             TAILQ_INSERT_TAIL(before_pkgs, entry, items);
         }
 
         if (peer->after_hdr) {
             entry = calloc(1, sizeof(*entry));
-            xasprintf(&entry->data, "%s %s", headerGetString(peer->after_hdr, RPMTAG_NAME), headerGetString(peer->after_hdr, RPMTAG_ARCH));
+            xasprintf(&entry->data, "%s %s", headerGetString(peer->after_hdr, RPMTAG_NAME), get_rpm_header_arch(peer->after_hdr));
             TAILQ_INSERT_TAIL(after_pkgs, entry, items);
         }
     }


### PR DESCRIPTION
If a subset of architectures including "src" was passed to rpminspect (e.g. -a x86_64,noarch,src), a subpackages test would fail if the source packages were built on different architectures (e.g. aarch64 and x86_64):

    Skipping specname inspection...      skip
    Running subpackages inspection...    FAIL
    Skipping symlinks inspection...      skip

The cause is that a source RPM package quotes an architecture where it was built in RPMTAG_ARCH tag, while rpminspect expected "src".

This patch fixes it by special-casing source packages.

In addition, if the source package was built on an unnamed (-a) architecture, the test logic reported an error without any details. This patch does not address this underreporting issue. A possible approach is moving "result = false" assignements into the if(allowed_arch()) branches in inspect_subpackages() function.

<https://centos.softwarefactory-project.io/zuul/t/centos/build/cb19599de10841c28ea3afb3ec2f1e7a>