### PR TITLE
Support new license DB format in the license inspection

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -24,6 +24,7 @@
 #include "results.h"
 #include "output.h"
 #include "readelf.h"
+#include "parser.h"
 
 #ifndef _LIBRPMINSPECT_RPMINSPECT_H
 #define _LIBRPMINSPECT_RPMINSPECT_H
@@ -536,5 +537,8 @@ char *human_size(const unsigned long int bytes);
  * @return Allocated path string that the caller must free.
  */
 char *joinpath(const char *path, ...);
+
+/* array.c */
+void array(parser_plugin *p, parser_context *ctx, const char *key1, const char *key2, string_list_t **list);
 
 #endif

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -149,6 +149,7 @@ string_list_t *list_from_array(const char **);
 bool list_contains(const string_list_t *, const char *);
 string_list_t *list_add(string_list_t *list, const char *s);
 void list_remove(string_list_t *list, const char *s);
+string_list_t *list_trim(string_list_t *list, const char *prefix);
 
 /* llvm.c */
 bool is_llvm_ir_bitcode(const char *file);

--- a/lib/array.c
+++ b/lib/array.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <stdbool.h>
+#include <assert.h>
+#include <err.h>
+#include "parser.h"
+#include "rpminspect.h"
+
+/**
+ * Given a string_list_t and a string, add the string to the list.  If
+ * the list is NULL, initialize it to start a new list.  Caller is
+ * responsible for freeing all memory associated with the list.
+ *
+ * @param list Pointer to a string_list_t to add entry to.
+ * @param s String to add to the string_list_t.
+ */
+static void add_entry(string_list_t **list, const char *s)
+{
+    assert(list != NULL);
+    assert(s != NULL);
+
+    if (*list != NULL && list_contains(*list, s)) {
+        /* do not add entry if it exists in the list */
+        return;
+    }
+
+    *list = list_add(*list, s);
+    return;
+}
+
+/* lambda for array() below. */
+static bool array_cb(const char *entry, void *cb_data)
+{
+    string_list_t **list = cb_data;
+    add_entry(list, entry);
+    return false;
+}
+
+/* Transform configuration's array into a string_list_t. */
+void array(parser_plugin *p, parser_context *ctx, const char *key1, const char *key2, string_list_t **list)
+{
+    if (p->strarray_foreach(ctx, key1, key2, array_cb, list)) {
+        warnx(_("*** problem adding entries to array %s->%s"), key1, key2);
+    }
+
+    return;
+}

--- a/lib/array.c
+++ b/lib/array.c
@@ -42,7 +42,7 @@ static bool array_cb(const char *entry, void *cb_data)
 /* Transform configuration's array into a string_list_t. */
 void array(parser_plugin *p, parser_context *ctx, const char *key1, const char *key2, string_list_t **list)
 {
-    if (key1 == NULL || key2 == NULL) {
+    if (key1 == NULL) {
         return;
     }
 

--- a/lib/array.c
+++ b/lib/array.c
@@ -42,6 +42,10 @@ static bool array_cb(const char *entry, void *cb_data)
 /* Transform configuration's array into a string_list_t. */
 void array(parser_plugin *p, parser_context *ctx, const char *key1, const char *key2, string_list_t **list)
 {
+    if (key1 == NULL || key2 == NULL) {
+        return;
+    }
+
     if (p->strarray_foreach(ctx, key1, key2, array_cb, list)) {
         warnx(_("*** problem adding entries to array %s->%s"), key1, key2);
     }

--- a/lib/init.c
+++ b/lib/init.c
@@ -91,28 +91,6 @@ static int add_regex(const char *pattern, regex_t **regex_out)
     return 0;
 }
 
-/**
- * Given a string_list_t and a string, add the string to the list.  If
- * the list is NULL, initialize it to start a new list.  Caller is
- * responsible for freeing all memory associated with the list.
- *
- * @param list Pointer to a string_list_t to add entry to.
- * @param s String to add to the string_list_t.
- */
-static void add_entry(string_list_t **list, const char *s)
-{
-    assert(list != NULL);
-    assert(s != NULL);
-
-    if (*list != NULL && list_contains(*list, s)) {
-        /* do not add entry if it exists in the list */
-        return;
-    }
-
-    *list = list_add(*list, s);
-    return;
-}
-
 /*
  * Given an inspection identifier from the config file reader and a
  * list value, add it to the per-inspection list of ignores.
@@ -361,24 +339,6 @@ static inline void strget(parser_plugin *p, parser_context *ctx, const char *key
 
     free(*dest);
     *dest = res;
-    return;
-}
-
-/* lambda for array() below. */
-static bool array_cb(const char *entry, void *cb_data)
-{
-    string_list_t **list = cb_data;
-    add_entry(list, entry);
-    return false;
-}
-
-/* Transform configuration's array into a string_list_t. */
-static inline void array(parser_plugin *p, parser_context *ctx, const char *key1, const char *key2, string_list_t **list)
-{
-    if (p->strarray_foreach(ctx, key1, key2, array_cb, list)) {
-        warnx(_("*** problem adding entries to array %s->%s"), key1, key2);
-    }
-
     return;
 }
 

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -150,8 +150,11 @@ static bool lic_cb(const char *license_name, void *cb_data)
     if (!approved) {
         /* invalid - do nothing */
         goto done;
-    } else if ((!strcmp(lic, spdx_abbrev) || list_contains(fedora_abbrev, lic)) ||
-               (list_len(fedora_abbrev) == 0 && (spdx_abbrev == NULL || strlen(spdx_abbrev) == 0) && list_contains(fedora_name, lic))) {
+    } else if (spdx_abbrev && !strcmp(lic, spdx_abbrev)) {
+        /* SPDX identifier matched */
+        data->valid = true;
+    } else if (list_contains(fedora_abbrev, lic) || (list_len(fedora_abbrev) == 0 && spdx_abbrev == NULL && list_contains(fedora_name, lic))) {
+        /* Old Fedora abbreviation matches -or- there are no Fedora abbreviations but a Fedora name matches */
         data->valid = true;
     }
 

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -407,7 +407,7 @@ string_list_t *list_add(string_list_t *list, const char *s)
 {
     string_entry_t *entry = NULL;
 
-    if (s == NULL) {
+    if (s == NULL || (s && !strcmp(s, ""))) {
         return list;
     }
 

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -447,3 +447,38 @@ void list_remove(string_list_t *list, const char *s)
 
     return;
 }
+
+/*
+ * Given a string_list_t, trim out any empty list members.
+ * Optionally, trim out any list members with a string prefix matching
+ * prefix.  Modifies the list in place and returns a pointer to the
+ * list.
+ */
+string_list_t *list_trim(string_list_t *list, const char *prefix)
+{
+    string_entry_t *entry = NULL;
+
+    if (list == NULL) {
+        return list;
+    }
+
+    if (list_len(list)) {
+        TAILQ_FOREACH(entry, list, items) {
+            if (entry->data == NULL) {
+                TAILQ_REMOVE(list, entry, items);
+                free(entry);
+            } else if (!strcmp(entry->data, "") || (prefix && strprefix(entry->data, prefix))) {
+                TAILQ_REMOVE(list, entry, items);
+                free(entry->data);
+                free(entry);
+            }
+        }
+    }
+
+    if (TAILQ_EMPTY(list)) {
+        free(list);
+        list = NULL;
+    }
+
+    return list;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -16,6 +16,7 @@ librpminspect_sources = [
     'abi.c',
     'abspath.c',
     'arches.c',
+    'array.c',
     'badwords.c',
     'builds.c',
     'checksums.c',

--- a/lib/parse_dson.c
+++ b/lib/parse_dson.c
@@ -70,7 +70,11 @@ static char *as_str(dson_value *v)
     if (v == NULL) {
         return NULL;
     } else if (v->type == DSON_STRING) {
-        return strdup(v->s);
+        if (!strcmp(v->s, "")) {
+            return NULL;
+        } else {
+            return strdup(v->s);
+        }
     } else if (v->type == DSON_BOOL) {
         if (v->b) {
             return strdup("true");

--- a/lib/parse_json.c
+++ b/lib/parse_json.c
@@ -52,6 +52,7 @@ static char *as_str(json_object *jo)
 {
     json_type type = json_type_null;
     char *out = NULL;
+    const char *s = NULL;
 
     type = json_object_get_type(jo);
 
@@ -68,7 +69,13 @@ static char *as_str(json_object *jo)
         xasprintf(&out, "%"PRId32, json_object_get_int(jo));
         return out;
     } else if (type == json_type_string) {
-        return strdup(json_object_get_string(jo));
+        s = json_object_get_string(jo);
+
+        if (!strcmp(s, "")) {
+            return NULL;
+        } else {
+            return strdup(s);
+        }
     }
 
     return NULL;

--- a/lib/parse_yaml.c
+++ b/lib/parse_yaml.c
@@ -464,8 +464,7 @@ static bool yaml_strarray_foreach(parser_context *context, const char *key1, con
     }
 
     for (i = 0; arrobj->v.array[i] != NULL; i++) {
-        if (arrobj->v.array[i]->type != Y_STRING ||
-            lambda(arrobj->v.array[i]->v.string, cb_data)) {
+        if (arrobj->v.array[i]->type != Y_STRING || lambda(arrobj->v.array[i]->v.string, cb_data)) {
             return true;
         }
     }

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,12 +26,12 @@ option('with_libcap',
 option('with_annocheck',
        type : 'boolean',
        value : true,
-       description : 'Enable annocheck(1) support for binary file analysis.  Disabling annocheck(1) support will also disable the annocheck inspection.')
+       description : 'Use annocheck(1) rather than libannocheck for binary file analysis.  Mutually exclusive with the with_libannocheck option.  Disabling both annocheck options will disable the annocheck inspection.')
 
 option('with_libannocheck',
        type : 'boolean',
        value : false,
-       description : 'Enable libannocheck support for binary file analysis.  Disabling libannocheck support will also disable the annocheck inspection.')
+       description : 'Use libannocheck rather than annocheck(1) for binary file analysis.  Mutually exclusive with the with_annocheck option.  Disabling both annocheck options will disable the annocheck inspection.')
 
 option('vendor_data_dir',
        type : 'string',

--- a/test/data/licenses/test.json
+++ b/test/data/licenses/test.json
@@ -136,5 +136,32 @@
     "fedora_abbrev": "",
     "fedora_name": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
     "spdx_abbrev": "",
+  },
+  "23": {
+    "license": {
+      "expression": "0BSD",
+      "status": [
+        "allowed"
+      ],
+      "url": "https://fedoraproject.org/wiki/Licensing/ZeroClauseBSD"
+    },
+    "fedora": {
+      "legacy-name": [
+        "Zero-Clause BSD"
+      ],
+      "legacy-abbreviation": [
+        "0BSD"
+      ]
+    }
+  },
+  "24": {
+    "license": {
+      "expression": "APSL-1.2",
+      "status": [
+        "not-allowed"
+      ],
+      "url": "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.2"
+    },
+    "fedora": {}
   }
 }

--- a/test/test_annocheck.py
+++ b/test/test_annocheck.py
@@ -23,7 +23,9 @@ class AnnocheckHardenedCompareRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
 
-        if os.path.isfile("/etc/slackware-version"):
+        if os.path.isfile("/etc/slackware-version") or os.path.isfile(
+            "/etc/fedora-release"
+        ):
             self.extra_cfg = {}
             self.extra_cfg["annocheck"] = {}
             self.extra_cfg["annocheck"]["jobs"] = [
@@ -46,7 +48,9 @@ class AnnocheckHardenedCompareKoji(TestCompareKoji):
     def setUp(self):
         super().setUp()
 
-        if os.path.isfile("/etc/slackware-version"):
+        if os.path.isfile("/etc/slackware-version") or os.path.isfile(
+            "/etc/fedora-release"
+        ):
             self.extra_cfg = {}
             self.extra_cfg["annocheck"] = {}
             self.extra_cfg["annocheck"]["jobs"] = [
@@ -95,7 +99,9 @@ class AnnocheckHardenedRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
 
-        if os.path.isfile("/etc/slackware-version"):
+        if os.path.isfile("/etc/slackware-version") or os.path.isfile(
+            "/etc/fedora-release"
+        ):
             self.extra_cfg = {}
             self.extra_cfg["annocheck"] = {}
             self.extra_cfg["annocheck"]["jobs"] = [
@@ -117,7 +123,9 @@ class AnnocheckHardenedKoji(TestKoji):
     def setUp(self):
         super().setUp()
 
-        if os.path.isfile("/etc/slackware-version"):
+        if os.path.isfile("/etc/slackware-version") or os.path.isfile(
+            "/etc/fedora-release"
+        ):
             self.extra_cfg = {}
             self.extra_cfg["annocheck"] = {}
             self.extra_cfg["annocheck"]["jobs"] = [

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -340,3 +340,57 @@ class InvalidUseOfLicenseStringKoji(TestKoji):
         self.inspection = "license"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
+
+
+class AllowedNewDBFormatLicenseSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("0BSD")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class AllowedNewDBFormatLicenseRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("0BSD")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class AllowedNewDBFormatLicenseKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("0BSD")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class NotAllowedNewDBFormatLicenseSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("APSL-1.2")
+        self.inspection = "license"
+        self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
+
+
+class NotAllowedNewDBFormatLicenseRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("APSL-1.2")
+        self.inspection = "license"
+        self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
+
+
+class NotAllowedNewDBFormatLicenseKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("APSL-1.2")
+        self.inspection = "license"
+        self.result = "BAD"
+        self.waiver_auth = "Not Waivable"

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -281,7 +281,7 @@ class ValidPerlHTTPMessageLicenseTagKoji(TestKoji):
 
 
 # Valid License string without any official abbreviations (OK)
-class ValidLoremIpsonLicenseTagSRPM(TestSRPM):
+class ValidLoremIpsumLicenseTagSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
         self.rpm.addLicense(
@@ -292,7 +292,7 @@ class ValidLoremIpsonLicenseTagSRPM(TestSRPM):
         self.waiver_auth = "Not Waivable"
 
 
-class ValidLoremIpsonLicenseTagRPMs(TestRPMs):
+class ValidLoremIpsumLicenseTagRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
         self.rpm.addLicense(
@@ -303,7 +303,7 @@ class ValidLoremIpsonLicenseTagRPMs(TestRPMs):
         self.waiver_auth = "Not Waivable"
 
 
-class ValidLoremIpsonLicenseTagKoji(TestKoji):
+class ValidLoremIpsumLicenseTagKoji(TestKoji):
     def setUp(self):
         super().setUp()
         self.rpm.addLicense(


### PR DESCRIPTION
The fedora-license-data project wants to change the JSON data format:

https://gitlab.com/fedora/legal/fedora-license-data/-/issues/387

The format of the config file is effectively an API.  There's no versioning and there's no way to tell what config file format you are looking at.  I personally view this as an inappropriate change.  However, I don't control fedora-license-data and that was the whole point of getting that project going.

This massive patch set splits out some JSON handling from init.c in public API so it can be used by the license inspection.  I have modified the license inspection to try reading license db blocks in the new format first and if that fails, fall back on the old format.  Without any versioning information obtainable from the config file, there does not appear to be a clean way to do it otherwise.  Both config file formats exist in the wild, so supporting both while favoring the new format makes the most sense to me.

I have added some test cases as well to test the new db format in the license inspection.

During this work I also ran in to some test suite failures on Fedora and the annocheck inspection, so that's why there are commits to test_annocheck.py.

Sadly, this is not the last license inspection update.  The next patch (simpler) is to honor the forthcoming exceptions array in the db.  This is to handle cases where fedora-license-data records a license as not-allowed for Fedora, oh except for the things we consider exceptions.