### PR TITLE
[fix] Recognize source RPM packages in arch test

### DIFF
--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -46,8 +46,8 @@ bool inspect_arch(struct rpminspect *ri)
             continue;
         }
 
-        before_arch = headerGetString(peer->before_hdr, RPMTAG_ARCH);
-        after_arch = headerGetString(peer->after_hdr, RPMTAG_ARCH);
+        before_arch = get_rpm_header_arch(peer->before_hdr);
+        after_arch = get_rpm_header_arch(peer->after_hdr);
 
         /*
          * loss of a noarch package is not something this inspection


### PR DESCRIPTION
If a subset of architectures including "src" was passed to rpminspect (e.g. -a x86_64,noarch,src), an arch test would fail if the source packages were built on different architectures (e.g. aarch64 and x86_64):

    Skipping annocheck inspection...     skip
    Running arch inspection...           FAIL
    Skipping badfuncs inspection...      skip

The cause is that a source RPM package quotes an architecture where it was built in RPMTAG_ARCH tag, while rpminspect expected "src".

This patch fixes it by using get_rpm_header_arch() which handles source packages correctly. This is similar to
79cbb84f3bd60889dbcf4ddfc7d1d2a714cf5442 commit.

<https://centos.softwarefactory-project.io/zuul/t/centos/build/be28da8c6aa7440780e5dc8cf5d36b67>