### PR TITLE
[fix] Make sure the license check honors "allowed-*" licenses

### DIFF
--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -99,7 +99,7 @@ static bool lic_cb(const char *license_name, void *cb_data)
 
         if (list_len(slist)) {
             TAILQ_FOREACH(entry, slist, items) {
-                if (!strcmp(entry->data, "allowed")) {
+                if (!strcmp(entry->data, "allowed") || strprefix(entry->data, "allowed-")) {
                     approved = true;
                     break;
                 }


### PR DESCRIPTION
Some allowed categories are more finegrained, so the license needs to account for this in the license database.