### PR TITLE
[lib] Honor packages_with_exceptions in the license database file

### DIFF
--- a/lib/inspect_udevrules.c
+++ b/lib/inspect_udevrules.c
@@ -59,7 +59,7 @@ static bool is_udev_rules_file(struct rpminspect *ri, const rpmfile_entry_t *fil
 static char *run_udevadm_verify(int *exitcode, const struct rpminspect *ri, const char *arg)
 {
     return run_cmd(exitcode, ri->worksubdir, ri->commands.udevadm, "verify",
-                   "--no-summary", "--resolve-names=never", arg, NULL);
+                   "--no-summary", "--no-style", "--resolve-names=never", arg, NULL);
 }
 
 static bool udevrules_driver(struct rpminspect *ri, rpmfile_entry_t *file)

--- a/test/data/licenses/test.json
+++ b/test/data/licenses/test.json
@@ -163,5 +163,17 @@
       "url": "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.2"
     },
     "fedora": {}
+  },
+  "25": {
+    "license": {
+      "expression": "DERP",
+      "status": [
+        "not-allowed"
+      ],
+      "packages_with_exceptions": [
+        "vaporware"
+      ]
+    },
+    "fedora": {}
   }
 }

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -394,3 +394,35 @@ class NotAllowedNewDBFormatLicenseKoji(TestKoji):
         self.inspection = "license"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
+
+
+class NotAllowedExceptionLicenseSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("DERP")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class NotAllowedExceptionLicenseRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("DERP")
+        self.inspection = "license"
+
+        # this is a failure while the others are not because when
+        # comparing two RPMs we do not have the corresponding SRPM to
+        # get the source package name, which is what would be in the
+        # package_with_exceptions array in the license database
+        self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
+
+
+class NotAllowedExceptionLicenseKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("DERP")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
The license database can carry an optional list of source package names that are exceptions to licenses marked as "not-allowed".  This patch checks to see if a not-allowed license is present in a package listed in packages_with_exceptions and considers that passing.

Fixes: #1286