### PR TITLE
Fix segfault in license inspection and close memory leaks

### DIFF
--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -122,8 +122,14 @@ static bool lic_cb(const char *license_name, void *cb_data)
         approved = false;
 
         /* the new API format failed, fall back on the legacy format */
-        fedora_abbrev = list_add(fedora_abbrev, p->getstr(db, license_name, "fedora_abbrev"));
-        fedora_name = list_add(fedora_name, p->getstr(db, license_name, "fedora_name"));
+        t = p->getstr(db, license_name, "fedora_abbrev");
+        fedora_abbrev = list_add(fedora_abbrev, t);
+        free(t);
+
+        t = p->getstr(db, license_name, "fedora_name");
+        fedora_name = list_add(fedora_name, t);
+        free(t);
+
         spdx_abbrev = p->getstr(db, license_name, "spdx_abbrev");
 
         t = p->getstr(db, license_name, "approved");
@@ -133,6 +139,8 @@ static bool lic_cb(const char *license_name, void *cb_data)
         } else {
             approved = false;
         }
+
+        free(t);
     }
 
     /* Handle "commented out" fields - not proper JSON, but I'm not a cop. */

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -457,13 +457,18 @@ void list_remove(string_list_t *list, const char *s)
 string_list_t *list_trim(string_list_t *list, const char *prefix)
 {
     string_entry_t *entry = NULL;
+    string_entry_t *next = NULL;
 
     if (list == NULL) {
         return list;
     }
 
     if (list_len(list)) {
-        TAILQ_FOREACH(entry, list, items) {
+        entry = TAILQ_FIRST(list);
+
+        while (entry) {
+            next = TAILQ_NEXT(entry, items);
+
             if (entry->data == NULL) {
                 TAILQ_REMOVE(list, entry, items);
                 free(entry);
@@ -472,6 +477,8 @@ string_list_t *list_trim(string_list_t *list, const char *prefix)
                 free(entry->data);
                 free(entry);
             }
+
+            entry = next;
         }
     }
 


### PR DESCRIPTION
Can't iterate over a tailq if you free the current entry.  Change how list_trim() works.  Also plug some memory leaks in lib_cb().