### PR TITLE
[fix] In removedfiles, report removed files at VERIFY on non-rebases

### DIFF
--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -108,7 +108,11 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (sentry || params.waiverauth == WAIVABLE_BY_SECURITY) {
             params.severity = get_secrule_result_severity(ri, file, SECRULE_SECURITYPATH);
         } else {
-            params.severity = RESULT_INFO;
+            if (rebase) {
+                params.severity = RESULT_INFO;
+            } else {
+                params.severity = RESULT_VERIFY;
+            }
         }
 
         if (params.severity <= RESULT_INFO) {

--- a/test/test_removedfiles.py
+++ b/test/test_removedfiles.py
@@ -62,6 +62,23 @@ class FileRemovedRPMs(TestCompareRPMs):
         )
 
         self.inspection = "removedfiles"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"
+
+
+class FileRemovedRebaseRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp(rebase=True)
+
+        with open(os.environ["RPMINSPECT"], "rb") as f:
+            before_src = f.read()
+
+        # create the test packages
+        self.before_rpm.add_installed_file(
+            "usr/bin/mount", rpmfluff.SourceFile("mount.bin", before_src), mode="0755"
+        )
+
+        self.inspection = "removedfiles"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
 
@@ -97,4 +114,22 @@ class FileRemovedKoji(TestCompareKoji):
         )
 
         self.inspection = "removedfiles"
-        self.result = "OK"
+        self.result = "VERIFY"
+        self.waiver_auth = "Anyone"
+
+
+class FileRemovedRebaseKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp(rebase=True)
+
+        with open(os.environ["RPMINSPECT"], "rb") as f:
+            before_src = f.read()
+
+        # create the test packages
+        self.before_rpm.add_installed_file(
+            "usr/bin/mount", rpmfluff.SourceFile("mount.bin", before_src), mode="0755"
+        )
+
+        self.inspection = "removedfiles"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
If two builds are being compared and they are not a rebase, report removed files at the VERIFY level.  For rebased comparisons, continue reporting at the INFO level.

Fixes: #1300