### PR TITLE
Modify headers to work with C++ projects; add C++ test case

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -148,6 +148,6 @@ jobs:
                   fi
 
                   make instreqs OSDEPS_ARCH=i686
-                  env CFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig make debug
+                  env CFLAGS="-m32" CXXFLAGS="-m32" LDFLAGS="-m32" PKG_CONFIG_PATH=/usr/lib/pkgconfig make debug
                   make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/include/compat/meson.build
+++ b/include/compat/meson.build
@@ -1,0 +1,4 @@
+install_headers(
+    'queue.h',
+    subdir : 'librpminspect/compat'
+)

--- a/include/constants.h
+++ b/include/constants.h
@@ -11,6 +11,11 @@
  * @copyright LGPL-3.0-or-later
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _LIBRPMINSPECT_CONSTANTS_H
 #define _LIBRPMINSPECT_CONSTANTS_H
 
@@ -947,4 +952,8 @@
 
 /** @} */
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/init.h
+++ b/include/init.h
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _LIBRPMINSPECT_INIT_H
 #define _LIBRPMINSPECT_INIT_H
 
@@ -151,4 +156,8 @@
 #define RI_WORKDIR                  "workdir"
 #define RI_XML                      "xml"
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -20,6 +20,11 @@
  * driver simple.
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -1622,4 +1627,8 @@ bool inspect_udevrules(struct rpminspect *ri);
 
 /** @} */
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/internal/callbacks.h
+++ b/include/internal/callbacks.h
@@ -7,6 +7,11 @@
  * Internal structures used for passing context information to callbacks
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _LIBRPMINSPECT_CALLBACKS_H
 #define _LIBRPMINSPECT_CALLBACKS_H
 
@@ -35,3 +40,7 @@ typedef struct {
 } lic_cb_data;
 
 #endif /* _LIBRPMINSPECT_CALLBACKS_H */
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/internal/tyranny.h
+++ b/include/internal/tyranny.h
@@ -6,6 +6,11 @@
 /* This file is derived from libtyranny:
  * https://github.com/frozencemetery/libtyranny/ */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _LIBRPMINSPECT_TYRANNY_H
 #define _LIBRPMINSPECT_TYRANNY_H
 
@@ -43,3 +48,7 @@ typedef struct {
 } context;
 
 #endif /* _LIBRPMINSPECT_TYRANNY_H */
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,9 +1,10 @@
-# Install header files
 install_headers(
     'constants.h',
     'init.h',
     'inspect.h',
     'output.h',
+    'parser.h',
+    'queue.h',
     'readelf.h',
     'results.h',
     'rpminspect.h',
@@ -12,3 +13,5 @@ install_headers(
     'uthash.h',
     subdir : 'librpminspect'
 )
+
+subdir('compat')

--- a/include/output.h
+++ b/include/output.h
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _LIBRPMINSPECT_OUTPUT_H
 #define _LIBRPMINSPECT_OUTPUT_H
 
@@ -44,4 +49,8 @@
 
 /** @} */
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -10,6 +10,11 @@
  * false otherwise.
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _LIBRPMINSPECT_PARSER_H
 #define _LIBRPMINSPECT_PARSER_H
 
@@ -96,3 +101,7 @@ static inline bool parse_agnostic(const char *filename, parser_plugin **plugin_o
 }
 
 #endif /* _LIBRPMINSPECT_PARSER_H */
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/queue.h
+++ b/include/queue.h
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _QUEUE_H
 #define _QUEUE_H
 
@@ -13,4 +18,8 @@
 #include <sys/queue.h>
 #endif
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/readelf.h
+++ b/include/readelf.h
@@ -11,6 +11,11 @@
  * @copyright LGPL-3.0-or-later
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _READELF_H
 #define _READELF_H
 
@@ -375,4 +380,8 @@ void elf_archive_iterate(int fd, Elf *archive, elf_ar_action action, string_list
 
 /** @} */
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/results.h
+++ b/include/results.h
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _LIBRPMINSPECT_RESULTS_H
 #define _LIBRPMINSPECT_RESULTS_H
 
@@ -791,4 +796,8 @@
 
 /** @} */
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -7,6 +7,11 @@
  * This header includes the API definition for librpminspect.
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdbool.h>
 #include <sys/types.h>
 #include <signal.h>
@@ -447,7 +452,7 @@ deprule_list_t *gather_deprules(Header hdr, deprule_ignore_map_t *ignores);
 void find_deprule_peers(deprule_list_t *before, deprule_list_t *after);
 const char *get_deprule_desc(const dep_type_t type);
 dep_op_t get_dep_operator(const rpmsenseFlags f);
-const char *get_deprule_operator_desc(const dep_op_t operator);
+const char *get_deprule_operator_desc(const dep_op_t op);
 bool deprules_match(const deprule_entry_t *a, const deprule_entry_t *b);
 char *strdeprule(const deprule_entry_t *deprule);
 
@@ -542,4 +547,8 @@ char *joinpath(const char *path, ...);
 /* array.c */
 void array(parser_plugin *p, parser_context *ctx, const char *key1, const char *key2, string_list_t **list);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/secrules.h
+++ b/include/secrules.h
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _LIBRPMINSPECT_SECRULES_H
 #define _LIBRPMINSPECT_SECRULES_H
 
@@ -93,4 +98,8 @@ typedef enum _secrule_type_t {
     SECRULE_UNICODE = 12
 } secrule_type_t;
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -7,6 +7,11 @@
  * This header defines types used by librpminspect
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <regex.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -153,10 +158,10 @@ typedef enum _dep_op_t {
 typedef struct _deprule_entry_t {
     dep_type_t type;                       /* dependency type */
     char *requirement;                     /* dependency requirement name (e.g., glibc or /bin/sh) */
-    dep_op_t operator;                     /* dependency operator (e.g., >, >=) */
+    dep_op_t op;                           /* dependency operator (e.g., >, >=) */
     char *version;                         /* dependency version */
     bool rich;                             /* true if this dep is a rich dependency */
-    bool explicit;                         /* true if this dep is matched for automatic shared lib deps */
+    bool direct;                           /* true if this dep is matched for automatic shared lib deps */
     string_list_t *providers;              /* for TYPE_REQUIRES, list of subpackages providing it */
     struct _deprule_entry_t *peer_deprule; /* corresponding before/after deprule */
     TAILQ_ENTRY(_deprule_entry_t) items;
@@ -1128,4 +1133,8 @@ typedef struct _patchstat_t {
     long int lines;
 } patchstat_t;
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -154,7 +154,7 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
             deprule_entry->requirement = strdup(r);
             assert(deprule_entry->requirement != NULL);
 
-            deprule_entry->operator = get_dep_operator(*(rpmtdGetUint32(op)));
+            deprule_entry->op = get_dep_operator(*(rpmtdGetUint32(op)));
 
             if (!strcmp(v, "")) {
                 deprule_entry->version = NULL;
@@ -164,7 +164,7 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
             }
 
             deprule_entry->rich = is_rich_dep(deprule_entry->requirement);
-            deprule_entry->explicit = false;
+            deprule_entry->direct = false;
 
             TAILQ_INSERT_TAIL(deprules, deprule_entry, items);
         }
@@ -243,7 +243,7 @@ static bool process_pair(deprule_entry_t *left, deprule_entry_t *right, const bo
 
     if (strict) {
         if ((left->requirement && right->requirement && !strcmp(left->requirement, right->requirement))
-            && left->operator == right->operator
+            && left->op == right->op
             && ((left->version == NULL && right->version == NULL) || (left->version && right->version && !strcmp(left->version, right->version)))) {
             match = true;
         }
@@ -428,8 +428,8 @@ char *strdeprule(const deprule_entry_t *deprule)
     assert(r != NULL);
 
     /* we may have an operator and version */
-    if (deprule->operator != OP_NULL && deprule->version) {
-        r = strappend(r, " ", get_deprule_operator_desc(deprule->operator), " ", deprule->version, NULL);
+    if (deprule->op != OP_NULL && deprule->version) {
+        r = strappend(r, " ", get_deprule_operator_desc(deprule->op), " ", deprule->version, NULL);
         assert(r != NULL);
     }
 
@@ -499,7 +499,7 @@ bool deprules_match(const deprule_entry_t *a, const deprule_entry_t *b)
     n_match = (ra == NULL && rb == NULL) || (ra && rb && !strcmp(ra, rb));
     v_match = (va == NULL && vb == NULL) || (va && vb && !strcmp(va, vb));
 
-    r = n_match && (a->operator == b->operator) && v_match;
+    r = n_match && (a->op == b->op) && v_match;
 
     free(ora);
     free(orb);

--- a/lib/init.c
+++ b/lib/init.c
@@ -12,7 +12,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <err.h>
-#include "callbacks.h"
+#include "internal/callbacks.h"
 #include "parser.h"
 #include "rpminspect.h"
 #include "init.h"

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -22,7 +22,7 @@
 #include <fcntl.h>
 #include <stdarg.h>
 #include <json.h>
-#include "callbacks.h"
+#include "internal/callbacks.h"
 #include "parser.h"
 #include "rpminspect.h"
 

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -361,8 +361,8 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                     isareq = remove_isa_substring(verify->requirement);
                     assert(isareq != NULL);
 
-                    if (!strcmp(isareq, pn) && verify->operator == OP_EQUAL && (!strcmp(verify->version, evr) || !strcmp(verify->version, vr))) {
-                        verify->explicit = true;
+                    if (!strcmp(isareq, pn) && verify->op == OP_EQUAL && (!strcmp(verify->version, evr) || !strcmp(verify->version, vr))) {
+                        verify->direct = true;
                         found = true;
                     }
 
@@ -571,7 +571,7 @@ static bool expected_deprule_change(const bool rebase, const deprule_entry_t *de
     }
 
     /* Rich dependencies and explicit dependencies for automatic deps are expected */
-    if (deprule->rich || deprule->explicit) {
+    if (deprule->rich || deprule->direct) {
         return true;
     }
 
@@ -634,7 +634,7 @@ static bool expected_deprule_change(const bool rebase, const deprule_entry_t *de
      * as:   Provides: thing = 1.2.3-4
      * where 1.2.3-4 matches %{version}-%{release}
      */
-    if (!found && deprule->version && deprule->operator == OP_EQUAL) {
+    if (!found && deprule->version && deprule->op == OP_EQUAL) {
         found = true;
         working_hdr = h;
     }

--- a/lib/parse_yaml.c
+++ b/lib/parse_yaml.c
@@ -12,8 +12,8 @@
 #include <string.h>
 #include <err.h>
 
+#include "internal/tyranny.h"
 #include "parser.h"
-#include "tyranny.h"
 #include "rpminspect.h"
 
 /* Uncomment to enable debug printing. */

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('rpminspect',
         'c',
-        version : '1.13',
+        version : '2.0',
         default_options : [
             'warning_level=3',
             'werror=true',

--- a/test/lib/test-cpp.cpp
+++ b/test/lib/test-cpp.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <string>
+#include <string.h>
+#include <CUnit/Basic.h>
+#include "rpminspect.h"
+
+#include "test-main.h"
+
+int init_test_cpp(void)
+{
+    return 0;
+}
+
+int clean_test_cpp(void)
+{
+    return 0;
+}
+
+void test_cpp(void)
+{
+    std::string msg = "Hello";
+
+    msg += ", world!";
+    RI_ASSERT_EQUAL(strcmp(msg.c_str(), "Hello, world!"), 0);
+
+    return;
+}
+
+CU_pSuite get_suite(void)
+{
+    CU_pSuite pSuite = NULL;
+
+    /* add a suite to the registry */
+    pSuite = CU_add_suite("cpp", init_test_cpp, clean_test_cpp);
+    if (pSuite == NULL) {
+        return NULL;
+    }
+
+    /* add tests to the suite */
+    if (CU_add_test(pSuite, "test c++ support", test_cpp) == NULL) {
+        return NULL;
+    }
+
+    return pSuite;
+}

--- a/test/lib/test-main.h
+++ b/test/lib/test-main.h
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef _LIBRPMINSPECT_TEST_MAIN_H
 #define _LIBRPMINSPECT_TEST_MAIN_H
 
@@ -67,4 +72,8 @@ CU_BOOL RI_assert_impl(CU_BOOL, unsigned int, const char *, const char *, ...)
     free(actual);\
 }
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -109,6 +109,20 @@ if cunit.found()
         link_with : [ librpminspect ],
     )
 
+    if add_languages('cpp', required : false)
+        test_cpp = executable(
+            'test_cpp',
+            ['lib/test-cpp.cpp',
+             'lib/test-main.c'],
+            include_directories : inc,
+            dependencies : [ cunit ],
+            cpp_args : '-std=c++17',
+            link_with : [ librpminspect ],
+        )
+
+        test('test-cpp', test_cpp)
+    endif
+
     # Support program used by test-inspect-elf
     execstack_prog = executable(
         'execstack',


### PR DESCRIPTION
These changes should make it possible to have a C++ project link with librpminspect and work.  I went ahead and added the extern C stuff to the public librpminspect headers.  I split the internal-only headers out in to a subdirectory.  And I also added a simple test case that builds a C++ program linking with librpminspect so we can see if any changes down the road break things.