### PR TITLE
[fix] In the symlinks inspection, honor transitive Requires

### DIFF
--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -449,6 +449,12 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                                             isareq = remove_isa_substring(verify->requirement);
                                             assert(isareq != NULL);
 
+                                            if (list_contains(transitive, pn)) {
+                                                found = true;
+                                                collect = false;
+                                                break;
+                                            }
+
                                             if (is_subpackage(ri->peers, isareq) && !list_contains(transitive, isareq)) {
                                                 transitive = list_add(transitive, isareq);
                                                 collect = true;
@@ -462,7 +468,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                         }
                     }
 
-                    if (list_contains(transitive, pn)) {
+                    if (!found && list_contains(transitive, pn)) {
                         found = true;
                     }
 


### PR DESCRIPTION
A package with automatic shared library dependencies usually require an explicit Requires on the %{name} = %{version}-%{release}.  This is done to ensure subpackages don't drift from the main package when performing upgrades.  However, it is also possible to have those explicit Requires handled by transitive Requires.  That is having an explicit Requires on a package that then itself has an explicit Requires on the package you need.  This commit implements that check when looking for explicit Requires and treats it as satisifed.

Fixes: #1231