### PR TITLE
[ci] Add '--break-system-packages' to PIP_CMD on Alpine Linux

### DIFF
--- a/osdeps/alpine/defs.mk
+++ b/osdeps/alpine/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = apk add
-PIP_CMD = pip3 install
+PIP_CMD = pip3 install --break-system-packages


### PR DESCRIPTION
pip continues to be more and more difficult to use with a system that has packaged software.