### PR TITLE
[bld] (Requires|Recommends): /usr/bin/annocheck -> annobin-annocheck

### DIFF
--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -65,9 +65,9 @@ Requires:       desktop-file-utils
 Requires:       gettext
 
 %if 0%{?rhel} >= 8 || 0%{?epel} >= 8 || 0%{?fedora}
-Recommends:     /usr/bin/annocheck
+Recommends:     annobin-annocheck
 %else
-Requires:       /usr/bin/annocheck
+Requires:       annobin-annocheck
 %endif
 
 # The clamav data is required for the virus inspection.  Either


### PR DESCRIPTION
Specify the package name rather than the executable for the dependency.  Path dependencies do not work with DNF 5/