### PR TITLE
[ci] add .local/bin/ to freebsd build

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -30,7 +30,7 @@ jobs:
 
         # Environment variables for the job
         env:
-            PATH: /usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin:/sbin
+            PATH: /home/runner/.local/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin:/sbin
 
         # All of these steps run from within the main source
         # directory, so think of that as your $PWD
@@ -49,7 +49,7 @@ jobs:
 
                   # Requirements before the git clone can happen
                   prepare: |
-                      yes | pkg update -y
+                      yes | pkg update
                       pkg install -q -y git tree
 
                   # Run the build and test


### PR DESCRIPTION
The vmaction installs pip packages as regular user, so HOME/.local/bin needs to be in PATH so ./VBox.sh can call vncdotool and other tools. $HOME didn't work, so I hard-coded it's value.

Also 'pkg update' doesn't have -y option, so this removes it. 'yes |' does the job of non-interactive run.