### PR TITLE
[fix] Prevent a SIGSEGV in the unicode inspection

### DIFF
--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -64,6 +64,10 @@ static bool is_excluded_mime_type(const char *path)
     /* get the MIME type */
     type = mime_type(globalri, path);
 
+    if (type == NULL) {
+        return false;
+    }
+
     /* check to see if this MIME type is explicitly excluded */
     if (globalri->unicode_excluded_mime_types != NULL && !TAILQ_EMPTY(globalri->unicode_excluded_mime_types)) {
         TAILQ_FOREACH(entry, globalri->unicode_excluded_mime_types, items) {

--- a/lib/magic.c
+++ b/lib/magic.c
@@ -61,6 +61,8 @@ const char *mime_type(struct rpminspect *ri, const char *file)
     if (tmp) {
         type = strdup(tmp);
         assert(type != NULL);
+    } else {
+        return NULL;
     }
 
     if (type != NULL) {
@@ -68,7 +70,9 @@ const char *mime_type(struct rpminspect *ri, const char *file)
          * Trim any trailing metadata after the MIME type, such
          * as '; charset=utf-8' and stuff like that.
          */
-        if ((pos = index(type, ';')) != NULL) {
+        pos = strchr(type, ';');
+
+        if (pos != NULL) {
             *pos = '\0';
         }
 
@@ -85,12 +89,7 @@ const char *mime_type(struct rpminspect *ri, const char *file)
     }
 
     free(type);
-
-    if (entry) {
-        return entry->data;
-    } else {
-        return NULL;
-    }
+    return entry->data;
 }
 
 /*


### PR DESCRIPTION
Yeah, this can happen.  Add more checks for NULL.

Fixes: #1329