### PR TITLE
Pin version of run-on-arch action for some fedora arches

### DIFF
--- a/.github/workflows/fedora-ppc64le.yml
+++ b/.github/workflows/fedora-ppc64le.yml
@@ -39,10 +39,11 @@ jobs:
 
         # All of these steps run from within the main source
         # directory, so think of that as your $PWD
+        # NOTE: Pinned action version v2.7.0 because 2.7.1 removes fedora ppc64le
         steps:
             # This means clone the git repo
             - uses: actions/checkout@v4
-            - uses: uraimo/run-on-arch-action@v2
+            - uses: uraimo/run-on-arch-action@v2.7.0
               id: buildtest
               timeout-minutes: 500
               with:

--- a/.github/workflows/fedora-s390x.yml
+++ b/.github/workflows/fedora-s390x.yml
@@ -39,10 +39,11 @@ jobs:
 
         # All of these steps run from within the main source
         # directory, so think of that as your $PWD
+        # NOTE: Pinned action version v2.7.0 because 2.7.1 removes fedora s390x
         steps:
             # This means clone the git repo
             - uses: actions/checkout@v4
-            - uses: uraimo/run-on-arch-action@v2
+            - uses: uraimo/run-on-arch-action@v2.7.0
               id: buildtest
               timeout-minutes: 500
               with:


### PR DESCRIPTION
The [version v2.7.1][v2.7.1] of uraimo/run-on-arch-action removed Dockerfiles for Fedora's s390x and ppc64le architecture (see https://github.com/uraimo/run-on-arch-action/commit/18a5cd7958b1f33f6a8f10b48fdbcbf02ccda003). Other Dockerfiles were removed, then readded (Fedora wasn't for some reason), but they will not be part of next v3.0.0.

So, either pin specific version for the action or remove these workflow files. This PR's commit proposes to pin the version.

See my test workflow runs: [fedora-ppc64le.yml][ppc64le] and [fedora-s390x.yml][s390x]

[v2.7.1]: https://github.com/uraimo/run-on-arch-action/commits/v2.7.1
[ppc64le]: https://github.com/rffontenelle/rpminspect/actions/runs/7704873344/job/20997913888
[s390x]: https://github.com/rffontenelle/rpminspect/actions/runs/7704872976