### PR TITLE
Fix misspellings

### DIFF
--- a/contrib/viewer.html
+++ b/contrib/viewer.html
@@ -118,7 +118,7 @@ let resultFilter = null;
 
 // Compute an overall result for inspections
 // Return a list of { name, results: [...], result } objects
-// results is a list of all occuring result types, sorted like RESULTS
+// results is a list of all occurring result types, sorted like RESULTS
 // result is the most severe of results (i.e. last array item)
 function getInspectionResults(report) {
     const inspections = [];

--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -854,7 +854,7 @@ badfuncs:
     # Some libraries deliberately use forbidden functions.  In these
     # cases, you can specify an 'allowed' block listing path globs and
     # the specific functions they are allowed to use.  It is
-    # adviseable to add a comment indicating why the function is
+    # advisable to add a comment indicating why the function is
     # allowed to use forbidden functions for future reference.  The
     # path specifications can be explicit paths or patterns that are
     # compatible with fnmatch(3) and glob(3).
@@ -946,7 +946,7 @@ unicode:
         - text/html
 
     # List of forbidden Unicode codepoints in source code.  Codepoints
-    # are written in hexidecimal notation.  The case of the letters
+    # are written in hexadecimal notation.  The case of the letters
     # does not matter.  Be sure to prefix the code point with '0x' and
     # use single quotes around the values.
     forbidden_codepoints:

--- a/include/constants.h
+++ b/include/constants.h
@@ -621,7 +621,7 @@ extern "C"
  * @def KERNEL_MODULE_FILENAME_EXTENSION
  *
  * Linux loadable kernel module filename extension.  Note that kernel
- * modules can be compressed with a typical compression appened after
+ * modules can be compressed with a typical compression appended after
  * this string.  rpminspect can handle those cases.
  */
 #define KERNEL_MODULE_FILENAME_EXTENSION ".ko"

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -179,7 +179,7 @@ bool inspect_manpage(struct rpminspect *ri);
  *
  * Perform some RPM header checks. First, check that the Vendor
  * contains the expected string as defined in the configuration
- * file. Second, chec k that the build host is in the expected
+ * file. Second, check that the build host is in the expected
  * subdomain as defined in the configuration file. Third, check the
  * Summary string for any unprofessional words. Fourth, check the
  * Description for any unprofessional words. Lastly, if there is a

--- a/include/parser.h
+++ b/include/parser.h
@@ -21,7 +21,7 @@ extern "C"
 #include <stdbool.h>
 #include <string.h>
 
-/* Abstract type - implemtations should cast to an appropriate type. */
+/* Abstract type - implementations should cast to an appropriate type. */
 typedef struct parser_context_st *parser_context;
 
 /* Initialize a parser context for the given file. */
@@ -38,7 +38,7 @@ typedef bool (*parser_have_section_fn)(parser_context *context, const char *sect
  * structure.  All structures are dictionary-like.  Pass NULL for the second
  * key if there's only one level of nesting, and NULL for both keys to operate
  * on the top-level structure.  free() the returned string when done.  Returns
- * NULL if string not found or the object at the specfied position wasn't a
+ * NULL if string not found or the object at the specified position wasn't a
  * string.
  */
 typedef char *(*parser_getstr_fn)(parser_context *context, const char *key1, const char *key2);

--- a/include/readelf.h
+++ b/include/readelf.h
@@ -139,7 +139,7 @@ bool is_elf(const char *path);
  * Given a path to a file, this function returns true if the file is
  * an ELF shared library.  That is, if it is ELF type ET_DYN.
  *
- * @param path The fullpath tothe file in question.
+ * @param path The fullpath to the file in question.
  * @return True if the file is an ELF shared library, false otherwise.
  */
 bool is_elf_shared_library(const char *path);
@@ -150,7 +150,7 @@ bool is_elf_shared_library(const char *path);
  * Given a path to a file, this function returns true if the file is
  * an ELF executable.  That is, if it is ELF type ET_EXEC.
  *
- * @param path The fullpath tothe file in question.
+ * @param path The fullpath to the file in question.
  * @return True if the file is an ELF executable, false otherwise.
  */
 bool is_elf_executable(const char *path);
@@ -162,7 +162,7 @@ bool is_elf_executable(const char *path);
  * an ELF file.  That is, an ELF executable, shared library, or shared
  * object.
  *
- * @param path The fullpath tothe file in question.
+ * @param path The fullpath to the file in question.
  * @return True if the file is an ELF file, false otherwise.
  */
 bool is_elf_file(const char *path);
@@ -174,7 +174,7 @@ bool is_elf_file(const char *path);
  * an ELF archive.  That is, a '.a' file consisting of ELF object
  * files.
  *
- * @param path The fullpath tothe file in question.
+ * @param path The fullpath to the file in question.
  * @return True if the file is an ELF archive, false otherwise.
  */
 bool is_elf_archive(const char *path);

--- a/include/results.h
+++ b/include/results.h
@@ -781,7 +781,7 @@ extern "C"
 
 #define REMEDY_RPMDEPS_LOST _("A dependency seen in the before build is not seen in the after build meaning it was removed or lost.  If this is a VERIFY result, it means rpminspect noticed the change in what it considers a maintenance update in a package.  An INFO result means it noticed this change, but deems it ok because it is comparing a rebased build.")
 
-#define REMEDY_RPMDEPS_EPOCH _("The package has an Epoch value greater than zero, but the explicit subpackage dependencies are not consistently using it.  For the dependency reported, the '= %{version}-%{release}' needs to change to '= %{epoch}:%{version}-%{release}' to capture the package package Epoch in the dependency.")
+#define REMEDY_RPMDEPS_EPOCH _("The package has an Epoch value greater than zero, but the explicit subpackage dependencies are not consistently using it.  For the dependency reported, the '= %{version}-%{release}' needs to change to '= %{epoch}:%{version}-%{release}' to capture the package Epoch in the dependency.")
 
 /** @} */
 

--- a/lib/badwords.c
+++ b/lib/badwords.c
@@ -25,7 +25,7 @@
  *
  * Given a list of bad words, check the specified string for any of
  * those bad words and return true on a match.  The search is
- * conducted with **strcasestr(3)** as well as checking for a preceeding
+ * conducted with **strcasestr(3)** as well as checking for a preceding
  * space to ensure it avoids substrings in the middle of a word.  For
  * example, if the badwords list contains `flag' then this function
  * will match ` flag' and ` flagging' but not ` conflagration'.  If

--- a/lib/files.c
+++ b/lib/files.c
@@ -40,7 +40,7 @@
 
 /*
  * hash table used for file entries
- * Not all values are used each time this hash table is implemeneted.
+ * Not all values are used each time this hash table is implemented.
  * See below.  One place uses the path and index and another place
  * uses the path and rpmfile.
  */
@@ -610,7 +610,7 @@ static char *comparable_version_substrings(const char *s, const char *ignore)
  * works and the accepted practices of packagers.
  *
  * @param path The path string.
- * @param version The version subtring.
+ * @param version The version substring.
  * @param release The release substring.
  * @return A newly allocated version-release substring for use in path
  * substring substitution.  Caller must free this returned string.

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -200,7 +200,7 @@ static libannocheck_test_state get_worst(libannocheck_test_state worst, libannoc
 
 /*
  * Do the libannocheck setup for a file.  If this is the first call,
- * it will initializae libannocheck.  Otherwise, it will reinit the
+ * it will initialize libannocheck.  Otherwise, it will reinit the
  * existing handle.  Returns libannocheck handle on success, NULL
  * otherwise.
  */

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -364,7 +364,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
                     params.severity = RESULT_VERIFY;
                     params.waiverauth = WAIVABLE_BY_ANYONE;
                     params.verb = VERB_FAILED;
-                    params.noun = _("${FILE} references unreadble icon on ${ARCH}");
+                    params.noun = _("${FILE} references unreadable icon on ${ARCH}");
                     add_result(ri, &params);
                     free(params.msg);
                     result = false;

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -316,7 +316,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
 
                 pn = headerGetString(peer->after_hdr, RPMTAG_NAME);
 
-                /* check that the Requires is explict and matches the Provides */
+                /* check that the Requires is explicit and matches the Provides */
                 if (!strcmp(req->requirement, prov->requirement)) {
                     /* a package is allowed to to Provide and Require the same thing */
                     /* otherwise we found the subpackage that Provides this explicit Requires */
@@ -331,7 +331,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                     /*
                      * we may have a dependency such as:
                      *     Requires: %{name}-libs%{?_isa} = %{version}-%{release}'
-                     * trim the '(x86-64)' or similar ISA substring for comparision purposes
+                     * trim the '(x86-64)' or similar ISA substring for comparison purposes
                      * also trim leading '(' to account for rich deps
                      */
                     isareq = remove_isa_substring(req->requirement);

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -188,7 +188,7 @@ const char *get_rpm_header_arch(Header h)
  *
  * @param hdr RPM header
  * @param tag RPM header tag constant (e.g., RPMTAG_SOURCE)
- * @return Newly allocated string_list_t containg tag values.
+ * @return Newly allocated string_list_t containing tag values.
  */
 string_list_t *get_rpm_header_string_array(Header hdr, rpmTagVal tag)
 {

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -50,7 +50,7 @@ class LostChangeLogCompareRPMs(TestCompareRPMs):
         self.after_rpm.section_changelog = None
 
         self.inspection = "changelog"
-        # this is INFO because it's only comapring the binary RPMs,
+        # this is INFO because it's only comparing the binary RPMs,
         # the other checks are for SRPMs
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -1320,7 +1320,7 @@ class SecurityFAILFileIWOTHandISVTXProhibitedCompareKoji(TestCompareKoji):
 class DirIWOTHProhibitedSRPM(TestSRPM):
     """
     Assert when a world-writable dir is in a package,
-    OK result occures when testing the SRPM.
+    OK result occurs when testing the SRPM.
     """
 
     def setUp(self):
@@ -1559,7 +1559,7 @@ class SecurityFAILDirIWOTHProhibitedKoji(TestKoji):
 class DirIWOTHProhibitedCompareSRPM(TestCompareSRPM):
     """
     Assert when a world-writable dir is in a package,
-    OK result occures when testing the SRPMs.
+    OK result occurs when testing the SRPMs.
     """
 
     def setUp(self):
@@ -1798,7 +1798,7 @@ class SecurityFAILDirIWOTHProhibitedCompareKoji(TestCompareKoji):
 class DirIWOTHandISVTXProhibitedSRPM(TestSRPM):
     """
     Assert when a world-writable dir with the sticky bit is in a package,
-    OK result occures when testing the SRPM.
+    OK result occurs when testing the SRPM.
     """
 
     def setUp(self):
@@ -2037,7 +2037,7 @@ class SecurityFAILDirIWOTHandISVTXProhibitedKoji(TestKoji):
 class DirIWOTHandISVTXProhibitedCompareSRPM(TestCompareSRPM):
     """
     Assert when a world-writable dir with the sticky bit is in a package,
-    OK result occures when testing the SRPMs.
+    OK result occurs when testing the SRPMs.
     """
 
     def setUp(self):


### PR DESCRIPTION
I also found typos in CHANGES.md, but I see it was programmatically generated from git history. Should I fix them as well or the scripts would replace it?