### PR TITLE
[fix] Honor case-insensitive SPDX names

### DIFF
--- a/include/results.h
+++ b/include/results.h
@@ -108,6 +108,13 @@ extern "C"
  */
 #define REMEDY_UNAPPROVED_LICENSE _("The specified license abbreviation is not listed as approved in the license database.  The license database is specified in the rpminspect configuration file.  Check this file and send a pull request to the appropriate upstream project to update the database.  If the license is listed in the database but marked unapproved, you may need to work with the legal team regarding options for this software.")
 
+/**
+ * @def REMEDY_INVALID_BOOLEAN
+ *
+ * How to handle an invalid boolean token in the License tag.
+ */
+#define REMEDY_INVALID_BOOLEAN _("The License tag contains SPDX license identifiers.  When SPDX identifiers are used, the boolean joining terms must be written in all capitable letters per the spec.  The actual SPDX identifiers are case-insensitive.  It is only the boolean terms that must be in all capital letters.")
+
 /** @} */
 
 /**

--- a/include/results.h
+++ b/include/results.h
@@ -113,7 +113,7 @@ extern "C"
  *
  * How to handle an invalid boolean token in the License tag.
  */
-#define REMEDY_INVALID_BOOLEAN _("The License tag contains SPDX license identifiers.  When SPDX identifiers are used, the boolean joining terms must be written in all capitable letters per the spec.  The actual SPDX identifiers are case-insensitive.  It is only the boolean terms that must be in all capital letters.")
+#define REMEDY_INVALID_BOOLEAN _("The License tag contains SPDX license identifiers.  When SPDX identifiers are used, the boolean joining terms must be written in all capital letters per the spec.  The actual SPDX identifiers are case-insensitive.  It is only the boolean terms that must be in all capital letters.")
 
 /** @} */
 

--- a/po/rpminspect.pot
+++ b/po/rpminspect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rpminspect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-27 09:48-0500\n"
+"POT-Creation-Date: 2024-02-27 15:33-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -424,72 +424,80 @@ msgid ""
 "options for this software."
 msgstr ""
 
-#: include/results.h:124 include/results.h:159
+#: include/results.h:116
+msgid ""
+"The License tag contains SPDX license identifiers.  When SPDX identifiers "
+"are used, the boolean joining terms must be written in all capitable letters "
+"per the spec.  The actual SPDX identifiers are case-insensitive.  It is only "
+"the boolean terms that must be in all capital letters."
+msgstr ""
+
+#: include/results.h:131 include/results.h:166
 msgid "Ensure all object files are compiled with -fPIC"
 msgstr ""
 
-#: include/results.h:131
+#: include/results.h:138
 msgid ""
 "Ensure that the package is being built with the correct compiler and "
 "compiler flags"
 msgstr ""
 
-#: include/results.h:138
+#: include/results.h:145
 msgid ""
 "The data in an ELF file appears to be corrupt; ensure that packaged ELF "
 "files are not being truncated or incorrectly modified"
 msgstr ""
 
-#: include/results.h:145
+#: include/results.h:152
 msgid ""
 "An ELF stack is marked as executable. Ensure that no execstack options are "
 "being passed to the linker, and that no functions are defined on the stack."
 msgstr ""
 
-#: include/results.h:152
+#: include/results.h:159
 msgid "Ensure executables are linked with with '-z relro -z now'"
 msgstr ""
 
-#: include/results.h:174
+#: include/results.h:181
 msgid "Correct the errors in the man page as reported by the libmandoc parser."
 msgstr ""
 
-#: include/results.h:181
+#: include/results.h:188
 msgid ""
 "Correct the installation path for the man page. Man pages must be installed "
 "in the directory beneath /usr/share/man that matches the section number of "
 "the page."
 msgstr ""
 
-#: include/results.h:196
+#: include/results.h:203
 msgid "Correct the reported errors in the XML document"
 msgstr ""
 
-#: include/results.h:211
+#: include/results.h:218
 msgid ""
 "Refer to the Desktop Entry Specification at https://standards.freedesktop."
 "org/desktop-entry-spec/latest/ for help correcting the errors and warnings"
 msgstr ""
 
-#: include/results.h:226
+#: include/results.h:233
 msgid ""
 "The Release: tag in the spec file must include a '%{?dist}' string.  Please "
 "add this to the spec file per the distribution packaging guidelines."
 msgstr ""
 
-#: include/results.h:241
+#: include/results.h:248
 msgid ""
 "The spec file name does not match the expected NAME.spec format.  Rename the "
 "spec file to conform to this policy."
 msgstr ""
 
-#: include/results.h:258
+#: include/results.h:265
 msgid ""
 "This package is part of a module but is missing the %{modularitylabel} "
 "header tag.  Add this as a %define in the spec file and rebuild."
 msgstr ""
 
-#: include/results.h:265
+#: include/results.h:272
 msgid ""
 "This package is part of a module but lacks a conformant Release tag value.  "
 "A Release tag in a modular RPM needs to carry a substring that is more "
@@ -497,7 +505,7 @@ msgid ""
 "must carry '+module' as a substring before that specific dist tag."
 msgstr ""
 
-#: include/results.h:272
+#: include/results.h:279
 msgid ""
 "This build either contains a valid or invalid /data/static_context setting.  "
 "Refer to the module rules for the product you are building to determine what "
@@ -506,32 +514,32 @@ msgid ""
 "forbidden, or recommend."
 msgstr ""
 
-#: include/results.h:289
+#: include/results.h:296
 msgid ""
 "The Java bytecode version for one or more class files in the build was not "
 "met for the product release.  Ensure you are using the correct JDK for the "
 "build."
 msgstr ""
 
-#: include/results.h:304
+#: include/results.h:311
 msgid ""
 "File changes were found.  In most cases these are expected, but it is a good "
 "idea to verify the changes found are deliberate."
 msgstr ""
 
-#: include/results.h:319
+#: include/results.h:326
 msgid ""
 "Unexpected file moves were found.  Verify these changes are correct.  If "
 "they are not, adjust the build to prevent the file moves between builds."
 msgstr ""
 
-#: include/results.h:334
+#: include/results.h:341
 msgid ""
 "Unexpected file removals were found.  Verify these changes are correct.  If "
 "they are not, adjust the build to prevent the file removals between builds."
 msgstr ""
 
-#: include/results.h:349
+#: include/results.h:356
 #, c-format
 msgid ""
 "Unexpected file additions were found.  Verify these changes are correct.  If "
@@ -542,7 +550,7 @@ msgid ""
 "change the forbidden_path_prefixes or forbidden_path_suffixes list."
 msgstr ""
 
-#: include/results.h:364
+#: include/results.h:371
 #, c-format
 msgid ""
 "Unexpected changed source archive content. The version of the package did "
@@ -551,7 +559,7 @@ msgid ""
 "send a patch to the project that owns that file."
 msgstr ""
 
-#: include/results.h:379
+#: include/results.h:386
 #, c-format
 msgid ""
 "Make sure the %%files section includes the %%defattr macro. If these "
@@ -559,7 +567,7 @@ msgid ""
 "owns it."
 msgstr ""
 
-#: include/results.h:386
+#: include/results.h:393
 #, c-format
 msgid ""
 "Bin path files must be owned by the bin_owner set in the rpminspect "
@@ -567,7 +575,7 @@ msgid ""
 "%s and send a patch to the project that owns it."
 msgstr ""
 
-#: include/results.h:393
+#: include/results.h:400
 #, c-format
 msgid ""
 "Bin path files must be owned by the bin_group set in the rpminspect "
@@ -575,7 +583,7 @@ msgid ""
 "and send a patch to the project that owns it."
 msgstr ""
 
-#: include/results.h:400
+#: include/results.h:407
 #, c-format
 msgid ""
 "Either chgrp the file to the bin_group set in the rpminspect configuration "
@@ -583,7 +591,7 @@ msgid ""
 "is expected, update %s and send a patch to the project that owns it."
 msgstr ""
 
-#: include/results.h:407
+#: include/results.h:414
 #, c-format
 msgid ""
 "Either chgrp the file to the bin_group set in the rpminspect configuration "
@@ -591,7 +599,7 @@ msgid ""
 "expected, update %s and send a patch to the project that owns it."
 msgstr ""
 
-#: include/results.h:414
+#: include/results.h:421
 #, c-format
 msgid ""
 "Verify the ownership changes are expected. If not, adjust the package build "
@@ -599,7 +607,7 @@ msgid ""
 "and send a patch to the project that owns it."
 msgstr ""
 
-#: include/results.h:421
+#: include/results.h:428
 msgid ""
 "rpminspect is expecting a fileinfo rule from the vendor data package for "
 "this file. Usually this means the file carries a non-standard set of "
@@ -609,27 +617,27 @@ msgid ""
 "the appropriate product release file."
 msgstr ""
 
-#: include/results.h:436
+#: include/results.h:443
 msgid "Consult the shell documentation for proper syntax."
 msgstr ""
 
-#: include/results.h:443
+#: include/results.h:450
 msgid ""
 "The file referenced was not a known shell script in the before build but is "
 "now a shell script in the after build."
 msgstr ""
 
-#: include/results.h:450
+#: include/results.h:457
 msgid ""
 "The referenced shell script is invalid. Consider debugging it with the '-n' "
 "option on the shell to find and fix the problem."
 msgstr ""
 
-#: include/results.h:465
+#: include/results.h:472
 msgid "See annocheck(1) for more information."
 msgstr ""
 
-#: include/results.h:472
+#: include/results.h:479
 msgid ""
 "Ensure all object files are compiled with '-O2 -D_FORTIFY_SOURCE=2', and "
 "that all appropriate headers are included (no implicit function "
@@ -637,7 +645,7 @@ msgid ""
 "unable to determine the size of a buffer, which is not necessarily an error."
 msgstr ""
 
-#: include/results.h:487
+#: include/results.h:494
 msgid ""
 "DT_NEEDED symbols have been added or removed.  This happens when the build "
 "environment has different versions of the required libraries.  Sometimes "
@@ -646,33 +654,33 @@ msgid ""
 "the correct shared libraries."
 msgstr ""
 
-#: include/results.h:502
+#: include/results.h:509
 msgid ""
 "A file grew by a noticeable amount.  Ensure this change is intended.  If it "
 "is, you can adjust the filesize inspection settings in the rpminspect.yaml "
 "file."
 msgstr ""
 
-#: include/results.h:509
+#: include/results.h:516
 msgid ""
 "A file shrank by a noticeable amount.  Ensure this change is intended.  If "
 "it is, you can adjust the filesize inspection settings in the rpminspect."
 "yaml file."
 msgstr ""
 
-#: include/results.h:516
+#: include/results.h:523
 msgid ""
 "A previously empty file is no longer empty.  Make sure this change is "
 "intended and fix the package spec file if necessary."
 msgstr ""
 
-#: include/results.h:523
+#: include/results.h:530
 msgid ""
 "A previously non-empty file is now empty.  Make sure this change is intended "
 "and fix the package space file if necessary."
 msgstr ""
 
-#: include/results.h:538
+#: include/results.h:545
 #, c-format
 msgid ""
 "Unexpected capabilities were found on the indicated file.  Consult "
@@ -682,73 +690,73 @@ msgid ""
 "changes found here and send a patch to the project that owns the data file."
 msgstr ""
 
-#: include/results.h:553
+#: include/results.h:560
 msgid ""
 "Kernel module parameters were removed between builds.  This may present "
 "usability problems for users if module parameters were removed in a "
 "maintenance update."
 msgstr ""
 
-#: include/results.h:560
+#: include/results.h:567
 msgid ""
 "Kernel module dependencies changed between builds.  This may present "
 "usability problems for users if module dependencies changed in a maintenance "
 "update."
 msgstr ""
 
-#: include/results.h:567
+#: include/results.h:574
 msgid ""
 "Kernel module device aliases changed between builds.  This may present "
 "usability problems for users if module device aliases changed in a "
 "maintenance update."
 msgstr ""
 
-#: include/results.h:577
+#: include/results.h:584
 msgid ""
 "An architecture present in the before build is now missing in the after "
 "build.  This may be deliberate, but check to make sure you do not have any "
 "unexpected ExclusiveArch lines in the spec file."
 msgstr ""
 
-#: include/results.h:578
+#: include/results.h:585
 msgid ""
 "A new architecture has appeared in the after build.  This may indicate "
 "progress in the world of computing."
 msgstr ""
 
-#: include/results.h:588
+#: include/results.h:595
 msgid ""
 "A subpackage present in the before build is now missing in the after build.  "
 "This may be deliberate, but check to make sure you have correct syntax "
 "defining the subpackage in the spec file"
 msgstr ""
 
-#: include/results.h:589
+#: include/results.h:596
 msgid ""
 "A new subpackage has appeared in the after build.  This may indicate "
 "progress in the world of computing."
 msgstr ""
 
-#: include/results.h:599
+#: include/results.h:606
 #, c-format
 msgid ""
 "Make sure the spec file in the after build contains a valid %changelog "
 "section."
 msgstr ""
 
-#: include/results.h:609
+#: include/results.h:616
 msgid ""
 "Files should not be installed in old directory names.  Modify the package to "
 "install the affected file to the preferred directory."
 msgstr ""
 
-#: include/results.h:619
+#: include/results.h:626
 msgid ""
 "ELF .o and .a files should not carry LTO (Link Time Optimization) bytecode.  "
 "Make sure you have stripped LTO bytecode from those files at install time."
 msgstr ""
 
-#: include/results.h:629
+#: include/results.h:636
 msgid ""
 "Make sure symlinks point to a valid destination in one of the subpackages of "
 "the build; dangling symlinks are not allowed.  If you are comparing builds "
@@ -756,7 +764,7 @@ msgid ""
 "NOTE:  You cannot turn a directory in to a symlink due to RPM limitations."
 msgstr ""
 
-#: include/results.h:630
+#: include/results.h:637
 #, c-format
 msgid ""
 "Make sure symlinks point to a valid destination in one of the subpackages of "
@@ -768,7 +776,7 @@ msgid ""
 "'Scriptlet to replace a directory' for more information."
 msgstr ""
 
-#: include/results.h:640
+#: include/results.h:647
 #, c-format
 msgid ""
 "Remove forbidden path references from the indicated line in the %files "
@@ -777,28 +785,28 @@ msgid ""
 "information."
 msgstr ""
 
-#: include/results.h:650
+#: include/results.h:657
 msgid ""
 "In many cases the changing MIME type is deliberate.  Verify that the change "
 "is intended and if necessary fix the spec file so the correct file is "
 "included in the built package."
 msgstr ""
 
-#: include/results.h:660
+#: include/results.h:667
 msgid ""
 "ABI changes introduced during maintenance updates can lead to problems for "
 "users.  See the abidiff(1) documentation and the distribution ABI policies "
 "to determine if this detected change is allowed."
 msgstr ""
 
-#: include/results.h:670
+#: include/results.h:677
 msgid ""
 "Kernel Module Interface introduced during maintenance updates can lead to "
 "problems for users.  See the libabigail documentation and the distribution "
 "KMI policy to determine if this detected change is allowed."
 msgstr ""
 
-#: include/results.h:680
+#: include/results.h:687
 #, c-format
 msgid ""
 "Changes to %config should be done carefully.  Make sure you have installed "
@@ -807,7 +815,7 @@ msgid ""
 "package -or- honor the old file locations."
 msgstr ""
 
-#: include/results.h:690
+#: include/results.h:697
 #, c-format
 msgid ""
 "Changes found among the %doc files.  Verify these changes are intended if "
@@ -815,7 +823,7 @@ msgid ""
 "documentation files and the spec file needs to account for those changes."
 msgstr ""
 
-#: include/results.h:700
+#: include/results.h:707
 msgid ""
 "An invalid patch file was found.  This is usually the result of generating a "
 "collection of patches by comparing two trees.  When files disappear that can "
@@ -824,7 +832,7 @@ msgid ""
 "correct the problem."
 msgstr ""
 
-#: include/results.h:702
+#: include/results.h:709
 #, c-format
 msgid ""
 "The named patch is defined in the source RPM header (this means it has a "
@@ -837,7 +845,7 @@ msgid ""
 "either a '%patch 47', '%patch -P 47', '%patch -P47', or '%patch47' macro."
 msgstr ""
 
-#: include/results.h:704
+#: include/results.h:711
 #, c-format
 msgid ""
 "The named patch is defined but is mismatched by number with the %patch "
@@ -846,13 +854,13 @@ msgid ""
 "'%patch -P47', or '%patch47' macro."
 msgstr ""
 
-#: include/results.h:706
+#: include/results.h:713
 msgid ""
 "The defined patch file is not something rpminspect can handle.  This is "
 "likely a bug and should be reported to the upstream rpminspect project."
 msgstr ""
 
-#: include/results.h:716
+#: include/results.h:723
 msgid ""
 "ClamAV has found a virus in the named file.  This may be a false positive, "
 "but you should manually inspect the file in question to ensure it is clean.  "
@@ -861,7 +869,7 @@ msgid ""
 "further help."
 msgstr ""
 
-#: include/results.h:726
+#: include/results.h:733
 #, c-format
 msgid ""
 "A file with potential politically sensitive content was found in the "
@@ -870,7 +878,7 @@ msgid ""
 "the project that owns it."
 msgstr ""
 
-#: include/results.h:736
+#: include/results.h:743
 msgid ""
 "Forbidden symbols were found in an ELF file in the package.  The "
 "configuration settings for rpminspect indicate the named symbols are "
@@ -882,7 +890,7 @@ msgid ""
 "deprecated functions should not be used."
 msgstr ""
 
-#: include/results.h:746
+#: include/results.h:753
 #, c-format
 msgid ""
 "Either DT_RPATH or DT_RUNPATH properties were found on ELF shared objects in "
@@ -893,14 +901,14 @@ msgid ""
 "files."
 msgstr ""
 
-#: include/results.h:748
+#: include/results.h:755
 msgid ""
 "Both DT_RPATH and DT_RUNPATH properties were found in an ELF shared object.  "
 "This indicates a linker error and should not happen.  ELF objects should "
 "only carry DT_RPATH or DT_RUNPATH, never both."
 msgstr ""
 
-#: include/results.h:758
+#: include/results.h:765
 msgid ""
 "The rpminspect configuration file contains a list of forbidden Unicode code "
 "points.  One was found in the extracted and patched source tree or in one of "
@@ -909,7 +917,7 @@ msgid ""
 "correct course of action."
 msgstr ""
 
-#: include/results.h:760
+#: include/results.h:767
 #, c-format
 msgid ""
 "The %prep section of the spec file could not be executed for some reason.  "
@@ -919,14 +927,14 @@ msgid ""
 "program is executing."
 msgstr ""
 
-#: include/results.h:770
+#: include/results.h:777
 msgid ""
 "Unexpanded RPM spec file macros were found in the noted dependency rule.  "
 "Check the spec file for this dependency and ensure you have not misspelled a "
 "macro or used a macro name that does not exist."
 msgstr ""
 
-#: include/results.h:772
+#: include/results.h:779
 msgid ""
 "Add the indicated explicit Requires to the spec file for the named "
 "subpackage.  Subpackages depending on shared libraries in another subpackage "
@@ -934,7 +942,7 @@ msgid ""
 "in the spec file."
 msgstr ""
 
-#: include/results.h:774
+#: include/results.h:781
 msgid ""
 "Add the indicated explicit Requires to the spec file for the named "
 "subpackage.  Subpackages depending on shared libraries in another subpackage "
@@ -942,7 +950,7 @@ msgid ""
 "%{release}' in the spec file."
 msgstr ""
 
-#: include/results.h:776
+#: include/results.h:783
 #, c-format
 msgid ""
 "Check subpackage %files sections and explicit Provides statements.  Only one "
@@ -952,7 +960,7 @@ msgid ""
 "the shared library in question."
 msgstr ""
 
-#: include/results.h:778
+#: include/results.h:785
 msgid ""
 "A dependency listed in the before build changed to the indicated dependency "
 "in the after build.  If this is a VERIFY result, it means rpminspect noticed "
@@ -961,7 +969,7 @@ msgid ""
 "a rebased build."
 msgstr ""
 
-#: include/results.h:780
+#: include/results.h:787
 msgid ""
 "A new dependency is seen in the after build that was not present in the "
 "before build.  If this is a VERIFY result, it means rpminspect noticed the "
@@ -970,7 +978,7 @@ msgid ""
 "a rebased build."
 msgstr ""
 
-#: include/results.h:782
+#: include/results.h:789
 msgid ""
 "A dependency seen in the before build is not seen in the after build meaning "
 "it was removed or lost.  If this is a VERIFY result, it means rpminspect "
@@ -979,7 +987,7 @@ msgid ""
 "comparing a rebased build."
 msgstr ""
 
-#: include/results.h:784
+#: include/results.h:791
 msgid ""
 "The package has an Epoch value greater than zero, but the explicit "
 "subpackage dependencies are not consistently using it.  For the dependency "
@@ -987,7 +995,7 @@ msgid ""
 "%{version}-%{release}' to capture the package Epoch in the dependency."
 msgstr ""
 
-#: include/results.h:793
+#: include/results.h:800
 msgid ""
 "Refer to the udev documentation at https://www.freedesktop.org/software/"
 "systemd/man/udev.html for help correcting the errors and warnings."
@@ -2231,48 +2239,55 @@ msgstr ""
 msgid "${FILE} kernel module parameter"
 msgstr ""
 
-#: lib/inspect_license.c:51
+#: lib/inspect_license.c:53
 #, c-format
 msgid "*** parse error in license database %s"
 msgstr ""
 
-#: lib/inspect_license.c:194
+#: lib/inspect_license.c:197
 msgid "*** problem checking license database"
 msgstr ""
 
-#: lib/inspect_license.c:523
+#: lib/inspect_license.c:528
 #, c-format
 msgid "Unapproved license in %s: %s"
 msgstr ""
 
-#: lib/inspect_license.c:564
+#: lib/inspect_license.c:555
+#, c-format
+msgid ""
+"SPDX license expressions in use, but an invalid boolean was found: %s; when "
+"using SPDX expression the booleans must be in all caps."
+msgstr ""
+
+#: lib/inspect_license.c:585
 #, c-format
 msgid "Empty License Tag in %s"
 msgstr ""
 
-#: lib/inspect_license.c:568
+#: lib/inspect_license.c:589
 msgid "missing License tag in ${FILE}"
 msgstr ""
 
-#: lib/inspect_license.c:577
+#: lib/inspect_license.c:598
 #, c-format
 msgid "Valid License Tag in %s: %s"
 msgstr ""
 
-#: lib/inspect_license.c:591
+#: lib/inspect_license.c:612
 #, c-format
 msgid "License Tag contains unprofessional language in %s: %s"
 msgstr ""
 
-#: lib/inspect_license.c:595
+#: lib/inspect_license.c:616
 msgid "unprofessional language in License tag in ${FILE}"
 msgstr ""
 
-#: lib/inspect_license.c:632
+#: lib/inspect_license.c:656
 msgid "Missing license database(s)."
 msgstr ""
 
-#: lib/inspect_license.c:636
+#: lib/inspect_license.c:660
 msgid "missing license database"
 msgstr ""
 

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -81,7 +81,7 @@ class ForbiddenLicenseTagKoji(TestKoji):
 class BadWordLicenseTagSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
-        self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
+        self.rpm.addLicense("GPLv2+ and reallybadword and ASL 2.0")
         self.inspection = "license"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
@@ -91,7 +91,7 @@ class BadWordLicenseTagSRPM(TestSRPM):
 class BadWordLicenseTagRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
-        self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
+        self.rpm.addLicense("GPLv2+ and reallybadword and ASL 2.0")
         self.inspection = "license"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
@@ -101,7 +101,7 @@ class BadWordLicenseTagRPMs(TestRPMs):
 class BadWordLicenseTagKoji(TestKoji):
     def setUp(self):
         super().setUp()
-        self.rpm.addLicense("GPLv2+ and reallybadword and MIT")
+        self.rpm.addLicense("GPLv2+ and reallybadword and ASL 2.0")
         self.inspection = "license"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
@@ -231,7 +231,7 @@ class ValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
 class AnotherValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
     def setUp(self):
         super().setUp()
-        self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
+        self.rpm.addLicense("GPLv3+ and (BSD or ASL 2.0)")
         self.inspection = "license"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
@@ -241,7 +241,7 @@ class AnotherValidLicenseTagWithBooleanSpacesParensSRPM(TestSRPM):
 class AnotherValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
     def setUp(self):
         super().setUp()
-        self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
+        self.rpm.addLicense("GPLv3+ and (BSD or ASL 2.0)")
         self.inspection = "license"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
@@ -251,7 +251,7 @@ class AnotherValidLicenseTagWithBooleanSpacesParensRPMs(TestRPMs):
 class AnotherValidLicenseTagWithBooleanSpacesParensKoji(TestKoji):
     def setUp(self):
         super().setUp()
-        self.rpm.addLicense("MIT and (BSD or ASL 2.0)")
+        self.rpm.addLicense("GPLv3+ and (BSD or ASL 2.0)")
         self.inspection = "license"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
@@ -263,7 +263,7 @@ class ValidGlibcLicenseTagKoji(TestKoji):
         super().setUp()
         self.rpm.addLicense(
             "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions "
-            "and BSD and Inner-Net and ISC and Public Domain and GFDL"
+            "and BSD and Inner-Net and Public Domain and GFDL"
         )
         self.inspection = "license"
         self.result = "INFO"
@@ -425,4 +425,60 @@ class NotAllowedExceptionLicenseKoji(TestKoji):
         self.rpm.addLicense("DERP")
         self.inspection = "license"
         self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# Valid compound SPDX license expression (INFO)
+class ValidCompoundSPDXLicenseExpressionSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT AND ISC")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidCompoundSPDXLicenseExpressionRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT AND ISC")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidCompoundSPDXLicenseExpressionKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT AND ISC")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# Invalid compound SPDX license expression (BAD)
+class InvalidCompoundSPDXLicenseExpressionSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT and ISC")
+        self.inspection = "license"
+        self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
+
+
+class InvalidCompoundSPDXLicenseExpressionRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT and ISC")
+        self.inspection = "license"
+        self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
+
+
+class InvalidCompoundSPDXLicenseExpressionKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT and ISC")
+        self.inspection = "license"
+        self.result = "BAD"
         self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
SPDX license names can be case-insensitive, but the boolean terms must be uppercase (thanks, spec!).  Ensure the license inspection honors this.

Fixes: #1335