### PR TITLE
[lib] End execstack testing early if there is no after_execstack

### DIFF
--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -447,6 +447,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
         }
 
         free(params.msg);
+        return result;
     }
 
     /* Check that the execstack flags make sense */


### PR DESCRIPTION
This just terminates the function earlier.  The rest of the function requires the presence of after_execstack so since we don't have that, just go ahead and return.