### PR TITLE
[ci] libtoml lacks a 'make install' target; install manually

### DIFF
--- a/osdeps/almalinux8/post.sh
+++ b/osdeps/almalinux8/post.sh
@@ -13,7 +13,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/almalinux9/post.sh
+++ b/osdeps/almalinux9/post.sh
@@ -26,7 +26,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -94,7 +94,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/amzn2/post.sh
+++ b/osdeps/amzn2/post.sh
@@ -33,7 +33,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/centos7/post.sh
+++ b/osdeps/centos7/post.sh
@@ -87,7 +87,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/centos8/post.sh
+++ b/osdeps/centos8/post.sh
@@ -13,7 +13,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/centos9/post.sh
+++ b/osdeps/centos9/post.sh
@@ -13,7 +13,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/debian-stable/post.sh
+++ b/osdeps/debian-stable/post.sh
@@ -70,7 +70,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/debian-testing/post.sh
+++ b/osdeps/debian-testing/post.sh
@@ -70,7 +70,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/freebsd/post.sh
+++ b/osdeps/freebsd/post.sh
@@ -80,7 +80,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/mageia/post.sh
+++ b/osdeps/mageia/post.sh
@@ -74,7 +74,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/opensuse-leap/post.sh
+++ b/osdeps/opensuse-leap/post.sh
@@ -65,7 +65,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/opensuse-tumbleweed/post.sh
+++ b/osdeps/opensuse-tumbleweed/post.sh
@@ -53,7 +53,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/oraclelinux8/post.sh
+++ b/osdeps/oraclelinux8/post.sh
@@ -26,7 +26,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 

--- a/osdeps/ubuntu/post.sh
+++ b/osdeps/ubuntu/post.sh
@@ -56,7 +56,8 @@ cd libtoml || exit 1
 cmake .
 make
 make test
-make install
+install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
+install -D -m 0644 toml.h /usr/local/include/toml.h
 cd "${CWD}" || exit 1
 rm -rf libtoml
 


### PR DESCRIPTION
I'm wondering if this is the ideal libtoml library to use.  Other distributions have libtoml++ and I think I saw another one out there. This one has no releases tagged, so I might bundle it like I do with libxdiff but if the system provides libtoml, let it use that.