### PR TITLE
Embed libtoml in source tree for systems that lack it

### DIFF
--- a/.github/workflows/fedora-aarch64.yml
+++ b/.github/workflows/fedora-aarch64.yml
@@ -80,4 +80,4 @@ jobs:
                   #
                   run: |
                       make instreqs SKIP_PIP=y
-                      make
+                      make MESON_OPTIONS="-D with_system_libtoml=true"

--- a/.github/workflows/fedora-ppc64le.yml
+++ b/.github/workflows/fedora-ppc64le.yml
@@ -81,4 +81,4 @@ jobs:
                   #
                   run: |
                       make instreqs SKIP_PIP=y
-                      make
+                      make MESON_OPTIONS="-D with_system_libtoml=true"

--- a/.github/workflows/fedora-s390x.yml
+++ b/.github/workflows/fedora-s390x.yml
@@ -81,4 +81,4 @@ jobs:
                   #
                   run: |
                       make instreqs SKIP_PIP=y
-                      make
+                      make MESON_OPTIONS="-D with_system_libtoml=true"

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -94,6 +94,6 @@ jobs:
                   fi
 
                   make instreqs
-                  make debug
+                  make debug MESON_OPTIONS="-D with_system_libtoml=true"
                   make check
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -77,13 +77,13 @@ all: setup
 	$(NINJA) -C $(MESON_BUILD_DIR) -v
 
 setup:
-	meson setup $(MESON_BUILD_DIR)
+	meson setup $(MESON_BUILD_DIR) $(MESON_OPTIONS)
 
 debug: setup-debug
 	$(NINJA) -C $(MESON_BUILD_DIR) -v
 
 setup-debug:
-	meson setup $(MESON_BUILD_DIR) --werror --buildtype=debug -Dpython_program="$(PYTHON)" -Db_coverage=true
+	meson setup $(MESON_BUILD_DIR) --werror --buildtype=debug -D python_program="$(PYTHON)" -D b_coverage=true $(MESON_OPTIONS)
 
 # NOTE: Set QA_RPATHS=63 so that check-rpaths is disabled during the
 # rpmfluff rpmbuild operations.  We want to let bad DT_RPATH values

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -128,7 +128,6 @@ deps = [
     libcurl,
     zlib,
     yaml,
-    toml,
     openssl,
     mandoc,
     magic,
@@ -170,12 +169,22 @@ if build_machine.system() == 'freebsd'
     deps += [ intl ]
 endif
 
+incdirs = [ inc, incxdiff ]
+locallibs = [ libxdiff ]
+
+if get_option('with_system_libtoml')
+    deps += [ toml ]
+else
+    incdirs += [ inctoml ]
+    locallibs += [ libtoml ]
+endif
+
 librpminspect = library(
     'rpminspect',
     librpminspect_sources,
-    include_directories : [ inc, incxdiff ],
+    include_directories : incdirs,
     version : '0.5.0',
     install : true,
-    link_with : [ libxdiff, ],
+    link_with : locallibs,
     dependencies : deps
 )

--- a/libtoml/LICENSE
+++ b/libtoml/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2013, Andrew Wansink
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/libtoml/README.md
+++ b/libtoml/README.md
@@ -1,0 +1,56 @@
+libtoml
+=======
+
+Fast C parser using Ragel to generate the state machine.
+
+Currently targetted at TOML v0.4.0
+
+Usage
+=====
+
+```c
+#include <toml.h>
+
+struct toml_node *root;
+struct toml_node *node;
+char *buf = "[foo]\nbar = 1\n";
+char *value;
+
+toml_init(&root);
+toml_parse(root, buf, len);
+
+node = toml_get(root, "foo.bar");
+
+toml_dump(root, stdout);
+
+value = toml_value_as_string(node);
+free(value);
+
+toml_free(root);
+```
+
+Building it
+===========
+
+Building libtoml requires cmake, ragel (the parser generator) and libicu for unicode support.
+
+```sh
+> cmake -G "Unix Makefiles" .
+> make
+```
+
+Testing it
+==========
+
+Compatible with [toml-test](https://github.com/BurntSushi/toml-test) when invoked
+as 'parser_test'
+
+```sh
+> ln -s main parser_test
+> $GOPATH/bin/toml-test $PWD/parser_test
+```
+
+TODO
+====
+
+More tests

--- a/libtoml/README.rpminspect
+++ b/libtoml/README.rpminspect
@@ -1,0 +1,24 @@
+This is a bundled copy of libtoml from this project:
+
+https://github.com/ajwans/libtoml
+
+The examples/ subdirectory has been removed as well as the
+CMakeLists.txt file.  I also removed test.c and main.c because this
+bundled library is only to build libtoml.a. config.h has been removed
+as well because it was only used by ccan and the value was static, so
+ccan has been modified to not conditonalize HAVE_TYPEOF.
+
+The parser has already been generated with ragel so that ragel is not
+a build dependency of rpminspect.  The toml_parse.c file can be
+regenerated with ragel with this command:
+
+    ragel -e -p -o toml_parse.c toml_parse.rl
+
+The generated toml_parse.c file was then stripped of all #line lines,
+uninitialized variables initialized, and unused variables removed.
+
+Other compile fixes have been committed to this fork.
+
+--
+David Cantrell
+<dcantrell@redhat.com>

--- a/libtoml/ccan/build_assert.h
+++ b/libtoml/ccan/build_assert.h
@@ -1,0 +1,39 @@
+#ifndef CCAN_BUILD_ASSERT_H
+#define CCAN_BUILD_ASSERT_H
+
+/**
+ * BUILD_ASSERT - assert a build-time dependency.
+ * @cond: the compile-time condition which must be true.
+ *
+ * Your compile will fail if the condition isn't true, or can't be evaluated
+ * by the compiler.  This can only be used within a function.
+ *
+ * Example:
+ *	#include <stddef.h>
+ *	...
+ *	static char *foo_to_char(struct foo *foo)
+ *	{
+ *		// This code needs string to be at start of foo.
+ *		BUILD_ASSERT(offsetof(struct foo, string) == 0);
+ *		return (char *)foo;
+ *	}
+ */
+#define BUILD_ASSERT(cond) \
+	do { (void) sizeof(char [1 - 2*!(cond)]); } while(0)
+
+/**
+ * EXPR_BUILD_ASSERT - assert a build-time dependency, as an expression.
+ * @cond: the compile-time condition which must be true.
+ *
+ * Your compile will fail if the condition isn't true, or can't be evaluated
+ * by the compiler.  This can be used in an expression: its value is "0".
+ *
+ * Example:
+ *	#define foo_to_char(foo)					\
+ *		 ((char *)(foo)						\
+ *		  + EXPR_BUILD_ASSERT(offsetof(struct foo, string) == 0))
+ */
+#define EXPR_BUILD_ASSERT(cond) \
+	(sizeof(char [1 - 2*!(cond)]) - 1)
+
+#endif /* CCAN_BUILD_ASSERT_H */

--- a/libtoml/ccan/build_assert/build_assert.h
+++ b/libtoml/ccan/build_assert/build_assert.h
@@ -1,0 +1,39 @@
+#ifndef CCAN_BUILD_ASSERT_H
+#define CCAN_BUILD_ASSERT_H
+
+/**
+ * BUILD_ASSERT - assert a build-time dependency.
+ * @cond: the compile-time condition which must be true.
+ *
+ * Your compile will fail if the condition isn't true, or can't be evaluated
+ * by the compiler.  This can only be used within a function.
+ *
+ * Example:
+ *	#include <stddef.h>
+ *	...
+ *	static char *foo_to_char(struct foo *foo)
+ *	{
+ *		// This code needs string to be at start of foo.
+ *		BUILD_ASSERT(offsetof(struct foo, string) == 0);
+ *		return (char *)foo;
+ *	}
+ */
+#define BUILD_ASSERT(cond) \
+	do { (void) sizeof(char [1 - 2*!(cond)]); } while(0)
+
+/**
+ * EXPR_BUILD_ASSERT - assert a build-time dependency, as an expression.
+ * @cond: the compile-time condition which must be true.
+ *
+ * Your compile will fail if the condition isn't true, or can't be evaluated
+ * by the compiler.  This can be used in an expression: its value is "0".
+ *
+ * Example:
+ *	#define foo_to_char(foo)					\
+ *		 ((char *)(foo)						\
+ *		  + EXPR_BUILD_ASSERT(offsetof(struct foo, string) == 0))
+ */
+#define EXPR_BUILD_ASSERT(cond) \
+	(sizeof(char [1 - 2*!(cond)]) - 1)
+
+#endif /* CCAN_BUILD_ASSERT_H */

--- a/libtoml/ccan/check_type/check_type.h
+++ b/libtoml/ccan/check_type/check_type.h
@@ -1,0 +1,52 @@
+#ifndef CCAN_CHECK_TYPE_H
+#define CCAN_CHECK_TYPE_H
+
+/**
+ * check_type - issue a warning or build failure if type is not correct.
+ * @expr: the expression whose type we should check (not evaluated).
+ * @type: the exact type we expect the expression to be.
+ *
+ * This macro is usually used within other macros to try to ensure that a macro
+ * argument is of the expected type.  No type promotion of the expression is
+ * done: an unsigned int is not the same as an int!
+ *
+ * check_type() always evaluates to 1.
+ *
+ * If your compiler does not support typeof, then the best we can do is fail
+ * to compile if the sizes of the types are unequal (a less complete check).
+ *
+ * Example:
+ *	// They should always pass a 64-bit value to _set_some_value!
+ *	#define set_some_value(expr)			\
+ *		_set_some_value((check_type((expr), uint64_t), (expr)))
+ */
+
+/**
+ * check_types_match - issue a warning or build failure if types are not same.
+ * @expr1: the first expression (not evaluated).
+ * @expr2: the second expression (not evaluated).
+ *
+ * This macro is usually used within other macros to try to ensure that
+ * arguments are of identical types.  No type promotion of the expressions is
+ * done: an unsigned int is not the same as an int!
+ *
+ * check_types_match() always evaluates to 0.
+ *
+ * If your compiler does not support typeof, then the best we can do is fail
+ * to compile if the sizes of the types are unequal (a less complete check).
+ *
+ * Example:
+ *	// Do subtraction to get to enclosing type, but make sure that
+ *	// pointer is of correct type for that member. 
+ *	#define container_of(mbr_ptr, encl_type, mbr)			\
+ *		(check_types_match((mbr_ptr), &((encl_type *)0)->mbr),	\
+ *		 ((encl_type *)						\
+ *		  ((char *)(mbr_ptr) - offsetof(enclosing_type, mbr))))
+ */
+#define check_type(expr, type)			\
+	((typeof(expr) *)0 != (type *)0)
+
+#define check_types_match(expr1, expr2)		\
+	((typeof(expr1) *)0 != (typeof(expr2) *)0)
+
+#endif /* CCAN_CHECK_TYPE_H */

--- a/libtoml/ccan/container_of/container_of.h
+++ b/libtoml/ccan/container_of/container_of.h
@@ -1,0 +1,56 @@
+#ifndef CCAN_CONTAINER_OF_H
+#define CCAN_CONTAINER_OF_H
+#include <stddef.h>
+
+#include <ccan/check_type/check_type.h>
+
+/**
+ * container_of - get pointer to enclosing structure
+ * @member_ptr: pointer to the structure member
+ * @containing_type: the type this member is within
+ * @member: the name of this member within the structure.
+ *
+ * Given a pointer to a member of a structure, this macro does pointer
+ * subtraction to return the pointer to the enclosing type.
+ *
+ * Example:
+ *	struct foo {
+ *		int fielda, fieldb;
+ *		// ...
+ *	};
+ *	struct info {
+ *		int some_other_field;
+ *		struct foo my_foo;
+ *	};
+ *
+ *	static struct info *foo_to_info(struct foo *foo)
+ *	{
+ *		return container_of(foo, struct info, my_foo);
+ *	}
+ */
+#define container_of(member_ptr, containing_type, member)		\
+	 ((containing_type *)						\
+	  ((char *)(member_ptr) - offsetof(containing_type, member))	\
+	  - check_types_match(*(member_ptr), ((containing_type *)0)->member))
+
+
+/**
+ * container_of_var - get pointer to enclosing structure using a variable
+ * @member_ptr: pointer to the structure member
+ * @var: a pointer to a structure of same type as this member is within
+ * @member: the name of this member within the structure.
+ *
+ * Given a pointer to a member of a structure, this macro does pointer
+ * subtraction to return the pointer to the enclosing type.
+ *
+ * Example:
+ *	static struct info *foo_to_i(struct foo *foo)
+ *	{
+ *		struct info *i = container_of_var(foo, i, my_foo);
+ *		return i;
+ *	}
+ */
+#define container_of_var(member_ptr, var, member) \
+	container_of(member_ptr, typeof(*var), member)
+
+#endif /* CCAN_CONTAINER_OF_H */

--- a/libtoml/ccan/list/list.h
+++ b/libtoml/ccan/list/list.h
@@ -1,0 +1,340 @@
+#ifndef CCAN_LIST_H
+#define CCAN_LIST_H
+#include <stdbool.h>
+#include <assert.h>
+#include <ccan/container_of/container_of.h>
+
+/**
+ * struct list_node - an entry in a doubly-linked list
+ * @next: next entry (self if empty)
+ * @prev: previous entry (self if empty)
+ *
+ * This is used as an entry in a linked list.
+ * Example:
+ *	struct child {
+ *		const char *name;
+ *		// Linked list of all us children.
+ *		struct list_node list;
+ *	};
+ */
+struct list_node
+{
+	struct list_node *next, *prev;
+};
+
+/**
+ * struct list_head - the head of a doubly-linked list
+ * @h: the list_head (containing next and prev pointers)
+ *
+ * This is used as the head of a linked list.
+ * Example:
+ *	struct parent {
+ *		const char *name;
+ *		struct list_head children;
+ *		unsigned int num_children;
+ *	};
+ */
+struct list_head
+{
+	struct list_node n;
+};
+
+/**
+ * list_check - check head of a list for consistency
+ * @h: the list_head
+ * @abortstr: the location to print on aborting, or NULL.
+ *
+ * Because list_nodes have redundant information, consistency checking between
+ * the back and forward links can be done.  This is useful as a debugging check.
+ * If @abortstr is non-NULL, that will be printed in a diagnostic if the list
+ * is inconsistent, and the function will abort.
+ *
+ * Returns the list head if the list is consistent, NULL if not (it
+ * can never return NULL if @abortstr is set).
+ *
+ * See also: list_check_node()
+ *
+ * Example:
+ *	static void dump_parent(struct parent *p)
+ *	{
+ *		struct child *c;
+ *
+ *		printf("%s (%u children):\n", p->name, p->num_children);
+ *		list_check(&p->children, "bad child list");
+ *		list_for_each(&p->children, c, list)
+ *			printf(" -> %s\n", c->name);
+ *	}
+ */
+struct list_head *list_check(const struct list_head *h, const char *abortstr);
+
+/**
+ * list_check_node - check node of a list for consistency
+ * @n: the list_node
+ * @abortstr: the location to print on aborting, or NULL.
+ *
+ * Check consistency of the list node is in (it must be in one).
+ *
+ * See also: list_check()
+ *
+ * Example:
+ *	static void dump_child(const struct child *c)
+ *	{
+ *		list_check_node(&c->list, "bad child list");
+ *		printf("%s\n", c->name);
+ *	}
+ */
+struct list_node *list_check_node(const struct list_node *n,
+				  const char *abortstr);
+
+#ifdef CCAN_LIST_DEBUG
+#define list_debug(h) list_check((h), __func__)
+#define list_debug_node(n) list_check_node((n), __func__)
+#else
+#define list_debug(h) (h)
+#define list_debug_node(n) (n)
+#endif
+
+/**
+ * LIST_HEAD_INIT - initializer for an empty list_head
+ * @name: the name of the list.
+ *
+ * Explicit initializer for an empty list.
+ *
+ * See also:
+ *	LIST_HEAD, list_head_init()
+ *
+ * Example:
+ *	static struct list_head my_list = LIST_HEAD_INIT(my_list);
+ */
+#define LIST_HEAD_INIT(name) { { &name.n, &name.n } }
+
+/**
+ * LIST_HEAD - define and initialize an empty list_head
+ * @name: the name of the list.
+ *
+ * The LIST_HEAD macro defines a list_head and initializes it to an empty
+ * list.  It can be prepended by "static" to define a static list_head.
+ *
+ * See also:
+ *	LIST_HEAD_INIT, list_head_init()
+ *
+ * Example:
+ *	static LIST_HEAD(my_global_list);
+ */
+#define LIST_HEAD(name) \
+	struct list_head name = LIST_HEAD_INIT(name)
+
+/**
+ * list_head_init - initialize a list_head
+ * @h: the list_head to set to the empty list
+ *
+ * Example:
+ *	...
+ *	struct parent *parent = malloc(sizeof(*parent));
+ *
+ *	list_head_init(&parent->children);
+ *	parent->num_children = 0;
+ */
+static inline void list_head_init(struct list_head *h)
+{
+	h->n.next = h->n.prev = &h->n;
+}
+
+/**
+ * list_add - add an entry at the start of a linked list.
+ * @h: the list_head to add the node to
+ * @n: the list_node to add to the list.
+ *
+ * The list_node does not need to be initialized; it will be overwritten.
+ * Example:
+ *	struct child *child = malloc(sizeof(*child));
+ *
+ *	child->name = "marvin";
+ *	list_add(&parent->children, &child->list);
+ *	parent->num_children++;
+ */
+static inline void list_add(struct list_head *h, struct list_node *n)
+{
+	n->next = h->n.next;
+	n->prev = &h->n;
+	h->n.next->prev = n;
+	h->n.next = n;
+	(void)list_debug(h);
+}
+
+/**
+ * list_add_tail - add an entry at the end of a linked list.
+ * @h: the list_head to add the node to
+ * @n: the list_node to add to the list.
+ *
+ * The list_node does not need to be initialized; it will be overwritten.
+ * Example:
+ *	list_add_tail(&parent->children, &child->list);
+ *	parent->num_children++;
+ */
+static inline void list_add_tail(struct list_head *h, struct list_node *n)
+{
+	n->next = &h->n;
+	n->prev = h->n.prev;
+	h->n.prev->next = n;
+	h->n.prev = n;
+	(void)list_debug(h);
+}
+
+/**
+ * list_empty - is a list empty?
+ * @h: the list_head
+ *
+ * If the list is empty, returns true.
+ *
+ * Example:
+ *	assert(list_empty(&parent->children) == (parent->num_children == 0));
+ */
+static inline bool list_empty(const struct list_head *h)
+{
+	(void)list_debug(h);
+	return h->n.next == &h->n;
+}
+
+/**
+ * list_del - delete an entry from an (unknown) linked list.
+ * @n: the list_node to delete from the list.
+ *
+ * Note that this leaves @n in an undefined state; it can be added to
+ * another list, but not deleted again.
+ *
+ * See also:
+ *	list_del_from()
+ *
+ * Example:
+ *	list_del(&child->list);
+ *	parent->num_children--;
+ */
+static inline void list_del(struct list_node *n)
+{
+	(void)list_debug_node(n);
+	n->next->prev = n->prev;
+	n->prev->next = n->next;
+#ifdef CCAN_LIST_DEBUG
+	/* Catch use-after-del. */
+	n->next = n->prev = NULL;
+#endif
+}
+
+/**
+ * list_del_from - delete an entry from a known linked list.
+ * @h: the list_head the node is in.
+ * @n: the list_node to delete from the list.
+ *
+ * This explicitly indicates which list a node is expected to be in,
+ * which is better documentation and can catch more bugs.
+ *
+ * See also: list_del()
+ *
+ * Example:
+ *	list_del_from(&parent->children, &child->list);
+ *	parent->num_children--;
+ */
+static inline void list_del_from(struct list_head *h, struct list_node *n)
+{
+#ifdef CCAN_LIST_DEBUG
+	{
+		/* Thorough check: make sure it was in list! */
+		struct list_node *i;
+		for (i = h->n.next; i != n; i = i->next)
+			assert(i != &h->n);
+	}
+#endif /* CCAN_LIST_DEBUG */
+
+	/* Quick test that catches a surprising number of bugs. */
+	assert(!list_empty(h));
+	list_del(n);
+}
+
+/**
+ * list_entry - convert a list_node back into the structure containing it.
+ * @n: the list_node
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * Example:
+ *	// First list entry is children.next; convert back to child.
+ *	child = list_entry(parent->children.n.next, struct child, list);
+ *
+ * See Also:
+ *	list_top(), list_for_each()
+ */
+#define list_entry(n, type, member) container_of(n, type, member)
+
+/**
+ * list_top - get the first entry in a list
+ * @h: the list_head
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * If the list is empty, returns NULL.
+ *
+ * Example:
+ *	struct child *first;
+ *	first = list_top(&parent->children, struct child, list);
+ */
+#define list_top(h, type, member) \
+	(list_empty(h) ? NULL : list_entry((h)->n.next, type, member))
+
+/**
+ * list_tail - get the last entry in a list
+ * @h: the list_head
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * If the list is empty, returns NULL.
+ *
+ * Example:
+ *	struct child *last;
+ *	last = list_tail(&parent->children, struct child, list);
+ */
+#define list_tail(h, type, member) \
+	(list_empty(h) ? NULL : list_entry((h)->n.prev, type, member))
+
+/**
+ * list_for_each - iterate through a list.
+ * @h: the list_head
+ * @i: the structure containing the list_node
+ * @member: the list_node member of the structure
+ *
+ * This is a convenient wrapper to iterate @i over the entire list.  It's
+ * a for loop, so you can break and continue as normal.
+ *
+ * Example:
+ *	list_for_each(&parent->children, child, list)
+ *		printf("Name: %s\n", child->name);
+ */
+#define list_for_each(h, i, member)					\
+	for (i = container_of_var(list_debug(h)->n.next, i, member);	\
+	     &i->member != &(h)->n;					\
+	     i = container_of_var(i->member.next, i, member))
+
+/**
+ * list_for_each_safe - iterate through a list, maybe during deletion
+ * @h: the list_head
+ * @i: the structure containing the list_node
+ * @nxt: the structure containing the list_node
+ * @member: the list_node member of the structure
+ *
+ * This is a convenient wrapper to iterate @i over the entire list.  It's
+ * a for loop, so you can break and continue as normal.  The extra variable
+ * @nxt is used to hold the next element, so you can delete @i from the list.
+ *
+ * Example:
+ *	struct child *next;
+ *	list_for_each_safe(&parent->children, child, next, list) {
+ *		list_del(&child->list);
+ *		parent->num_children--;
+ *	}
+ */
+#define list_for_each_safe(h, i, nxt, member)				\
+	for (i = container_of_var(list_debug(h)->n.next, i, member),	\
+		nxt = container_of_var(i->member.next, i, member);	\
+	     &i->member != &(h)->n;					\
+	     i = nxt, nxt = container_of_var(i->member.next, i, member))
+#endif /* CCAN_LIST_H */

--- a/libtoml/meson.build
+++ b/libtoml/meson.build
@@ -1,0 +1,13 @@
+# Build libtoml
+libtoml_sources = [
+    'toml.c',
+    'toml_parse.c',
+    'toml_private.c',
+]
+
+libtoml = static_library(
+    'toml',
+    libtoml_sources,
+    include_directories : inc,
+    install : false,
+)

--- a/libtoml/toml.c
+++ b/libtoml/toml.c
@@ -1,0 +1,532 @@
+#include "toml.h"
+#include "toml_private.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <time.h>
+#include <errno.h>
+#include <string.h>
+
+int
+toml_init(struct toml_node **toml_root)
+{
+	struct toml_node *toml_node;
+
+	toml_node = malloc(sizeof(*toml_node));
+	if (!toml_node) {
+		return -1;
+	}
+
+	toml_node->type = TOML_ROOT;
+	toml_node->name = NULL;
+	list_head_init(&toml_node->value.map);
+
+	*toml_root = toml_node;
+	return 0;
+}
+
+struct toml_node *
+toml_get(struct toml_node *toml_root, char *key)
+{
+	char *ancestor, *tofree, *name;
+	struct toml_node *node = toml_root;
+
+	tofree = name = strdup(key);
+
+	while ((ancestor = strsep(&name, "."))) {
+		struct toml_table_item *item = NULL;
+		int found = 0;
+
+		list_for_each(&node->value.map, item, map) {
+			if (!item->node.name)
+				continue;
+							
+			if (strcmp(item->node.name, ancestor) == 0) {
+				node = &item->node;
+				found = 1;
+				break;
+			}
+		}
+
+		if (!found) {
+			node = NULL;
+			break;
+		}
+	}
+
+	free(tofree);
+
+	return node;
+}
+
+static void
+_toml_dump(struct toml_node *toml_node, FILE *output, char *bname, int indent,
+																	int newline)
+{
+	int		i;
+	char*	value;
+
+	for (i = 0; i < indent - 1; i++)
+		fprintf(output, "\t");
+
+	switch (toml_node->type) {
+	case TOML_ROOT: {
+		struct toml_table_item *item = NULL;
+
+		list_for_each(&toml_node->value.map, item, map) {
+			_toml_dump(&item->node, output, toml_node->name, indent, 1);
+		}
+		break;
+	}
+
+	case TOML_INLINE_TABLE:
+	case TOML_TABLE: {
+		struct toml_table_item *item = NULL;
+		char name[100];
+
+		if (toml_node->name) {
+			sprintf(name, "%s%s%s", bname ? bname : "", bname ? "." : "",
+															toml_node->name);
+			fprintf(output, "%s[%s]\n", indent ? "\t": "", name);
+		}
+		list_for_each(&toml_node->value.map, item, map)
+			_toml_dump(&item->node, output, name, indent+1, 1);
+		fprintf(output, "\n");
+		break;
+	}
+
+	case TOML_LIST: {
+		struct toml_list_item *item = NULL;
+		struct toml_list_item *tail =
+				list_tail(&toml_node->value.list, struct toml_list_item, list);
+
+		if (toml_node->name)
+			fprintf(output, "%s = ", toml_node->name);
+		fprintf(output, "[ ");
+		list_for_each(&toml_node->value.list, item, list) {
+			_toml_dump(&item->node, output, toml_node->name, 0, 0);
+			if (item != tail)
+				fprintf(output, ", ");
+		}
+		fprintf(output, " ]%s", newline ? "\n" : "");
+
+		break;
+	}
+
+	case TOML_INT:
+	case TOML_FLOAT:
+	case TOML_STRING:
+	case TOML_DATE:
+	case TOML_BOOLEAN:
+		if (toml_node->name)
+			fprintf(output, "%s = ", toml_node->name);
+		value = toml_value_as_string(toml_node);
+		fprintf(output, "%s%s%s%s",
+				toml_node->type == TOML_STRING ? "\"" : "",
+				value, 
+				toml_node->type == TOML_STRING ? "\"" : "",
+				newline ? "\n" : "");
+		free(value);
+		break;
+
+	case TOML_TABLE_ARRAY: {
+		struct toml_list_item *item = NULL;
+
+		list_for_each(&toml_node->value.list, item, list) {
+			fprintf(output, "[[%s]]\n", toml_node->name);
+			_toml_dump(&item->node, output, toml_node->name, indent, 1);
+		}
+
+		break;
+	}
+
+	default:
+		fprintf(stderr, "unknown toml type %d\n", toml_node->type);
+		/* assert(toml_node->type); */
+	}
+}
+
+enum order {
+	kOrderWalk = 1,
+	kOrderDive
+};
+
+static void
+_toml_process(struct toml_node *node, toml_node_walker fn, enum order order, void *ctx)
+{
+	if (order == kOrderWalk)
+		fn(node, ctx);
+
+	switch (node->type) {
+	case TOML_ROOT:
+	case TOML_INLINE_TABLE:
+	case TOML_TABLE: {
+		struct toml_table_item *item = NULL, *next = NULL;
+
+		list_for_each_safe(&node->value.map, item, next, map)
+			_toml_process(&item->node, fn, order, ctx);
+		break;
+	}
+
+	case TOML_TABLE_ARRAY:
+	case TOML_LIST: {
+		struct toml_list_item *item = NULL, *next = NULL;
+
+		list_for_each_safe(&node->value.list, item, next, list) {
+			_toml_process(&item->node, fn, order, ctx);
+		}
+		break;
+	}
+
+	default:
+		break;
+	}
+
+	if (order == kOrderDive)
+		fn(node, ctx);
+}
+
+void
+toml_walk(struct toml_node *root, toml_node_walker fn, void *ctx)
+{
+	_toml_process(root, fn, kOrderWalk, ctx);
+}
+
+void
+toml_dive(struct toml_node *root, toml_node_walker fn, void *ctx)
+{
+	_toml_process(root, fn, kOrderDive, ctx);
+}
+
+void
+toml_dump(struct toml_node *toml_root, FILE *output)
+{
+	_toml_dump(toml_root, output, NULL, 0, 1);
+}
+
+static char*
+_json_string_encode(const char* string)
+{
+	char*	ret;
+	int		j = 0;
+	int		i = 0;
+
+	for (i = 0; string[i]; i++)
+	{
+		switch (string[i]) {
+		case '"':
+		case '\\':
+		case '/':
+		case '\b':
+		case '\f':
+		case '\n':
+		case '\r':
+		case '\t':
+			j++;
+
+		default:
+			break;
+		}
+	}
+
+	ret = malloc(i + j + 1);
+	for (i = 0, j = 0; string[i]; i++)
+	{
+		switch (string[i]) {
+		case '"':
+			ret[i+j++] = '\\';
+			ret[i+j] = '"';
+			break;
+
+		case '\\':
+			ret[i+j++] = '\\';
+			ret[i+j] = '\\';
+			break;
+
+		case '/':
+			ret[i+j++] = '\\';
+			ret[i+j] = '/';
+			break;
+
+		case '\b':
+			ret[i+j++] = '\\';
+			ret[i+j] = 'b';
+			break;
+
+		case '\f':
+			ret[i+j++] = '\\';
+			ret[i+j] = 'f';
+			break;
+
+		case '\n':
+			ret[i+j++] = '\\';
+			ret[i+j] = 'n';
+			break;
+
+		case '\r':
+			ret[i+j++] = '\\';
+			ret[i+j] = 'r';
+			break;
+
+		case '\t':
+			ret[i+j++] = '\\';
+			ret[i+j] = 't';
+			break;
+
+		default:
+			ret[i+j] = string[i];
+			break;
+		}
+	}
+
+	ret[i+j] = 0;
+
+	return ret;
+}
+
+static void
+_output_name(struct toml_node* node, FILE* output)
+{
+	char* name;
+
+	if (!node->name)
+		return;
+
+	name = _json_string_encode(node->name);
+	fprintf(output, "\"%s\": ", name);
+	free(name);
+}
+
+static void
+_toml_tojson(struct toml_node *toml_node, FILE *output, int indent)
+{
+	int		i;
+	char*	value;
+
+	char*	toml_json_types[TOML_MAX];
+
+	toml_json_types[TOML_INT]		= "integer";
+	toml_json_types[TOML_FLOAT]		= "float";
+	toml_json_types[TOML_STRING]	= "string";
+	toml_json_types[TOML_DATE]		= "datetime";
+	toml_json_types[TOML_BOOLEAN]	= "bool";
+
+	for (i = 0; i < indent - 1; i++)
+		fprintf(output, "\t");
+
+	switch (toml_node->type) {
+	case TOML_ROOT: {
+		struct toml_table_item *item = NULL;
+		struct toml_table_item *tail =
+			list_tail(&toml_node->value.map, struct toml_table_item, map);
+
+		list_for_each(&toml_node->value.map, item, map) {
+			_toml_tojson(&item->node, output, indent+1);
+			fprintf(output, "%s\n", item != tail ? "," : "");
+		}
+		break;
+	}
+
+	case TOML_INLINE_TABLE:
+	case TOML_TABLE: {
+		struct toml_table_item *item = NULL;
+		struct toml_table_item *tail =
+			list_tail(&toml_node->value.map, struct toml_table_item, map);
+
+		_output_name(toml_node, output);
+
+		fprintf(output, "{\n");
+
+		list_for_each(&toml_node->value.map, item, map) {
+			_toml_tojson(&item->node, output, indent+1);
+			fprintf(output, "%s\n", item != tail ? "," : "");
+		}
+
+		for (i = 0; i < indent - 1; i++)
+			fprintf(output, "\t");
+		fprintf(output, "}");
+		break;
+	}
+
+	case TOML_LIST: {
+		struct toml_list_item *item = NULL;
+		struct toml_list_item *tail =
+			list_tail(&toml_node->value.map, struct toml_list_item, list);
+
+		_output_name(toml_node, output);
+		fprintf(output, "{ \"type\": \"array\", \"value\": [\n");
+
+		list_for_each(&toml_node->value.list, item, list) {
+			_toml_tojson(&item->node, output, indent+1);
+			fprintf(output, "%s\n", item != tail ? "," : "");
+		}
+
+		for (i = 0; i < indent - 1; i++)
+			fprintf(output, "\t");
+		fprintf(output, " ] }");
+		break;
+	}
+
+	case TOML_INT:
+	case TOML_FLOAT:
+	case TOML_STRING:
+	case TOML_DATE:
+	case TOML_BOOLEAN:
+		value = toml_value_as_string(toml_node);
+		_output_name(toml_node, output);
+		fprintf(output, "{ \"type\": \"%s\", \"value\": \"%s\" }",
+									toml_json_types[toml_node->type], value);
+		free(value);
+		break;
+
+	case TOML_TABLE_ARRAY: {
+		struct toml_list_item *item = NULL;
+		struct toml_list_item *tail =
+			list_tail(&toml_node->value.list, struct toml_list_item, list);
+
+		_output_name(toml_node, output);
+		fprintf(output, "[\n");
+
+		list_for_each(&toml_node->value.list, item, list) {
+			_toml_tojson(&item->node, output, indent+1);
+			fprintf(output, "%s\n", item != tail ? "," : "");
+		}
+
+		for (i = 0; i < indent - 1; i++)
+			fprintf(output, "\t");
+		fprintf(output, "]");
+		break;
+	}
+
+	default:
+		fprintf(stderr, "unknown toml type %d\n", toml_node->type);
+		/* assert(toml_node->type); */
+	}
+}
+
+void
+toml_tojson(struct toml_node *toml_root, FILE *output)
+{
+	fprintf(output, "{\n");
+	_toml_tojson(toml_root, output, 1);
+	fprintf(output, "}\n");
+}
+
+static void
+toml_node_walker_free(struct toml_node* node, __attribute__((unused)) void* ctx)
+{
+	if (node->name)
+		free(node->name);
+
+	switch (node->type) {
+	case TOML_ROOT:
+	case TOML_INLINE_TABLE:
+	case TOML_TABLE: {
+		struct toml_table_item *item = NULL, *next = NULL;
+
+		list_for_each_safe(&node->value.map, item, next, map) {
+			list_del(&item->map);
+			free(item);
+		}
+		break;
+	}
+
+	case TOML_TABLE_ARRAY:
+	case TOML_LIST: {
+		struct toml_list_item *item = NULL, *next = NULL;
+
+		list_for_each_safe(&node->value.list, item, next, list) {
+			list_del(&item->list);
+			free(item);
+		}
+		break;
+	}
+
+	case TOML_STRING:
+		free(node->value.string);
+		break;
+
+	default:
+		break;
+	}
+}
+
+void
+toml_free(struct toml_node *toml_root)
+{
+	assert(toml_root->type == TOML_ROOT);
+	toml_dive(toml_root, toml_node_walker_free, NULL);
+	free(toml_root);
+}
+
+char*
+toml_value_as_string(struct toml_node* node)
+{
+	char* ret = NULL;
+
+	switch (node->type)
+	{
+	case TOML_INT:
+		asprintf(&ret, "%" PRId64, node->value.integer);
+		break;
+
+	case TOML_FLOAT:
+		asprintf(&ret, "%.*f", node->value.floating.precision,
+								node->value.floating.value);
+		break;
+
+	case TOML_STRING:
+		ret = _json_string_encode(node->value.string);
+		break;
+
+	case TOML_DATE: {
+		struct tm	tm;
+		char		offset_string[7] = "Z";
+		char		sec_frac[1024] = "";
+
+		if (!node->value.rfc3339_time.offset_is_zulu)
+			sprintf(offset_string, "%s%02d:%02d",
+				node->value.rfc3339_time.offset_sign_negative ? "-" : "+",
+				node->value.rfc3339_time.offset / 60,
+				node->value.rfc3339_time.offset % 60);
+
+		if (node->value.rfc3339_time.sec_frac != -1)
+			snprintf(sec_frac, sizeof(sec_frac), ".%d",
+											node->value.rfc3339_time.sec_frac);
+
+		if (!gmtime_r(&node->value.rfc3339_time.epoch, &tm))
+			break;
+
+		asprintf(&ret, "%d-%02d-%02dT%02d:%02d:%02d%s%s",
+			1900 + tm.tm_year,
+			tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec,
+			sec_frac, offset_string);
+		break;
+	}
+
+	case TOML_BOOLEAN:
+		asprintf(&ret, "%s", node->value.integer ? "true" : "false");
+		break;
+
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+enum toml_type
+toml_type(struct toml_node* node)
+{
+	return node->type;
+}
+
+char*
+toml_name(struct toml_node* node)
+{
+	return _json_string_encode(node->name);
+}

--- a/libtoml/toml.h
+++ b/libtoml/toml.h
@@ -1,0 +1,44 @@
+#ifndef TOML_H
+#define TOML_H
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum toml_type {
+	TOML_ROOT = 1,
+	TOML_TABLE,
+	TOML_LIST,
+	TOML_INT,
+	TOML_FLOAT,
+	TOML_STRING,
+	TOML_DATE,
+	TOML_BOOLEAN,
+	TOML_TABLE_ARRAY,
+	TOML_INLINE_TABLE,
+	TOML_MAX
+};
+
+struct toml_node;
+
+typedef void (*toml_node_walker)(struct toml_node*, void*);
+
+int toml_init(struct toml_node**);
+int toml_parse(struct toml_node*, char*, int);
+struct toml_node* toml_get(struct toml_node*, char*);
+void toml_dump(struct toml_node*, FILE*);
+void toml_tojson(struct toml_node*, FILE*);
+void toml_free(struct toml_node*);
+void toml_walk(struct toml_node*, toml_node_walker, void*);
+void toml_dive(struct toml_node*, toml_node_walker, void*);
+enum toml_type toml_type(struct toml_node*);
+char* toml_name(struct toml_node*);				/* caller should free return value */
+char* toml_value_as_string(struct toml_node*);	/* caller should free return value */
+
+#ifdef __cplusplus
+}; // extern "C"
+#endif
+
+#endif /* TOML_H */

--- a/libtoml/toml_private.c
+++ b/libtoml/toml_private.c
@@ -1,0 +1,168 @@
+#include "toml_private.h"
+
+#include <ccan/list/list.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+const char *
+toml_type_to_str(enum toml_type type)
+{
+#define CASE_ENUM_TO_STR(x) case(x): return #x
+	switch (type) {
+	CASE_ENUM_TO_STR(TOML_ROOT);
+	CASE_ENUM_TO_STR(TOML_TABLE);
+	CASE_ENUM_TO_STR(TOML_LIST);
+	CASE_ENUM_TO_STR(TOML_INT);
+	CASE_ENUM_TO_STR(TOML_FLOAT);
+	CASE_ENUM_TO_STR(TOML_STRING);
+	CASE_ENUM_TO_STR(TOML_DATE);
+	CASE_ENUM_TO_STR(TOML_BOOLEAN);
+	CASE_ENUM_TO_STR(TOML_TABLE_ARRAY);
+	CASE_ENUM_TO_STR(TOML_INLINE_TABLE);
+	default:
+		return "unknown toml type";
+	}
+#undef CASE_ENUM_TO_STR
+}
+
+static struct toml_node*
+InsertAnonymousTable(struct toml_node* place)
+{
+	struct toml_table_item* new_table;
+	new_table = malloc(sizeof(*new_table));
+	new_table->node.type = TOML_TABLE;
+	new_table->node.name = NULL;
+	list_head_init(&new_table->node.value.map);
+	list_add_tail(&place->value.list, &new_table->map);
+	return &new_table->node;
+}
+
+static struct toml_node*
+InsertTableArray(char* name, struct toml_node* place)
+{
+	struct toml_table_item* item;
+
+	item = malloc(sizeof(*item));
+	item->node.type = TOML_TABLE_ARRAY;
+	item->node.name = strdup(name);
+	list_head_init(&item->node.value.list);
+	list_add_tail(&place->value.map, &item->map);
+
+	return InsertAnonymousTable(&item->node);
+}
+
+int
+SawTableArray(struct toml_node* root, char* tableArrayName, struct toml_node** lastTable, __attribute__((unused)) char** err)
+{
+	char*					ancestor;
+	bool					found = false;
+	struct toml_table_item*	item;
+	struct toml_node*		place;
+
+	if (root->type != TOML_ROOT)
+		return 1;
+
+	/*
+	 * A table array is a list of anonymous tables.  Every time we see [[<table>]]
+	 * we should first instantiate <table> if it does not already exist.  Once we
+	 * have <table> we must add a new anonymous TOML_TABLE and set it to be the
+	 * current table.
+	 */
+	place = root;
+
+	while ((ancestor = strsep(&tableArrayName, "."))) {
+		found = false;
+
+		list_for_each(&place->value.map, item, map) {
+			if (!item->node.name)
+				continue;
+
+			if (!strcmp(item->node.name, ancestor))
+			{
+				struct toml_list_item* last;
+				last = list_tail(&item->node.value.list, struct toml_list_item, list);
+				place = &last->node;
+				found = true;
+				break;
+			}
+		}
+
+		if (found)
+			continue;
+
+		/* this is the instantiation of <table> or one of its sub-parts */
+		place = InsertTableArray(ancestor, place);
+		*lastTable = place;
+	}
+
+	/* This is the creation of an anoymous table once we reach the base of tableArrayName */
+	if (found)
+		*lastTable = InsertAnonymousTable(&item->node);
+
+	return 0;
+}
+
+int
+SawTable(struct toml_node* place, char* name, struct toml_node** lastTable, char** err)
+{
+	char *ancestor, *tofree = NULL, *tablename;
+	int item_added = 0;
+
+	tofree = tablename = strdup(name);
+	if (!tablename)
+		return ENOMEM;
+
+	while ((ancestor = strsep(&tablename, "."))) {
+		struct toml_table_item *item = NULL;
+		int found = 0;
+
+		if (strcmp(ancestor, "") == 0) {
+			asprintf(err, "empty implicit table");
+			return 1;
+		}
+
+		list_for_each(&place->value.map, item, map) {
+			if (!item->node.name)
+				continue;
+
+			if (strcmp(item->node.name, ancestor) == 0) {
+				place = &item->node;
+				found = 1;
+				break;
+			}
+		}
+
+		if (found)
+			continue;
+
+		/* this is the auto-vivification */
+		item = malloc(sizeof(*item));
+		if (!item)
+			return ENOMEM;
+
+		item->node.name = strdup(ancestor);
+		item->node.type = TOML_TABLE;
+		list_head_init(&item->node.value.map);
+		list_add_tail(&place->value.map, &item->map);
+
+		place = &item->node;
+		item_added = 1;
+	}
+
+	if (!item_added) {
+		asprintf(err, "Duplicate item %s", name);
+		return 2;
+	}
+
+	if (place->type != TOML_TABLE) {
+		asprintf(err, "Attempt to overwrite table %s", name);
+		return 3;
+	}
+
+	free(tofree);
+
+	*lastTable = place;
+	return 0;
+}

--- a/libtoml/toml_private.h
+++ b/libtoml/toml_private.h
@@ -1,0 +1,46 @@
+#ifndef _TOML_PRIVATE_H
+#define _TOML_PRIVATE_H
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <ccan/list/list.h>
+
+#include "toml.h"
+
+struct toml_node {
+	enum toml_type type;
+	char *name;
+	union {
+		struct list_head map;
+		struct list_head list;
+		int64_t integer;
+		struct {
+			double	value;
+			int		precision;
+		} floating;
+		char *string;
+		struct {
+			time_t	epoch;
+			int		sec_frac;
+			bool	offset_sign_negative;
+			uint8_t	offset;
+			bool	offset_is_zulu;
+		} rfc3339_time;
+	} value;
+};
+
+struct toml_table_item {
+	struct list_node map;
+	struct toml_node node;
+};
+
+struct toml_list_item {
+	struct list_node list;
+	struct toml_node node;
+};
+
+const char* toml_type_to_str(enum toml_type);
+int SawTableArray(struct toml_node*, char*, struct toml_node**, char**);
+int SawTable(struct toml_node*, char*, struct toml_node**, char**);
+
+#endif /* _TOML_PRIVATE_H */

--- a/meson.build
+++ b/meson.build
@@ -382,11 +382,14 @@ if not cc.has_header('sys/queue.h', include_directories : inc)
 endif
 
 # libtoml
-if not cc.has_function('toml_init', args : ['-ltoml'])
-    error('*** unable to find toml_init() in libtoml')
+# Default to bundled library, otherwise use the system one if we can.
+if get_option('with_system_libtoml') and cc.has_function('toml_init', args : ['-ltoml'])
+    inctoml = include_directories('libtoml')
+    toml = declare_dependency(link_args : ['-ltoml'])
+else
+    inctoml = include_directories('libtoml')
+    subdir('libtoml')
 endif
-
-toml = declare_dependency(link_args : ['-ltoml'])
 
 # Header files for builds
 inc = include_directories('include')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -33,6 +33,11 @@ option('with_libannocheck',
        value : false,
        description : 'Use libannocheck rather than annocheck(1) for binary file analysis.  Mutually exclusive with the with_annocheck option.  Disabling both annocheck options will disable the annocheck inspection.')
 
+option('with_system_libtoml',
+       type : 'boolean',
+       value : false,
+       description : 'Use libtoml from the system rather than the bundled library in this source tree.')
+
 option('vendor_data_dir',
        type : 'string',
        value : '/usr/share/rpminspect',

--- a/osdeps/almalinux8/post.sh
+++ b/osdeps/almalinux8/post.sh
@@ -6,18 +6,5 @@ if [ "$(uname -m)" = "x86_64" ]; then
     yum install -y glibc-devel.i686 glibc.i686 libgcc.i686
 fi
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 freshclam

--- a/osdeps/almalinux8/reqs.txt
+++ b/osdeps/almalinux8/reqs.txt
@@ -3,7 +3,6 @@ bash
 clamav-data
 clamav-devel
 clamav-update
-cmake
 CUnit
 CUnit-devel
 dash
@@ -11,7 +10,6 @@ desktop-file-utils
 elfutils-devel
 file-devel
 gcc
-gcc-c++
 gettext
 gettext-devel
 git
@@ -41,7 +39,6 @@ python3-pip
 python3-pyyaml
 python3-rpm
 python3-timeout-decorator
-ragel
 rc
 rpm-build
 rpm-devel

--- a/osdeps/almalinux9/post.sh
+++ b/osdeps/almalinux9/post.sh
@@ -19,18 +19,5 @@ make V=1
 make V=1 install
 cd "${CWD}" || exit 1
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 freshclam

--- a/osdeps/almalinux9/reqs.txt
+++ b/osdeps/almalinux9/reqs.txt
@@ -3,14 +3,12 @@ bash
 clamav-data
 clamav-devel
 clamav-update
-cmake
 CUnit
 CUnit-devel
 desktop-file-utils
 elfutils-devel
 file-devel
 gcc
-gcc-c++
 gettext
 gettext-devel
 git
@@ -39,7 +37,6 @@ python3-devel
 python3-pip
 python3-pyyaml
 python3-rpm
-ragel
 rc
 rpm-build
 rpm-devel

--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -87,19 +87,6 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Avoid getting %{_arch} in filenames from rpmbuild
 echo "%_arch %(/bin/arch)" > ~/.rpmmacros
 

--- a/osdeps/alpine/reqs.txt
+++ b/osdeps/alpine/reqs.txt
@@ -7,7 +7,6 @@ cargo
 clamav-daemon
 clamav-db
 clamav-dev
-cmake
 cunit-dev
 curl
 curl-dev
@@ -16,7 +15,6 @@ elfutils
 elfutils-dev
 file
 freshclam
-g++
 gcc
 gcovr
 gettext
@@ -43,7 +41,6 @@ py3-rpm
 py3-timeout-decorator
 py3-yaml
 python3-dev
-ragel
 rpm-dev
 rust
 sed

--- a/osdeps/amzn2/post.sh
+++ b/osdeps/amzn2/post.sh
@@ -26,18 +26,5 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 freshclam

--- a/osdeps/amzn2/reqs.txt
+++ b/osdeps/amzn2/reqs.txt
@@ -2,7 +2,6 @@ bash
 clamav-data
 clamav-devel
 clamav-update
-cmake
 CUnit
 CUnit-devel
 dash
@@ -10,7 +9,6 @@ desktop-file-utils
 elfutils-devel
 file-devel
 gcc
-gcc-g++
 gettext
 gettext-devel
 git
@@ -36,7 +34,6 @@ patchelf
 python3-devel
 python3-pip
 python3-rpm
-ragel
 rc
 rpm-build
 rpm-devel

--- a/osdeps/arch/post.sh
+++ b/osdeps/arch/post.sh
@@ -72,18 +72,5 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update the clamav database
 freshclam

--- a/osdeps/arch/reqs.txt
+++ b/osdeps/arch/reqs.txt
@@ -2,7 +2,6 @@ autoconf
 automake
 bison
 clamav
-cmake
 cunit
 desktop-file-utils
 gcc
@@ -20,7 +19,6 @@ patchelf
 pkg-config
 python
 python-pip
-ragel
 rpm
 tcsh
 xmlrpc-c

--- a/osdeps/centos7/post.sh
+++ b/osdeps/centos7/post.sh
@@ -80,18 +80,5 @@ tar -xf mandoc.tar.gz
 ( cd "${SUBDIR}" && ./configure && make && make lib-install )
 rm -rf mandoc.tar.gz "${SUBDIR}"
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 freshclam

--- a/osdeps/centos7/reqs.txt
+++ b/osdeps/centos7/reqs.txt
@@ -2,7 +2,6 @@ bash
 clamav-data
 clamav-devel
 clamav-update
-cmake
 CUnit
 CUnit-devel
 dash
@@ -11,7 +10,6 @@ elfutils-devel
 fedora-packager
 file-devel
 gcc
-gcc-g++
 gettext
 gettext-devel
 git
@@ -38,7 +36,6 @@ ninja-build
 openssl11-devel
 openssl-devel
 patchelf
-ragel
 rc
 rpm-build
 rpm-devel

--- a/osdeps/centos8/post.sh
+++ b/osdeps/centos8/post.sh
@@ -6,18 +6,5 @@ if [ "$(uname -m)" = "x86_64" ]; then
     yum install -y glibc-devel.i686 glibc.i686 libgcc.i686
 fi
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 freshclam

--- a/osdeps/centos8/reqs.txt
+++ b/osdeps/centos8/reqs.txt
@@ -3,7 +3,6 @@ bash
 clamav-data
 clamav-devel
 clamav-update
-cmake
 CUnit
 CUnit-devel
 dash
@@ -11,7 +10,6 @@ desktop-file-utils
 elfutils-devel
 file-devel
 gcc
-gcc-g++
 gettext
 gettext-devel
 git
@@ -41,7 +39,6 @@ python3-pip
 python3-pyyaml
 python3-rpm
 python3-timeout-decorator
-ragel
 rc
 rpm-build
 rpm-devel

--- a/osdeps/centos9/post.sh
+++ b/osdeps/centos9/post.sh
@@ -6,18 +6,5 @@ if [ "$(uname -m)" = "x86_64" ]; then
     dnf install -y glibc-devel.i686 glibc.i686 libgcc.i686
 fi
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 freshclam

--- a/osdeps/centos9/reqs.txt
+++ b/osdeps/centos9/reqs.txt
@@ -3,14 +3,12 @@ bash
 clamav-data
 clamav-devel
 clamav-update
-cmake
 CUnit
 CUnit-devel
 desktop-file-utils
 elfutils-devel
 file-devel
 gcc
-gcc-g++
 gettext
 gettext-devel
 git
@@ -39,7 +37,6 @@ python3-devel
 python3-pip
 python3-pyyaml
 python3-rpm
-ragel
 rc
 rpm-build
 rpm-devel

--- a/osdeps/debian-stable/post.sh
+++ b/osdeps/debian-stable/post.sh
@@ -63,19 +63,6 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 service clamav-freshclam stop
 freshclam

--- a/osdeps/debian-stable/reqs.txt
+++ b/osdeps/debian-stable/reqs.txt
@@ -1,9 +1,7 @@
 abigail-tools
 clamav
-cmake
 desktop-file-utils
 elfutils
-g++
 gcc
 gcovr
 gettext
@@ -31,7 +29,6 @@ pkg-config
 python3-pip
 python3-rpm
 python3-setuptools
-ragel
 rc
 rpm
 sssd

--- a/osdeps/debian-testing/post.sh
+++ b/osdeps/debian-testing/post.sh
@@ -63,19 +63,6 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 service clamav-freshclam stop
 freshclam

--- a/osdeps/debian-testing/reqs.txt
+++ b/osdeps/debian-testing/reqs.txt
@@ -1,9 +1,7 @@
 abigail-tools
 clamav
-cmake
 desktop-file-utils
 elfutils
-g++
 gcc
 gcovr
 gettext
@@ -31,7 +29,6 @@ pkg-config
 python3-pip
 python3-rpm
 python3-setuptools
-ragel
 rc
 rpm
 sssd

--- a/osdeps/freebsd/post.sh
+++ b/osdeps/freebsd/post.sh
@@ -73,17 +73,5 @@ rm -rf cdson
 # The ksh93 package does not install a 'ksh' executable, so create a symlink
 ln -sf ksh93 /usr/local/bin/ksh
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/local/lib/libtoml.so
-install -D -m 0644 toml.h /usr/local/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-
 # Update the clamav database
 freshclam

--- a/osdeps/freebsd/reqs.txt
+++ b/osdeps/freebsd/reqs.txt
@@ -4,7 +4,6 @@ bash
 binutils
 ca_root_nss
 clamav
-cmake
 coreutils
 cunit
 curl
@@ -37,7 +36,6 @@ patchelf
 pkgconf
 popt
 python3
-ragel
 rc
 rpm4
 rust

--- a/osdeps/gentoo/post.sh
+++ b/osdeps/gentoo/post.sh
@@ -59,19 +59,6 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Gentoo Linux does not define an RPM dist tag
 echo '%dist .ri47' > "${HOME}"/.rpmmacros
 

--- a/osdeps/gentoo/reqs.txt
+++ b/osdeps/gentoo/reqs.txt
@@ -4,7 +4,6 @@ app-shells/dash
 app-shells/ksh
 app-shells/tcsh
 app-shells/zsh
-dev-build/cmake
 dev-debug/valgrind
 dev-libs/icu
 dev-libs/json-c
@@ -17,5 +16,4 @@ dev-util/desktop-file-utils
 dev-util/gcovr
 dev-util/libabigail
 dev-util/patchelf
-dev-util/ragel
 sys-devel/gettext

--- a/osdeps/mageia/post.sh
+++ b/osdeps/mageia/post.sh
@@ -67,18 +67,5 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update the clamav database
 freshclam

--- a/osdeps/mageia/reqs.txt
+++ b/osdeps/mageia/reqs.txt
@@ -2,10 +2,8 @@ bash
 bison
 clamav
 clamav-db
-cmake
 dash
 desktop-file-utils
-gcc-c++
 gettext-devel
 git
 glibc-devel
@@ -37,7 +35,6 @@ python3-devel
 python3-pip
 python3-pyaml
 python3-rpm
-ragel
 rpm-build
 sssd-client
 tcsh

--- a/osdeps/opensuse-leap/post.sh
+++ b/osdeps/opensuse-leap/post.sh
@@ -58,18 +58,5 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update the clamav database
 freshclam

--- a/osdeps/opensuse-leap/reqs.txt
+++ b/osdeps/opensuse-leap/reqs.txt
@@ -5,14 +5,12 @@ bison
 cargo
 clamav
 clamav-devel
-cmake
 cunit-devel
 curl
 desktop-file-utils
 file-devel
 gcc
 gcc-32bit
-gcc-c++
 gcovr
 gettext-tools
 git
@@ -44,7 +42,6 @@ python3-pip
 python3-Pygments
 python3-PyYAML
 python3-rpm
-ragel
 rpm-build
 rpm-devel
 rust

--- a/osdeps/opensuse-tumbleweed/post.sh
+++ b/osdeps/opensuse-tumbleweed/post.sh
@@ -46,18 +46,5 @@ make install
 cd "${CWD}" || exit 1
 rm -rf rc
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 freshclam

--- a/osdeps/opensuse-tumbleweed/reqs.txt
+++ b/osdeps/opensuse-tumbleweed/reqs.txt
@@ -5,14 +5,12 @@ bison
 cargo
 clamav
 clamav-devel
-cmake
 cunit-devel
 curl
 desktop-file-utils
 file-devel
 gcc
 gcc-32bit
-gcc-c++
 gettext-tools
 git
 glibc-devel-32bit
@@ -42,7 +40,6 @@ python3-devel
 python3-pip
 python3-PyYAML
 python3-rpm
-ragel
 rpm-build
 rpm-devel
 rust

--- a/osdeps/oraclelinux8/post.sh
+++ b/osdeps/oraclelinux8/post.sh
@@ -19,18 +19,5 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-ldconfig
-
 # Update clamav database
 freshclam

--- a/osdeps/oraclelinux8/reqs.txt
+++ b/osdeps/oraclelinux8/reqs.txt
@@ -3,7 +3,6 @@ bash
 clamav-data
 clamav-devel
 clamav-update
-cmake
 CUnit
 CUnit-devel
 dash
@@ -11,7 +10,6 @@ desktop-file-utils
 elfutils-devel
 file-devel
 gcc
-gcc-c++
 gettext
 gettext-devel
 git
@@ -40,7 +38,6 @@ python3-pip
 python3-pyyaml
 python3-rpm
 python3-timeout-decorator
-ragel
 rc
 rpm-build
 rpm-devel

--- a/osdeps/ubuntu/post.sh
+++ b/osdeps/ubuntu/post.sh
@@ -49,18 +49,6 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
-# Install libtoml from git
-cd "${CWD}" || exit 1
-git clone -q https://github.com/ajwans/libtoml.git
-cd libtoml || exit 1
-cmake .
-make
-make test
-install -D -m 0755 libtoml.so /usr/lib64/libtoml.so
-install -D -m 0644 toml.h /usr/include/toml.h
-cd "${CWD}" || exit 1
-rm -rf libtoml
-
 # Update the clamav database
 service clamav-freshclam stop
 freshclam

--- a/osdeps/ubuntu/reqs.txt
+++ b/osdeps/ubuntu/reqs.txt
@@ -1,10 +1,8 @@
 abigail-tools
 cargo
 clamav
-cmake
 desktop-file-utils
 elfutils
-g++
 gcc
 gcc-multilib
 gcovr
@@ -34,7 +32,6 @@ pkg-config
 python3-pip
 python3-rpm
 python3-setuptools
-ragel
 rc
 rpm
 rustc

--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -19,6 +19,7 @@ Group:          Development/Tools
 # * include/uthash.h is BSD-1-Clause
 # * include/compat/queue.h is BSD-3-Clause
 # * libxdiff/ is LGPL-2.1-or-later
+# * libtoml/ is BSD-3-Clause
 License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND MIT AND AND BSD-1-Clause AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-4.0
 URL:            https://github.com/rpminspect/rpminspect
 Source0:        https://github.com/rpminspect/rpminspect/releases/download/v%{version}/%{name}-%{version}.tar.xz
@@ -160,7 +161,7 @@ control files.
 
 
 %build
-%meson -Dtests=false
+%meson -D tests=false -D with_system_libtoml=true
 %meson_build
 
 
@@ -171,7 +172,9 @@ control files.
 
 %files -f %{name}.lang
 %doc AUTHORS.md CHANGES.md README.md TODO
-%license COPYING
+%doc libxdiff/AUTHORS libxdiff/README
+%doc libtoml/README.md libtoml/README.rpminspect
+%license COPYING libxdiff/COPYING libtoml/LICENSE
 %{_bindir}/rpminspect
 %{_mandir}/man1/rpminspect.1*
 


### PR DESCRIPTION
This is easier than chasing it down on every non-Fedora platform and manually installing it.  The project has not changed upstream in about 8 years anyway.