### PR TITLE
[bld] Set c_std='gnu99' so toml_parse.c will compile

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project('rpminspect',
         'c',
         version : '2.0',
         default_options : [
+            'c_std=gnu99',
             'warning_level=3',
             'werror=true',
             'buildtype=debugoptimized'


### PR DESCRIPTION
The default is C90, but that won't work here.