### PR TITLE
Exclude libpython3.so from the debuginfo tests

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -1079,6 +1079,7 @@ debuginfo:
         - /lib/modules/*
         - /usr/lib/debug/.dwz/*
         - /usr/lib/grub/*
+        - /usr/lib/debug/usr/lib*/libpython3.so*
 
     # The ELF section name(s) required in debuginfo packages.  The
     # default is shown here.  Some products may need to modify this


### PR DESCRIPTION
libpython3.so doesn't contain any compiled code
and it's there to point applications to the versioned libpython library where the compiled code is. Hence we cannot strip debug symbols from there.

See also: https://bugzilla.redhat.com/show_bug.cgi?id=2144553#c16

Cherry-picked from https://github.com/rpminspect/rpminspect-data-fedora/commit/fb53cacddcc8f72ee475b5e83b8d41851cbd7c85

This does not only affect Fedora.