### PR TITLE
[cfg] Exclude libpython3.so from the debuginfo tests

### DIFF
--- a/data/generic.dson
+++ b/data/generic.dson
@@ -137,5 +137,6 @@ such "common" is such "workdir" is "/var/tmp/rpminspect",
      "upstream" is empty!
      "debuginfo" is such "ignore" is so "/lib/modules/*" and
                                         "/usr/lib/debug/.dwz/*" and
-                                        "/usr/lib/grub/*" many,
+                                        "/usr/lib/grub/*" and
+                                        "/usr/lib/debug/usr/lib*/libpython3.so*" many,
                          "debuginfo_sections" is ".symtab .debug_info" wow wow

--- a/data/generic.json
+++ b/data/generic.json
@@ -244,7 +244,8 @@
     "ignore": [
       "/lib/modules/*",
       "/usr/lib/debug/.dwz/*",
-      "/usr/lib/grub/*"
+      "/usr/lib/grub/*",
+      "/usr/lib/debug/usr/lib*/libpython3.so*"
     ],
     "debuginfo_sections": ".symtab .debug_info"
   },


### PR DESCRIPTION
Apply the change in 172d0b30efbde3984a27ba39557c43ca39fcf560 to generic.dson and generic.json.