### PR TITLE
[fix] Drop libtoml-devel BR from the spec file

### DIFF
--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -50,7 +50,6 @@ BuildRequires:  libmandoc-devel >= 1.14.5
 BuildRequires:  gnupg2
 BuildRequires:  libicu-devel
 BuildRequires:  libcdson-devel
-BuildRequires:  libtoml-devel
 
 
 %description


### PR DESCRIPTION
This BR is no longer needed as the libtoml source code has been added to the repository in 6577ec61.

This should fix the FTBFS problem for EPEL buildroots in COPR.