### PR TITLE
Cache the result of "is it an ELF file?" checks

### DIFF
--- a/include/readelf.h
+++ b/include/readelf.h
@@ -70,7 +70,7 @@ extern "C"
  *        of path.
  * @return The Elf object for path or NULL on error.
  */
-Elf *get_elf(const char *path, int *out_fd);
+Elf *get_elf(rpmfile_entry_t *file, int *out_fd);
 
 /**
  * @brief Get an Elf object for the named ELF archive object.
@@ -91,7 +91,7 @@ Elf *get_elf(const char *path, int *out_fd);
  *        of path.
  * @return The Elf object for path or NULL on error.
  */
-Elf *get_elf_archive(const char *path, int *out_fd);
+Elf *get_elf_archive(rpmfile_entry_t *file, int *out_fd);
 
 /**
  * @brief Return the ELF_TYPE of the given Elf object.
@@ -131,7 +131,7 @@ GElf_Half get_elf_machine(Elf *elf);
  * @param path The full path to the file in question.
  * @return True if the file is ELF, false otherwise.
  */
-bool is_elf(const char *path);
+bool is_elf(rpmfile_entry_t *file);
 
 /**
  * @brief Determine if the specified file is an ELF shared library.
@@ -142,7 +142,7 @@ bool is_elf(const char *path);
  * @param path The fullpath to the file in question.
  * @return True if the file is an ELF shared library, false otherwise.
  */
-bool is_elf_shared_library(const char *path);
+bool is_elf_shared_library(rpmfile_entry_t *file);
 
 /**
  * @brief Determine if the specified file is an ELF executable.
@@ -153,7 +153,7 @@ bool is_elf_shared_library(const char *path);
  * @param path The fullpath to the file in question.
  * @return True if the file is an ELF executable, false otherwise.
  */
-bool is_elf_executable(const char *path);
+bool is_elf_executable(rpmfile_entry_t *file);
 
 /**
  * @brief Determine if the specified file is an ELF file.
@@ -165,7 +165,7 @@ bool is_elf_executable(const char *path);
  * @param path The fullpath to the file in question.
  * @return True if the file is an ELF file, false otherwise.
  */
-bool is_elf_file(const char *path);
+bool is_elf_file(rpmfile_entry_t *file);
 
 /**
  * @brief Determine if the specified file is an ELF archive.
@@ -177,7 +177,7 @@ bool is_elf_file(const char *path);
  * @param path The fullpath to the file in question.
  * @return True if the file is an ELF archive, false otherwise.
  */
-bool is_elf_archive(const char *path);
+bool is_elf_archive(rpmfile_entry_t *file);
 
 /**
  * @brief Determine if the specified Elf object contains the specified
@@ -277,7 +277,7 @@ GElf_Phdr *get_elf_phdr(Elf *elf, Elf64_Word type, GElf_Phdr *out);
  * @return Newly allocated string containing the DT_SONAME value or
  *         NULL
  */
-char *get_elf_soname(const char *filepath);
+char *get_elf_soname(rpmfile_entry_t *file);
 
 /**
  * @brief Check for tag in the specified ELF object

--- a/include/types.h
+++ b/include/types.h
@@ -119,6 +119,10 @@ typedef struct _rpmfile_entry_t {
     struct _rpmfile_entry_t *peer_file;
     bool moved_path;
     bool moved_subpackage;
+    signed char is_elf_archive;
+    signed char is_elf_file;
+    signed char is_elf_executable;
+    signed char is_elf_shared_library;
     TAILQ_ENTRY(_rpmfile_entry_t) items;
 } rpmfile_entry_t;
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -838,7 +838,7 @@ static void find_one_peer(struct rpminspect *ri, rpmfile_entry_t *file, rpmfile_
                     return;
                 }
             } else if ((S_ISREG(file->st.st_mode) && S_ISREG(after_file->st.st_mode))
-                       || (is_elf(file->fullpath) && is_elf(after_file->fullpath))) {
+                       || (is_elf(file) && is_elf(after_file))) {
                 /*
                  * Try to match libraries that have changed versions.
                  * The idea is to look for ELF files that carry a

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -179,14 +179,14 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* skip anything that is not an ELF shared library file.  */
-    if (!S_ISREG(file->st.st_mode) || !is_elf_file(file->fullpath)) {
+    if (!S_ISREG(file->st.st_mode) || !is_elf_file(file)) {
         return true;
     }
 
-    soname = get_elf_soname(file->fullpath);
+    soname = get_elf_soname(file);
 
     /* ET_DYN with no DT_SONAME is _probably_ an executable */
-    if (is_elf_executable(file->fullpath) || (is_elf_shared_library(file->fullpath) && soname == NULL)) {
+    if (is_elf_executable(file) || (is_elf_shared_library(file) && soname == NULL)) {
         return true;
     }
 

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -334,7 +334,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only run this check on ELF files */
-    if (!is_elf_file(file->fullpath) || (!is_elf_file(file->fullpath) && file->peer_file && !is_elf_file(file->peer_file->fullpath))) {
+    if (!is_elf_file(file) || (!is_elf_file(file) && file->peer_file && !is_elf_file(file->peer_file))) {
         return true;
     }
 

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -107,10 +107,10 @@ static bool badfuncs_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     arch = get_rpm_header_arch(after->rpm_header);
 
     /* get an ELF object of some sort, if we can */
-    after_elf = get_elf_archive(after->fullpath, &after_elf_fd);
+    after_elf = get_elf_archive(after, &after_elf_fd);
 
     if (after_elf == NULL) {
-        after_elf = get_elf(after->fullpath, &after_elf_fd);
+        after_elf = get_elf(after, &after_elf_fd);
     }
 
     if (after_elf == NULL) {

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -118,7 +118,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* ELF content changing is handled by other inspections */
-    if (is_elf(file->fullpath)) {
+    if (is_elf(file)) {
         return true;
     }
 

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -66,7 +66,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* If we lack dynamic or shared ELF files, we're done */
-    if ((after_elf = get_elf(file->fullpath, &after_fd)) == NULL) {
+    if ((after_elf = get_elf(file, &after_fd)) == NULL) {
         return true;
     }
 
@@ -90,7 +90,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.arch = arch;
     params.file = file->localpath;
 
-    if ((before_elf = get_elf(file->fullpath, &before_fd)) == NULL) {
+    if ((before_elf = get_elf(file, &before_fd)) == NULL) {
         xasprintf(&params.msg, _("%s was an ELF file and now is not on %s"), file->localpath, arch);
         params.verb = VERB_CHANGED;
         params.noun = _("ELF file ${FILE} on ${ARCH}");

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -870,7 +870,7 @@ static bool elf_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     }
 
     /* Skip kernel modules */
-    after_elf = get_elf(after->fullpath, &after_elf_fd);
+    after_elf = get_elf(after, &after_elf_fd);
 
     if (after_elf != NULL
         && get_elf_type(after_elf) == ET_REL
@@ -890,15 +890,15 @@ static bool elf_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     arch = get_rpm_header_arch(after->rpm_header);
 
     /* Is this an archive or a regular ELF file? */
-    if ((after_elf = get_elf_archive(after->fullpath, &after_elf_fd)) != NULL) {
+    if ((after_elf = get_elf_archive(after, &after_elf_fd)) != NULL) {
         if (after->peer_file != NULL) {
-            before_elf = get_elf_archive(after->peer_file->fullpath, &before_elf_fd);
+            before_elf = get_elf_archive(after->peer_file, &before_elf_fd);
         }
 
         result = elf_archive_tests(ri, after_elf, after_elf_fd, before_elf, before_elf_fd, after, arch, name);
-    } else if ((after_elf = get_elf(after->fullpath, &after_elf_fd)) != NULL) {
+    } else if ((after_elf = get_elf(after, &after_elf_fd)) != NULL) {
         if (after->peer_file != NULL) {
-            before_elf = get_elf(after->peer_file->fullpath, &before_elf_fd);
+            before_elf = get_elf(after->peer_file, &before_elf_fd);
         }
 
         result = elf_regular_tests(ri, after_elf, before_elf, after, arch, name);

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -163,7 +163,7 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* skip anything that is not an ELF file */
-    if (!S_ISREG(file->st.st_mode) || !is_elf(file->fullpath)) {
+    if (!S_ISREG(file->st.st_mode) || !is_elf(file)) {
         return true;
     }
 

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -125,7 +125,7 @@ static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only valid for ELF files */
-    if (!is_elf_file(file->fullpath)) {
+    if (!is_elf_file(file)) {
         return true;
     }
 
@@ -143,7 +143,7 @@ static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.file = file->localpath;
     params.noun = _("${FILE} not portable on ${ARCH}");
 
-    if ((elf = get_elf_archive(file->fullpath, &fd)) != NULL) {
+    if ((elf = get_elf_archive(file, &fd)) != NULL) {
         /* we found an ELF static library */
         elf_archive_iterate(fd, elf, find_lto_symbols, &names);
 
@@ -156,7 +156,7 @@ static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             free(badsyms);
             result = false;
         }
-    } else if (((elf = get_elf(file->fullpath, &fd)) != NULL) && (get_elf_type(elf) == ET_REL)) {
+    } else if (((elf = get_elf(file, &fd)) != NULL) && (get_elf_type(elf) == ET_REL)) {
         /* we found an ELF relocatable */
         names = get_elf_section_names(elf, SHT_SYMTAB);
 

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -116,8 +116,8 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.verb = VERB_FAILED;
         }
 
-        if (is_elf_file(file->fullpath) && !strcmp(type, "application/x-pie-executable")) {
-            soname = get_elf_soname(file->fullpath);
+        if (is_elf_file(file) && !strcmp(type, "application/x-pie-executable")) {
+            soname = get_elf_soname(file);
 
             if (soname) {
                 if (params.waiverauth == WAIVABLE_BY_SECURITY) {

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -232,7 +232,7 @@ static bool runpath_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* If we lack dynamic or shared ELF files, we're done */
-    if ((elf = get_elf(file->fullpath, &fd)) == NULL) {
+    if ((elf = get_elf(file, &fd)) == NULL) {
         result = true;
         goto cleanup;
     }


### PR DESCRIPTION
Add four flag fields to rpmfile_entry_t struct to save the information such as "is it an ELF archive?"
"is it ELF file?" and if yes, is it executable, or shared lib. (the fields are "signed char" to keep the struct compact, we have 100 thousands of those when running on kernel packages).

get_elf() attempts to open the file only if
"is it ELF file?" flag is "don't know".
It sets the flag to yes/no.
Future get_elf()'s on file which is known to not be an ELF immediately return NULL with no file operations attempted.

get_elf_archive() does the same with "is it an ELF archive?" flag.

This is the key speedup. It stops us from opening files and testing them for ELFness some 100+ million times for kernel packages.

is_elf_file() uses get_elf()'s cached result if it is present (therefore does not open the ELF not only if it's known to not be an ELF, but even if it *is* an ELF). Else calls get_elf() to find out.

is_elf_archive() uses get_elf_archive()'s cached result if it is present, else calls get_elf_archive().

is_elf_shared_library() uses get_elf() but additionally sets "is it ELF shared lib flag?" and does not try get_elf() on the second call, since it already has the cached answer. is_elf_executable() is similar, for executables.