### PR TITLE
[fix] Pick the correct remedy string when displaying findings

### DIFF
--- a/lib/remedy.c
+++ b/lib/remedy.c
@@ -15,6 +15,7 @@ struct remedy remedies[] = {
      *   "short name",
      *   "default remedy message" },
      */
+    { REMEDY_NULL, "", NULL },
     { REMEDY_ABIDIFF, "abidiff", NULL },
     { REMEDY_ADDEDFILES, "addedfiles", NULL },
     { REMEDY_ANNOCHECK_FORTIFY_SOURCE, "annocheck_fortify_source", NULL },


### PR DESCRIPTION
The remedies array needed an entry for REMEDY_NULL.

Fixes: #1360