### PR TITLE
[bld] Build libtoml sources without -Werror

### DIFF
--- a/libtoml/meson.build
+++ b/libtoml/meson.build
@@ -10,4 +10,5 @@ libtoml = static_library(
     libtoml_sources,
     include_directories : inc,
     install : false,
+    override_options: ['werror=false']
 )


### PR DESCRIPTION
COPR builds for EPEL fail because the sources are compiled with -Werror. The problem is that the bundled libtoml sources don't compile when warnings are treated as errors.

The right thing to do would be to work with the libtoml upstream to fix the problems and make sure that they use -Werror as well. But this can take some time to achieve.

In the meantime, we compile the libtoml sources without -Werror.