### PR TITLE
[fix] Replace asprintf() with xasprintf() in libtoml source code

### DIFF
--- a/include/helpers.h
+++ b/include/helpers.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/*
+ * This header includes the helper functions and macros for librpminspect.
+ */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifndef _LIBRPMINSPECT_HELPERS_H
+#define _LIBRPMINSPECT_HELPERS_H
+
+/* Macros */
+#ifdef NDEBUG
+/* Don't create unused variables if not using assert() */
+#define xasprintf(dest, ...) {                         \
+    *(dest) = NULL;                                    \
+    asprintf((dest), __VA_ARGS__);                     \
+}
+#else
+#define xasprintf(dest, ...) {                         \
+    int _xasprintf_result;                             \
+    *(dest) = NULL;                                    \
+    _xasprintf_result = asprintf((dest), __VA_ARGS__); \
+    assert(_xasprintf_result != -1);                   \
+}
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,5 +1,6 @@
 install_headers(
     'constants.h',
+    'helpers.h',
     'i18n.h',
     'init.h',
     'inspect.h',

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -24,6 +24,7 @@ extern "C"
 #endif
 
 #include "constants.h"
+#include "helpers.h"
 #include "types.h"
 #include "inspect.h"
 #include "output.h"
@@ -53,20 +54,6 @@ extern struct buildtype buildtypes[];
 extern volatile sig_atomic_t terminal_resized;
 
 /* Macros */
-#ifdef NDEBUG
-/* Don't create unused variables if not using assert() */
-#define xasprintf(dest, ...) {                         \
-    *(dest) = NULL;                                    \
-    asprintf((dest), __VA_ARGS__);                     \
-}
-#else
-#define xasprintf(dest, ...) {                         \
-    int _xasprintf_result;                             \
-    *(dest) = NULL;                                    \
-    _xasprintf_result = asprintf((dest), __VA_ARGS__); \
-    assert(_xasprintf_result != -1);                   \
-}
-#endif
 
 /*
  * Simple debugging printf.  Sends output to stderr if debugging

--- a/libtoml/toml.c
+++ b/libtoml/toml.c
@@ -471,11 +471,11 @@ toml_value_as_string(struct toml_node* node)
 	switch (node->type)
 	{
 	case TOML_INT:
-		asprintf(&ret, "%" PRId64, node->value.integer);
+		xasprintf(&ret, "%" PRId64, node->value.integer);
 		break;
 
 	case TOML_FLOAT:
-		asprintf(&ret, "%.*f", node->value.floating.precision,
+		xasprintf(&ret, "%.*f", node->value.floating.precision,
 								node->value.floating.value);
 		break;
 
@@ -501,7 +501,7 @@ toml_value_as_string(struct toml_node* node)
 		if (!gmtime_r(&node->value.rfc3339_time.epoch, &tm))
 			break;
 
-		asprintf(&ret, "%d-%02d-%02dT%02d:%02d:%02d%s%s",
+		xasprintf(&ret, "%d-%02d-%02dT%02d:%02d:%02d%s%s",
 			1900 + tm.tm_year,
 			tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec,
 			sec_frac, offset_string);
@@ -509,7 +509,7 @@ toml_value_as_string(struct toml_node* node)
 	}
 
 	case TOML_BOOLEAN:
-		asprintf(&ret, "%s", node->value.integer ? "true" : "false");
+		xasprintf(&ret, "%s", node->value.integer ? "true" : "false");
 		break;
 
 	default:

--- a/libtoml/toml.h
+++ b/libtoml/toml.h
@@ -1,6 +1,7 @@
 #ifndef TOML_H
 #define TOML_H
 
+#include "../include/helpers.h"
 #include <stdio.h>
 
 #ifdef __cplusplus

--- a/libtoml/toml_private.c
+++ b/libtoml/toml_private.c
@@ -119,7 +119,7 @@ SawTable(struct toml_node* place, char* name, struct toml_node** lastTable, char
 		int found = 0;
 
 		if (strcmp(ancestor, "") == 0) {
-			asprintf(err, "empty implicit table");
+			xasprintf(err, "empty implicit table");
 			return 1;
 		}
 
@@ -152,12 +152,12 @@ SawTable(struct toml_node* place, char* name, struct toml_node** lastTable, char
 	}
 
 	if (!item_added) {
-		asprintf(err, "Duplicate item %s", name);
+		xasprintf(err, "Duplicate item %s", name);
 		return 2;
 	}
 
 	if (place->type != TOML_TABLE) {
-		asprintf(err, "Attempt to overwrite table %s", name);
+		xasprintf(err, "Attempt to overwrite table %s", name);
 		return 3;
 	}
 


### PR DESCRIPTION
Compiler complains about the return value of `asprintf()` being ignored, and -Werror flag causes the build to fail because of that.

`xasprintf()` makes this warning to go away.

However, `xasprintf()` was previously defined in `include/rpminspect.h`, and there were conflicts between this header file and `ccan/list/list.h`. Therefore I moved the `xasprintf()` definition to a separate header file -- `include/helpers.h`. See the commit message for more details.