### PR TITLE
[ci] Fix up failing CentOS 7 and Oracle Linux CI jobs

### DIFF
--- a/.github/workflows/oraclelinux.yml
+++ b/.github/workflows/oraclelinux.yml
@@ -58,6 +58,7 @@ jobs:
                   # Turn on all the other repos
                   sed -i -e 's|enabled=0|enabled=1|g' /etc/yum.repos.d/*.repo
 
+                  dnf upgrade -y
                   dnf install -y git
 
             # This means clone the git repo
@@ -73,7 +74,10 @@ jobs:
                   # Install build dependencies and set up the target
                   make instreqs
 
+                  # Use the latest Python
+                  PYTHON_PROG="$(basename $(ls -1 /usr/bin/python*.* | grep -v config | sort -V | tail -n 1))"
+
                   # Build the software and run the test suite
-                  make debug
-                  make check
+                  make debug PYTHON=${PYTHON_PROG}
+                  make check PYTHON=${PYTHON_PROG}
                   ninja -C build coverage && ( curl -s https://codecov.io/bash | bash ) || :

--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -3,13 +3,13 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
 # The mandoc package in Alpine Linux lacks the library
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"

--- a/osdeps/arch/post.sh
+++ b/osdeps/arch/post.sh
@@ -6,13 +6,13 @@ CWD="$(pwd)"
 echo '%dist .ri47' > "${HOME}"/.rpmmacros
 
 # There is no mandoc package in Arch Linux
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"

--- a/osdeps/debian-stable/post.sh
+++ b/osdeps/debian-stable/post.sh
@@ -17,13 +17,13 @@ esac
 
 # The mandoc package on Debian lacks libmandoc.a and
 # header files, which we need to build rpminspect
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"

--- a/osdeps/debian-testing/post.sh
+++ b/osdeps/debian-testing/post.sh
@@ -17,13 +17,13 @@ esac
 
 # The mandoc package on Debian lacks libmandoc.a and
 # header files, which we need to build rpminspect
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"

--- a/osdeps/fedora-rawhide.i686/post.sh
+++ b/osdeps/fedora-rawhide.i686/post.sh
@@ -14,7 +14,7 @@ esac
 # Remove any potentially bad udev rules files
 if [ -d /usr/lib/udev/rules.d ]; then
     for rulefile in /usr/lib/udev/rules.d/*.rules ; do
-        if ! udevadm verify "${rulefile}" >&- 2>&- ; then
+        if ! udevadm verify "${rulefile}" >/dev/null 2>&1 ; then
             rm -f "${rulefile}"
         fi
     done

--- a/osdeps/fedora-rawhide/post.sh
+++ b/osdeps/fedora-rawhide/post.sh
@@ -14,7 +14,7 @@ esac
 # Remove any potentially bad udev rules files
 if [ -d /usr/lib/udev/rules.d ]; then
     for rulefile in /usr/lib/udev/rules.d/*.rules ; do
-        if ! udevadm verify "${rulefile}" >&- 2>&- ; then
+        if ! udevadm verify "${rulefile}" >/dev/null 2>&1 ; then
             rm -f "${rulefile}"
         fi
     done

--- a/osdeps/fedora.i686/post.sh
+++ b/osdeps/fedora.i686/post.sh
@@ -13,7 +13,7 @@ case "$(uname -m)" in
 esac
 
 # Work around a bug in meson 0.55.0
-MESON_VER="$(meson --version 2>&-)"
+MESON_VER="$(meson --version 2>/dev/null)"
 
 if [ -z "${MESON_VER}" ] || [ ! "${MESON_VER}" = "0.55.0" ]; then
     exit 0

--- a/osdeps/fedora/post.sh
+++ b/osdeps/fedora/post.sh
@@ -13,7 +13,7 @@ case "$(uname -m)" in
 esac
 
 # Work around a bug in meson 0.55.0
-MESON_VER="$(meson --version 2>&-)"
+MESON_VER="$(meson --version 2>/dev/null)"
 
 if [ -z "${MESON_VER}" ] || [ ! "${MESON_VER}" = "0.55.0" ]; then
     exit 0

--- a/osdeps/freebsd/post.sh
+++ b/osdeps/freebsd/post.sh
@@ -8,7 +8,7 @@ git clone https://git.freebsd.org/ports.git /usr/ports
 
 # https://github.com/rpm-software-management/rpm/pull/2459
 RPMTAG_HDR="/usr/local/include/rpm/rpmtag.h"
-if grep RPM_MASK_RETURN_TYPE ${RPMTAG_HDR} 2>&- | grep -q 0xffff0000 >&- 2>&- ; then
+if grep RPM_MASK_RETURN_TYPE ${RPMTAG_HDR} 2>/dev/null | grep -q 0xffff0000 >/dev/null 2>&1 ; then
     sed -I -E 's|^.*RPM_MASK_RETURN_TYPE.*=.*0xffff0000$|#define RPM_MASK_RETURN_TYPE 0xffff0000|g' ${RPMTAG_HDR}
     sed -I -E '/RPM_MAPPING_RETURN_TYPE/ s/\,$//' ${RPMTAG_HDR}
 fi
@@ -26,13 +26,13 @@ pip install -q cpp-coveralls gcovr rpmfluff
 
 # libmandoc is missing on FreeBSD
 cd "${CWD}" || exit 1
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"

--- a/osdeps/gentoo/post.sh
+++ b/osdeps/gentoo/post.sh
@@ -4,13 +4,13 @@ CWD="$(pwd)"
 
 # The mandoc package in Gentoo Linux is both masked and does not
 # install the library.
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"

--- a/osdeps/mageia/post.sh
+++ b/osdeps/mageia/post.sh
@@ -3,13 +3,13 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 CWD="$(pwd)"
 
 # Mageia Linux does not have mandoc
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"

--- a/osdeps/opensuse-leap/post.sh
+++ b/osdeps/opensuse-leap/post.sh
@@ -7,13 +7,13 @@ sed -i -e '/^%vendor/d' /usr/lib/rpm/macros.d/*
 
 # The mandoc package on OpenSUSE lacks libmandoc.a and
 # header files, which we need to build rpminspect
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"

--- a/osdeps/opensuse-tumbleweed/post.sh
+++ b/osdeps/opensuse-tumbleweed/post.sh
@@ -4,13 +4,13 @@ CWD="$(pwd)"
 
 # The mandoc package on OpenSUSE lacks libmandoc.a and
 # header files, which we need to build rpminspect
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | awk '{ print $6; }')"

--- a/osdeps/oraclelinux8/defs.mk
+++ b/osdeps/oraclelinux8/defs.mk
@@ -1,2 +1,2 @@
-PKG_CMD = dnf install -y
-PIP_CMD = pip3 install -I
+PKG_CMD = dnf install --allowerasing --nobest -y
+PIP_CMD = pip-3.11 install

--- a/osdeps/oraclelinux8/pip.txt
+++ b/osdeps/oraclelinux8/pip.txt
@@ -1,4 +1,5 @@
 cpp-coveralls
-rpmfluff
 gcovr
 PyYAML
+rpmfluff
+timeout-decorator

--- a/osdeps/oraclelinux8/post.sh
+++ b/osdeps/oraclelinux8/post.sh
@@ -8,7 +8,8 @@ if [ "$(uname -m)" = "x86_64" ]; then
 fi
 
 # cdson is not [yet] in Oracle Linux
-git clone https://github.com/frozencemetery/cdson.git
+cd "${CWD}" || exit 1
+git clone -q https://github.com/frozencemetery/cdson.git
 cd cdson || exit 1
 TAG="$(git tag -l | sort -n | tail -n 1)"
 git checkout -b "${TAG}" "${TAG}"

--- a/osdeps/oraclelinux8/pre.sh
+++ b/osdeps/oraclelinux8/pre.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/sbin:/usr/sbin
-
-# Update pip and setuptools
-dnf install -y python3-pip
-pip3 install --upgrade pip setuptools

--- a/osdeps/oraclelinux8/reqs.txt
+++ b/osdeps/oraclelinux8/reqs.txt
@@ -33,11 +33,11 @@ meson
 ninja-build
 openssl-devel
 patchelf
-python3-devel
-python3-pip
-python3-pyyaml
-python3-rpm
-python3-timeout-decorator
+python3.11-devel
+python3.11-pip
+python3.11-pyyaml
+python3.11-rpm
+python3.11-timeout-decorator
 rc
 rpm-build
 rpm-devel

--- a/osdeps/oraclelinux9/defs.mk
+++ b/osdeps/oraclelinux9/defs.mk
@@ -1,2 +1,2 @@
 PKG_CMD = dnf install -y
-PIP_CMD = pip3 install -I
+PIP_CMD = pip3 install

--- a/osdeps/oraclelinux9/post.sh
+++ b/osdeps/oraclelinux9/post.sh
@@ -8,7 +8,8 @@ if [ "$(uname -m)" = "x86_64" ]; then
 fi
 
 # cdson is not [yet] in Oracle Linux
-git clone https://github.com/frozencemetery/cdson.git
+cd "${CWD}" || exit 1
+git clone -q https://github.com/frozencemetery/cdson.git
 cd cdson || exit 1
 TAG="$(git tag -l | sort -n | tail -n 1)"
 git checkout -b "${TAG}" "${TAG}"

--- a/osdeps/ubuntu/post.sh
+++ b/osdeps/ubuntu/post.sh
@@ -7,13 +7,13 @@ echo '%dist .ri47' > "${HOME}"/.rpmmacros
 
 # The mandoc package on Ubuntu lacks libmandoc.a and
 # header files, which we need to build rpminspect
-if curl -s http://mandoc.bsd.lv/ >&- 2>&- ; then
+if curl -s http://mandoc.bsd.lv/ >/dev/null 2>&1 ; then
     curl -O http://mandoc.bsd.lv/snapshots/mandoc.tar.gz
 else
     # failed to connect to upstream host; take Debian's source
     DEBIAN_URL=http://ftp.debian.org/debian/pool/main/m/mdocml/
     # figure out which one is the latest and get that
-    SRCFILE="$(curl -s ${DEBIAN_URL} 2>&- | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
+    SRCFILE="$(curl -s ${DEBIAN_URL} 2>/dev/null | sed -r 's/<[^>]*>//g' | sed -r 's/<[^>]*>$//g' | tr -s ' ' | grep -vE '^[ \t]*$' | grep ".orig.tar" | sed -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}.*$//g' | sort -n | tail -n 1)"
     curl -o mandoc.tar.gz ${DEBIAN_URL}/"${SRCFILE}"
 fi
 SUBDIR="$(tar -tvf mandoc.tar.gz | head -n 1 | rev | cut -d ' ' -f 1 | rev)"

--- a/regress/all-inspections-kernel.sh
+++ b/regress/all-inspections-kernel.sh
@@ -21,7 +21,7 @@ trap 'rm -rf "${TMPDIR}"' EXIT
 
 # Make sure we have additional commands available
 for cmd in ${RPMINSPECT} ${TIMECMD} koji ; do
-    ${cmd} --help >&- 2>&-
+    ${cmd} --help >/dev/null 2>&1
     if [ $? -eq 127 ]; then
         echo "*** Missing ${cmd}, exiting." >&2
         exit 1

--- a/regress/indiv-inspections-kernel.sh
+++ b/regress/indiv-inspections-kernel.sh
@@ -21,7 +21,7 @@ trap 'rm -rf "${TMPDIR}"' EXIT
 
 # Make sure we have additional commands available
 for cmd in ${RPMINSPECT} ${TIMECMD} koji ; do
-    ${cmd} --help >&- 2>&-
+    ${cmd} --help >/dev/null 2>&1
     if [ $? -eq 127 ]; then
         echo "*** Missing ${cmd}, exiting." >&2
         exit 1

--- a/utils/determine-os.sh
+++ b/utils/determine-os.sh
@@ -13,7 +13,7 @@ if [ -r /etc/os-release ] || [ -L /etc/os-release ]; then
 fi
 
 # Crux Linux lacks /etc/os-release or an /etc/*-release file
-grep -q ^CRUX /etc/issue >&- 2>&-
+grep -q ^CRUX /etc/issue >/dev/null 2>&1
 IS_CRUX=$?
 
 # NetBSD does not have an /etc/os-release file
@@ -22,7 +22,7 @@ if [ -z "${ID}" ] && [ ! -f /etc/os-release ]; then
 fi
 
 if [ -r /etc/fedora-release ] && [ "${ID}" = "fedora" ]; then
-    if grep -q -i rawhide /etc/fedora-release >&- 2>&- ; then
+    if grep -q -i rawhide /etc/fedora-release >/dev/null 2>&1 ; then
         echo "${ID}-rawhide"
     else
         echo "${ID}"

--- a/utils/find-ninja.sh
+++ b/utils/find-ninja.sh
@@ -3,12 +3,12 @@
 # Find the ninja command to use.
 #
 
-if ! ninja --help >&- 2>&- ; then
+if ! ninja --help >/dev/null 2>&1 ; then
     echo "ninja"
     exit 0
 fi
 
-if ! ninja-build --help >&- 2>&- ; then
+if ! ninja-build --help >/dev/null 2>&1 ; then
     echo "ninja-build"
     exit 0
 fi

--- a/utils/gate.sh
+++ b/utils/gate.sh
@@ -39,7 +39,7 @@ packages="zsh kernel python3 firefox mutt emacs tmux elfutils"
 # Validate programs we need are present
 reqs="rpmbuild koji"
 for req in $reqs; do
-    if ! $req --help >&- 2>&-; then
+    if ! $req --help >/dev/null 2>&1 ; then
         echo "ERROR: Required program $req missing." >&2
         exit 1
     fi

--- a/utils/mkannounce.sh
+++ b/utils/mkannounce.sh
@@ -35,7 +35,7 @@ fi
 
 # gather log entries since the latest tag in reverse order and only
 # those with category markers
-git log --reverse --pretty=format:%s "${PREV_TAG}".."${LATEST_TAG}" 2>&- | grep -E "^\[" | while read -r logline ; do
+git log --reverse --pretty=format:%s "${PREV_TAG}".."${LATEST_TAG}" 2>/dev/null | grep -E "^\[" | while read -r logline ; do
     category="$(echo "${logline}" | cut -d ']' -f 1 | cut -d '[' -f 2)"
     [ -z "${category}" ] && continue
     echo "*$(echo "${logline}" | cut -d ']' -f 2 | xargs -0)" >> "${TMPDIR}"/"${category}"

--- a/utils/submit-koji-builds.sh
+++ b/utils/submit-koji-builds.sh
@@ -31,7 +31,7 @@ trap cleanup EXIT
 
 # Verify specific tools are available
 for tool in ${TOOLS} ${VENDORPKG} ${VENDORKOJI} ; do
-    ${tool} >&- 2>&-
+    ${tool} >/dev/null 2>&1
     if [ $? -eq 127 ]; then
         echo "*** Missing '${tool}', perhaps 'yum install -y /usr/bin/${tool}'" >&2
         exit 1
@@ -51,7 +51,7 @@ if [ ! -f "${TARBALL}" ]; then
     exit 1
 fi
 
-if ! tar tf "${TARBALL}" >&- 2>&- ; then
+if ! tar tf "${TARBALL}" >/dev/null 2>&1 ; then
     echo "*** $(basename "${TARBALL}") is not a tar archive" >&2
     exit 1
 fi
@@ -88,13 +88,13 @@ PROJECT="$1"
 shift
 
 # Need a krb5 ticket
-klist >&- 2>&-
+klist >/dev/null 2>&1
 if [ $? -eq 1 ]; then
     echo "*** You lack an active Kerberos ticket" >&2
     exit 1
 fi
 
-klist | grep -q "krbtgt/FEDORAPROJECT.ORG@FEDORAPROJECT.ORG" >&- 2>&-
+klist | grep -q "krbtgt/FEDORAPROJECT.ORG@FEDORAPROJECT.ORG" >/dev/null 2>&1
 if [ $? -eq 1 ]; then
     echo "*** You need a FEDORAPROJECT.ORG Kerberos ticket" >&2
     exit 1
@@ -121,7 +121,7 @@ for branch in ${BRANCHES} ; do
 
     # skip this branch if we lack build targets
     if [ ! "${branch}" = "rawhide" ]; then
-        if ! ${VENDORKOJI} list-targets --name="${branch}-candidate" >&- 2>&- ; then
+        if ! ${VENDORKOJI} list-targets --name="${branch}-candidate" >/dev/null 2>&1 ; then
             echo "*** Skipping ${branch} because there is no longer a ${VENDORKOJI} target"
             continue
         fi


### PR DESCRIPTION
Also do a bit of shell script cleanup work.  For CentOS 7, had to adjust the way pip modules were installed and then python-rpm was rebuilt.  For Oracle, we're using 2 different versions of Python 3, but that's ok.