### PR TITLE
[fix] Stop unpacking archive when we receive ARCHIVE_FATAL

### DIFF
--- a/lib/unpack.c
+++ b/lib/unpack.c
@@ -167,6 +167,11 @@ int unpack_archive(const char *archive, const char *dest, const bool force)
 
     /* extract each archive member */
     while ((r = archive_read_next_header(input, &entry)) != ARCHIVE_EOF) {
+        if (r == ARCHIVE_FATAL) {
+            /* we cannot recover here, so just take what we could extract */
+            break;
+        }
+
         if (r != ARCHIVE_OK) {
             warnx("*** archive_read_next_header: %s", archive_error_string(input));
         } else if (r < ARCHIVE_WARN) {


### PR DESCRIPTION
With some versions of libarchive, it is possible to receive ARCHIVE_FATAL from archive_read_next_header() in a loop where you are unpacking an archive.  From all of my testing, it appears to be data at the end of the stream that libarchive is unable to handle.  Since you can't recover from ARCHIVE_FATAL, just break out of the loop and close everything down.  In the example I have been using to test this locally, I have found that on the problematic version of libarchive and a working version of libarchive, this patch causes all files to be correctly extracted.

The only place where I have seen ARCHIVE_FATAL returned by archive_read_next_header() are on RHEL UBI9 containers with libarchive-3.5.3.  Regular RHEL-9 installs, recent Fedora releases, and regular CentOS Stream installs all work fine.  But, better to handle ARCHIVE_FATAL than not.