### PR TITLE
[bld] Correct the check for CURLINFO_CONTENT_LENGTH_DOWNLOAD_T

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -116,7 +116,8 @@ curlinfo_src = '''
     #include <curl/curl.h>
     int main(void)
     {
-        return !(CURL_AT_LEAST_VERSION(7, 55, 0));
+        int i = CURLINFO_CONTENT_LENGTH_DOWNLOAD_T;
+        return 0;
     }
     '''
 have_newer_curlinfo = cc.compiles(curlinfo_src,


### PR DESCRIPTION
Builds on systems with older versions of libcurl were failing.  I was using the check incorrectly.  All I needed to do was just test to see that source compiles with a defined macro so I have changed it to that.