### PR TITLE
[fix] Do not allow skipping of security checks via config file

### DIFF
--- a/lib/flags.c
+++ b/lib/flags.c
@@ -58,7 +58,7 @@ bool process_inspection_flag(const char *inspection, const bool exclude, uint64_
     for (i = 0; inspections[i].name != NULL; i++) {
         if (!strcasecmp(inspection, inspections[i].name)) {
             /* user specified a valid inspection */
-            if (exclude) {
+            if (exclude && inspections[i].security_checks == false) {
                 *selected &= ~(inspections[i].flag);
                 found = true;
                 break;


### PR DESCRIPTION
There were already protections in place for individual file paths and inspections named on the command line, but this picks up local config files that have disabled an inspection with security checks in it.

Fixes: #1374