### PR TITLE
[tst] LooseVersion from distutils.version is deprecated; replace it

### DIFF
--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 from baseclass import TestSRPM, TestRPMs, TestKoji
 from baseclass import RequiresRpminspect, check_results
 
@@ -18,7 +18,7 @@ proc = subprocess.Popen(
     ["rpmbuild", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
 )
 (out, err) = proc.communicate()
-if LooseVersion(out.split()[2].decode("utf-8")) <= LooseVersion("4.0.4"):
+if parse(out.split()[2].decode("utf-8")) <= Version("4.0.4"):
     have_old_rpm = True
 else:
     have_old_rpm = False

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -7,14 +7,14 @@ import rpm
 import subprocess
 import rpmfluff
 import unittest
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 from baseclass import TestSRPM, TestCompareSRPM
 
 # rpm < v4.18 does not support '%patch N' syntax
 rpmver = list(map(lambda x: int(x), rpm.__version__.strip().split("-")[0].split(".")))
 
-if LooseVersion("%d.%d" % (rpmver[0], rpmver[1])) <= LooseVersion("4.18"):
+if parse("%d.%d" % (rpmver[0], rpmver[1])) <= Version("4.18"):
     patch_N_supported = False
 else:
     patch_N_supported = True


### PR DESCRIPTION
Use packaging.version's parse() and Version() instead.