### PR TITLE
[tst] Handle older Python 3.x releases without 'packaging' module

### DIFF
--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -9,19 +9,25 @@ import shutil
 import subprocess
 import tempfile
 import unittest
-from packaging.version import Version, parse
 from baseclass import TestSRPM, TestRPMs, TestKoji
 from baseclass import RequiresRpminspect, check_results
 
-# Older versions of rpm require a Group tag
 proc = subprocess.Popen(
     ["rpmbuild", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
 )
 (out, err) = proc.communicate()
-if parse(out.split()[2].decode("utf-8")) <= Version("4.0.4"):
-    have_old_rpm = True
-else:
-    have_old_rpm = False
+have_old_rpm = False
+
+try:
+    from packaging.version import Version, parse
+
+    if parse(out.split()[2].decode("utf-8")) <= Version("4.0.4"):
+        have_old_rpm = True
+except ImportError:
+    from distutils.version import LooseVersion
+
+    if LooseVersion(out.split()[2].decode("utf-8")) < LooseVersion("4.0.4"):
+        have_old_rpm = True
 
 specdir = os.path.realpath(
     os.path.join(os.environ["RPMINSPECT_TEST_DATA_PATH"], "SPECS")

--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -18,6 +18,11 @@ proc = subprocess.Popen(
 (out, err) = proc.communicate()
 have_old_rpm = False
 
+# Starting with Python 3.10, distutils emits DeprecationWarnings and
+# more recent Python releases have simply removed distutils entirely.
+# Try the modern replacement before falling back on distutils.  This
+# should allow the test suite to work across a range of Python 3.x
+# releases.
 try:
     from packaging.version import Version, parse
 

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -7,17 +7,22 @@ import rpm
 import subprocess
 import rpmfluff
 import unittest
-from packaging.version import Version, parse
-
 from baseclass import TestSRPM, TestCompareSRPM
 
 # rpm < v4.18 does not support '%patch N' syntax
 rpmver = list(map(lambda x: int(x), rpm.__version__.strip().split("-")[0].split(".")))
+patch_N_supported = True
 
-if parse("%d.%d" % (rpmver[0], rpmver[1])) <= Version("4.18"):
-    patch_N_supported = False
-else:
-    patch_N_supported = True
+try:
+    from packaging.version import Version, parse
+
+    if parse("%d.%d" % (rpmver[0], rpmver[1])) <= Version("4.18"):
+        patch_N_supported = False
+except ImportError:
+    from distutils.version import LooseVersion
+
+    if LooseVersion("%d.%d" % (rpmver[0], rpmver[1])) < LooseVersion("4.18"):
+        patch_N_supported = False
 
 # Check to see if %autopatch works (requires lua)
 proc = subprocess.Popen(

--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -13,6 +13,11 @@ from baseclass import TestSRPM, TestCompareSRPM
 rpmver = list(map(lambda x: int(x), rpm.__version__.strip().split("-")[0].split(".")))
 patch_N_supported = True
 
+# Starting with Python 3.10, distutils emits DeprecationWarnings and
+# more recent Python releases have simply removed distutils entirely.
+# Try the modern replacement before falling back on distutils.  This
+# should allow the test suite to work across a range of Python 3.x
+# releases.
 try:
     from packaging.version import Version, parse
 


### PR DESCRIPTION
I was using LooseVersion from distutils, but that's deprecated in more recent releases.  Since the CI jobs run on a variety, still handle cases where we should still use LooseVersion.