### PR TITLE
[ci] Fix the RHEL UBI9 job; drop 'cost' from c9s repo definitions

### DIFF
--- a/.github/workflows/ubi.yml
+++ b/.github/workflows/ubi.yml
@@ -56,7 +56,6 @@ jobs:
                               echo "[c9s-${c}]" >> /etc/yum.repos.d/ubi.repo
                               echo "name = CentOS Stream 9 - ${c}" >> /etc/yum.repos.d/ubi.repo
                               echo "baseurl = https://mirror.stream.centos.org/9-stream/${c}/\$basearch/os/" >> /etc/yum.repos.d/ubi.repo
-                              echo "cost = 100" >> /etc/yum.repos.d/ubi.repo
                               echo "enabled = 1" >> /etc/yum.repos.d/ubi.repo
                               echo "gpgcheck = 0" >> /etc/yum.repos.d/ubi.repo
                               echo >> /etc/yum.repos.d/ubi.repo


### PR DESCRIPTION
I think this was messing up the various dnf commands I run to get the environment set up in the CI job.