### PR TITLE
[fix] Correctly handle dual SPDX/legacy license identifiers

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -599,28 +599,17 @@ static inline void _remedy_walker(struct toml_node *node, void *data)
         r = toml_value_as_string(node);
 
         if (r) {
-            entry = calloc(1, sizeof(*entry));
-            assert(entry != NULL);
-            entry->data = r;
+            ri->remedy_overrides = list_add(ri->remedy_overrides, r);
 
-            if (ri->remedy_overrides == NULL) {
-                ri->remedy_overrides = calloc(1, sizeof(*(ri->remedy_overrides)));
-                assert(ri->remedy_overrides != NULL);
-                TAILQ_INIT(ri->remedy_overrides);
-            }
-
-            TAILQ_INSERT_TAIL(ri->remedy_overrides, entry, items);
-        }
-
-        if (!set_remedy(n, r)) {
-            warnx("*** '%s' is not a valid remedy identifier", n);
-
-            if (r) {
+            if (!set_remedy(n, r)) {
+                warnx("*** '%s' is not a valid remedy identifier", n);
                 TAILQ_REMOVE(ri->remedy_overrides, entry, items);
                 free(entry->data);
                 free(entry);
             }
         }
+
+        free(r);
     }
 
     free(n);

--- a/test/data/licenses/test.json
+++ b/test/data/licenses/test.json
@@ -73,7 +73,7 @@
   },
   "12": {
     "approved": "yes",
-    "fedora_abbrev": "",
+    "fedora_abbrev": "MIT",
     "fedora_name": "",
     "spdx_abbrev": "MIT",
   },
@@ -175,5 +175,26 @@
       ]
     },
     "fedora": {}
+  },
+  "26": {
+    "license": {
+      "expression": "Python-2.0.1",
+      "status": [
+        "allowed"
+      ],
+      "url": "https://spdx.org/licenses/Python-2.0.1.html"
+    },
+    "fedora": {
+      "legacy-name": [
+        "Python License"
+      ],
+      "legacy-abbreviation": [
+        "Python"
+      ]
+    },
+    "approved": "yes",
+    "fedora_abbrev": "Python",
+    "fedora_name": "Python License",
+    "spdx_abbrev": "Python-2.0.1"
   }
 }

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -512,3 +512,31 @@ class InvalidCompoundLicenseExpressionKoji(TestKoji):
         self.inspection = "license"
         self.result = "BAD"
         self.waiver_auth = "Not Waivable"
+
+
+# Valid compound license expression mixing dual and SPDX (INFO)
+class ValidCompoundSPDXLicenseExpressionDualSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("Python-2.0.1 AND CC0-1.0 AND MIT")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidCompoundSPDXLicenseExpressionDualRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("Python-2.0.1 AND CC0-1.0 AND MIT")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidCompoundSPDXLicenseExpressionDualKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("Python-2.0.1 AND CC0-1.0 AND MIT")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
The license inspection was incorrectly handling license identifiers that appear as both legacy identifiers in the license database as well as SPDX expressions.  The core problem is that under the legacy system, there was a lot of identifier reuse.  This patch refactors how the license inspection notes the dual licenses so that the inspection passes on packages that have migrated to SPDX.

Fixes: #1387