### PR TITLE
Add xalloc.c with wrapper functions for memory allocation

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -526,6 +526,14 @@ char *joinpath(const char *path, ...);
 /* array.c */
 void array(parser_plugin *p, parser_context *ctx, const char *key1, const char *key2, string_list_t **list);
 
+/* xalloc.c */
+void *xcalloc(size_t n, size_t s);
+void *xalloc(size_t s);
+void *xrealloc(void *p, size_t s);
+#ifdef _HAVE_REALLOCARRAY
+void *xreallocarray(void *p, size_t n, size_t s);
+#endif
+
 #endif
 
 #ifdef __cplusplus

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -103,7 +103,7 @@ bool init_rebaseable(struct rpminspect *);
 bool init_politics(struct rpminspect *ri);
 bool init_security(struct rpminspect *ri);
 bool init_icons(struct rpminspect *ri);
-struct rpminspect *calloc_rpminspect(struct rpminspect *);
+struct rpminspect *xalloc_rpminspect(struct rpminspect *);
 struct rpminspect *init_rpminspect(struct rpminspect *, const char *, const char *);
 
 /* free.c */

--- a/lib/abi.c
+++ b/lib/abi.c
@@ -103,9 +103,7 @@ abi_t *read_abi(const char *vendor_data_dir, const char *product_release)
 
             /* package is not found, add it to the table */
             if (entry == NULL) {
-                entry = calloc(1, sizeof(*entry));
-                assert(entry != NULL);
-
+                entry = xalloc(sizeof(*entry));
                 entry->pkg = strdup(pkg->data);
                 assert(entry->pkg != NULL);
 
@@ -188,11 +186,11 @@ string_list_t *get_abidiff_suppressions(const struct rpminspect *ri, const char 
         TAILQ_FOREACH(file, peer->after_files, items) {
             if (!strcmp(file->localpath, suppression_file)) {
                 if (list == NULL) {
-                    list = calloc(1, sizeof(*list));
+                    list = xalloc(sizeof(*list));
                     TAILQ_INIT(list);
                 }
 
-                entry = calloc(1, sizeof(*entry));
+                entry = xalloc(sizeof(*entry));
                 xasprintf(&entry->data, "%s %s", ABI_SUPPRESSIONS, file->fullpath);
                 assert(entry->data != NULL);
                 TAILQ_INSERT_TAIL(list, entry, items);

--- a/lib/abspath.c
+++ b/lib/abspath.c
@@ -38,8 +38,7 @@ char *abspath(const char *path)
     assert(tokens != NULL);
 
     /* our new path elements */
-    newpath = calloc(1, sizeof(*newpath));
-    assert(newpath != NULL);
+    newpath = xalloc(sizeof(*newpath));
     TAILQ_INIT(newpath);
 
     /* handle each part of the path */

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -375,8 +375,7 @@ static int download_build(struct rpminspect *ri, const struct koji_build *build)
                 }
 
                 /* Initialize a string list. */
-                filter = calloc(1, sizeof(*filter));
-                assert(filter != NULL);
+                filter = xalloc(sizeof(*filter));
                 TAILQ_INIT(filter);
 
                 if (p->strarray_foreach(ctx, "filter", "rpms", filter_cb, filter)) {
@@ -588,7 +587,7 @@ static int download_task(struct rpminspect *ri, struct koji_task *task)
                 }
 
                 len = strlen(dst);
-                dst = realloc(dst, len + strlen(pkg) + 2);
+                dst = xrealloc(dst, len + strlen(pkg) + 2);
                 tail = dst + len;
                 tail = stpcpy(tail, "/");
                 (void) stpcpy(tail, pkg);

--- a/lib/checksums.c
+++ b/lib/checksums.c
@@ -176,12 +176,7 @@ char *compute_checksum(const char *filename, mode_t *st_mode, int type)
     }
 
     /* this is our human readable digest, caller must free */
-    ret = calloc(len + 1, sizeof(char *));
-
-    if (ret == NULL) {
-        warn("*** calloc");
-        return NULL;
-    }
+    ret = xcalloc(len + 1, sizeof(char *));
 
     for (i = 0; i < len; ++i) {
         sprintf(&ret[i*2], "%02x", (unsigned int) digest[i]);

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -39,13 +39,7 @@ static int fill_mmfile(mmfile_t *mf, const char *file)
 
     /* extra byte for the \0 */
     size = sb.st_size;
-    buf = calloc(1, size + 1);
-
-    if (buf == NULL) {
-        warn("*** malloc");
-        return 1;
-    }
-
+    buf = xalloc(size + 1);
     mf->ptr = buf;
     mf->ptr[size] = '\0';
     mf->size = size;
@@ -105,19 +99,15 @@ static int delta_out(void *priv, mmbuffer_t *mb, int nbuf)
         }
 
         /* capture the line */
-        entry = calloc(1, sizeof(*entry));
-        assert(entry != NULL);
+        entry = xalloc(sizeof(*entry));
 
         if ((mb[i].size > 1) && mb[i].ptr != NULL) {
             if (prefix) {
-                entry->data = calloc(1, strlen(prefix) + mb[i].size + 1);
-                assert(entry->data != NULL);
-
+                entry->data = xalloc(strlen(prefix) + mb[i].size + 1);
                 end = stpcpy(entry->data, prefix);
                 end = strncpy(end, mb[i].ptr, mb[i].size);
             } else {
-                entry->data = calloc(1, mb[i].size + 1);
-                assert(entry->data != NULL);
+                entry->data = xalloc(mb[i].size + 1);
 
                 entry->data = strncpy(entry->data, mb[i].ptr, mb[i].size);
             }
@@ -127,7 +117,7 @@ static int delta_out(void *priv, mmbuffer_t *mb, int nbuf)
 
         assert(entry->data != NULL);
         entry->data[strcspn(entry->data, "\n")] = '\0';
-        entry->data = realloc(entry->data, strlen(entry->data) + 1);
+        entry->data = xrealloc(entry->data, strlen(entry->data) + 1);
         TAILQ_INSERT_TAIL(list, entry, items);
         prefix = NULL;
     }
@@ -165,8 +155,7 @@ char *get_file_delta(const char *a, const char *b)
     memset(&xecfg, 0, sizeof(xecfg));
     memset(&ecb, 0, sizeof(ecb));
 
-    list = calloc(1, sizeof(*list));
-    assert(list != NULL);
+    list = xalloc(sizeof(*list));
     TAILQ_INIT(list);
 
     xpp.flags = 0;

--- a/lib/deprules.c
+++ b/lib/deprules.c
@@ -106,8 +106,7 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
 
     if (headerGet(hdr, rtag, req, flags) && headerGet(hdr, otag, op, flags) && headerGet(hdr, vtag, ver, flags)) {
         if (deprules == NULL) {
-            deprules = calloc(1, sizeof(*deprules));
-            assert(deprules != NULL);
+            deprules = xalloc(sizeof(*deprules));
             TAILQ_INIT(deprules);
         }
 
@@ -146,14 +145,10 @@ static deprule_list_t *gather_deprules_by_type(deprule_list_t *rules, Header hdr
 
             v = rpmtdGetString(ver);
 
-            deprule_entry = calloc(1, sizeof(*deprule_entry));
-            assert(deprule_entry != NULL);
-
+            deprule_entry = xalloc(sizeof(*deprule_entry));
             deprule_entry->type = type;
-
             deprule_entry->requirement = strdup(r);
             assert(deprule_entry->requirement != NULL);
-
             deprule_entry->op = get_dep_operator(*(rpmtdGetUint32(op)));
 
             if (!strcmp(v, "")) {

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -49,13 +49,11 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     assert(progver != NULL);
 
     /* initialize a new list */
-    list = calloc(1, sizeof(*list));
-    assert(list != NULL);
+    list = xalloc(sizeof(*list));
     TAILQ_INIT(list);
 
     /* start by adding info about ourself */
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "%s version %s", progname, progver);
     TAILQ_INSERT_TAIL(list, entry, items);
 
@@ -65,41 +63,35 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
      */
 
     /* zlib */
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "zlib version %s", zlibVersion());
     TAILQ_INSERT_TAIL(list, entry, items);
 
 #ifdef _HAVE_MAGIC_VERSION
     /* libmagic */
     /* older versions of libmagic lack this function */
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "libmagic version %d", magic_version());
     TAILQ_INSERT_TAIL(list, entry, items);
 #endif
 
     /* libclamav */
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "libclamav version %s", cl_retver());
     TAILQ_INSERT_TAIL(list, entry, items);
 
     /* librpm */
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "librpm version %s", RPMVERSION);
     TAILQ_INSERT_TAIL(list, entry, items);
 
     /* libxml */
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "libxml version %s", xmlParserVersion);
     TAILQ_INSERT_TAIL(list, entry, items);
 
     /* json-c */
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "json-c version %s", json_c_version());
     TAILQ_INSERT_TAIL(list, entry, items);
 
@@ -117,8 +109,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     tmp = list_to_string(details, " ");                     /* rejoin remaining details */
     list_free(details, free);
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "libcurl version %s (%s)", ver, tmp);
     TAILQ_INSERT_TAIL(list, entry, items);
 
@@ -140,31 +131,27 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
     tmp = list_to_string(details, " ");
     list_free(details, free);
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "libarchive version %s (%s)", ver, tmp);
     TAILQ_INSERT_TAIL(list, entry, items);
 
     free(ver);
     free(tmp);
 #elif _HAVE_ARCHIVE_VERSION_STRING
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "%s", archive_version_string());
     TAILQ_INSERT_TAIL(list, entry, items);
 #endif
 
     /* libyaml */
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "libyaml version %s", yaml_get_version_string());
     TAILQ_INSERT_TAIL(list, entry, items);
 
 #ifndef NO_OPENSSL_VERSION_FUNCTION
     /* openssl */
     tmp = strreplace(OpenSSL_version(OPENSSL_VERSION), "OpenSSL ", "OpenSSL version ");
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "%s", tmp);
     TAILQ_INSERT_TAIL(list, entry, items);
     free(tmp);
@@ -172,15 +159,13 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     /* xmlrpc-c */
     xmlrpc_client_version(&major, &minor, &update);
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "xmlrpc-c version %u.%u.%u", major, minor, update);
     TAILQ_INSERT_TAIL(list, entry, items);
 
 #ifdef _WITH_LIBANNOCHECK
     /* libannocheck */
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     xasprintf(&entry->data, "libannocheck version %u", libannocheck_get_version());
     TAILQ_INSERT_TAIL(list, entry, items);
 #endif
@@ -214,8 +199,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
             assert(ver != NULL);
         }
 
-        entry = calloc(1, sizeof(*entry));
-        assert(entry != NULL);
+        entry = xalloc(sizeof(*entry));
         xasprintf(&entry->data, "%s", ver);
         TAILQ_INSERT_TAIL(list, entry, items);
 
@@ -247,8 +231,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
             assert(ver != NULL);
         }
 
-        entry = calloc(1, sizeof(*entry));
-        assert(entry != NULL);
+        entry = xalloc(sizeof(*entry));
         xasprintf(&entry->data, "%s", ver);
         TAILQ_INSERT_TAIL(list, entry, items);
 
@@ -280,8 +263,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
             assert(ver != NULL);
         }
 
-        entry = calloc(1, sizeof(*entry));
-        assert(entry != NULL);
+        entry = xalloc(sizeof(*entry));
         xasprintf(&entry->data, "%s", ver);
         TAILQ_INSERT_TAIL(list, entry, items);
 
@@ -312,8 +294,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
             assert(ver != NULL);
         }
 
-        entry = calloc(1, sizeof(*entry));
-        assert(entry != NULL);
+        entry = xalloc(sizeof(*entry));
         xasprintf(&entry->data, "%s", ver);
         TAILQ_INSERT_TAIL(list, entry, items);
 
@@ -344,8 +325,7 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
             assert(ver != NULL);
         }
 
-        entry = calloc(1, sizeof(*entry));
-        assert(entry != NULL);
+        entry = xalloc(sizeof(*entry));
         xasprintf(&entry->data, "udevadm version %s", ver);
         TAILQ_INSERT_TAIL(list, entry, items);
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -222,8 +222,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
             goto cleanup;
         }
 
-        path_entry = calloc(1, sizeof(*path_entry));
-        assert(path_entry != NULL);
+        path_entry = xalloc(sizeof(*path_entry));
         path_entry->path = strdup(rpm_path);
         path_entry->index = i;
         HASH_ADD_KEYPTR(hh, path_table, path_entry->path, strlen(path_entry->path), path_entry);
@@ -252,8 +251,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
     }
 
     /* Allocate space for the return value */
-    file_list = calloc(1, sizeof(rpmfile_t));
-    assert(file_list != NULL);
+    file_list = xalloc(sizeof(rpmfile_t));
     TAILQ_INIT(file_list);
 
     while ((archive_result = archive_read_next_header(archive, &entry)) != ARCHIVE_EOF) {
@@ -282,8 +280,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         }
 
         /* Create a new rpmfile_entry_t for this file */
-        file_entry = calloc(1, sizeof(rpmfile_entry_t));
-        assert(file_entry != NULL);
+        file_entry = xalloc(sizeof(rpmfile_entry_t));
 
         file_entry->rpm_header = hdr;
         file_entry->idx = path_entry->index;
@@ -445,8 +442,7 @@ static struct file_data *files_to_table(rpmfile_t *list)
     assert(iter);
 
     TAILQ_FOREACH(iter, list, items) {
-        fentry = calloc(1, sizeof(*fentry));
-        assert(fentry != NULL);
+        fentry = xalloc(sizeof(*fentry));
         fentry->path = iter->localpath;
         fentry->rpmfile = iter;
         HASH_ADD_KEYPTR(hh, table, fentry->path, strlen(fentry->path), fentry);

--- a/lib/init.c
+++ b/lib/init.c
@@ -75,14 +75,12 @@ static int add_regex(const char *pattern, regex_t **regex_out)
     assert(regex_out);
 
     free_regex(*regex_out);
-    *regex_out = calloc(1, sizeof(regex_t));
-    assert(*regex_out != NULL);
+    *regex_out = xalloc(sizeof(regex_t));
 
     if ((reg_result = regcomp(*regex_out, pattern, REG_EXTENDED)) != 0) {
         /* Get the size needed for the error message */
         errbuf_size = regerror(reg_result, *regex_out, NULL, 0);
-        errbuf = malloc(errbuf_size);
-        assert(errbuf != NULL);
+        errbuf = xalloc(errbuf_size);
 
         regerror(reg_result, *regex_out, errbuf, errbuf_size);
         warnx("*** %s", errbuf);
@@ -112,8 +110,7 @@ static void add_string_list_map_entry(string_list_map_t **table, const char *key
 
     if (mapentry == NULL) {
         /* start a new entry for this inspection */
-        mapentry = calloc(1, sizeof(*mapentry));
-        assert(mapentry != NULL);
+        mapentry = xalloc(sizeof(*mapentry));
         mapentry->key = strdup(key);
         mapentry->value = list_add(mapentry->value, value);
         HASH_ADD_KEYPTR(hh, *table, mapentry->key, strlen(mapentry->key), mapentry);
@@ -167,8 +164,7 @@ static void process_table(const char *key, const char *value, const bool require
             warnx("*** missing key `%s', unable to append `%s'", key, value);
         } else {
             /* add the new key/value pair to the table */
-            entry = calloc(1, sizeof(*entry));
-            assert(entry != NULL);
+            entry = xalloc(sizeof(*entry));
             entry->key = strdup(key);
             entry->value = strdup(value);
             HASH_ADD_KEYPTR(hh, *table, entry->key, strlen(entry->key), entry);
@@ -472,8 +468,7 @@ static bool rpmdeps_cb(const char *key, const char *value, void *cb_data)
 
     /* overwrite existing entry, otherwise create new one */
     if (drentry == NULL) {
-        drentry = calloc(1, sizeof(*drentry));
-        assert(drentry != NULL);
+        drentry = xalloc(sizeof(*drentry));
         drentry->type = depkey;
         drentry->pattern = strdup(value);
 
@@ -553,8 +548,7 @@ static void process_desktop_skips(desktop_skips_t **desktop_skips, string_list_t
         HASH_FIND_STR(*desktop_skips, sentry->data, ds);
 
         if (ds == NULL) {
-            ds = calloc(1, sizeof(*ds));
-            assert(ds != NULL);
+            ds = xalloc(sizeof(*ds));
             ds->path = strdup(sentry->data);
             assert(ds->path != NULL);
             ds->flags |= flag;
@@ -1036,8 +1030,7 @@ bool init_fileinfo(struct rpminspect *ri)
     }
 
     /* initialize the list */
-    ri->fileinfo = calloc(1, sizeof(*(ri->fileinfo)));
-    assert(ri->fileinfo != NULL);
+    ri->fileinfo = xalloc(sizeof(*(ri->fileinfo)));
     TAILQ_INIT(ri->fileinfo);
 
     /* add all the entries to the fileinfo list */
@@ -1056,8 +1049,7 @@ bool init_fileinfo(struct rpminspect *ri)
         }
 
         /* initialize a new list entry */
-        fientry = calloc(1, sizeof(*fientry));
-        assert(fientry != NULL);
+        fientry = xalloc(sizeof(*fientry));
 
         /* read the fields */
         while ((token = strsep(&line, " \t")) != NULL) {
@@ -1155,8 +1147,7 @@ bool init_caps(struct rpminspect *ri)
     }
 
     /* initialize the list */
-    ri->caps = calloc(1, sizeof(*(ri->caps)));
-    assert(ri->caps != NULL);
+    ri->caps = xalloc(sizeof(*(ri->caps)));
     TAILQ_INIT(ri->caps);
 
     /* add all the entries to the caps list */
@@ -1199,18 +1190,15 @@ bool init_caps(struct rpminspect *ri)
 
                 if (TAILQ_EMPTY(ri->caps) || files == NULL) {
                     /* new package for the list */
-                    centry = calloc(1, sizeof(*centry));
-                    assert(centry != NULL);
+                    centry = xalloc(sizeof(*centry));
                     centry->pkg = strdup(token);
-                    centry->files = calloc(1, sizeof(*centry->files));
-                    assert(centry->files != NULL);
+                    centry->files = xalloc(sizeof(*centry->files));
                     TAILQ_INIT(centry->files);
                     TAILQ_INSERT_TAIL(ri->caps, centry, items);
                     files = centry->files;
                 }
 
-                filelist_entry = calloc(1, sizeof(*filelist_entry));
-                assert(filelist_entry != NULL);
+                filelist_entry = xalloc(sizeof(*filelist_entry));
                 field = FILEPATH;
             } else if (field == FILEPATH && filelist_entry->path == NULL) {
                 filelist_entry->path = strdup(token);
@@ -1289,8 +1277,7 @@ bool init_rebaseable(struct rpminspect *ri)
     }
 
     /* initialize the list */
-    ri->rebaseable = calloc(1, sizeof(*(ri->rebaseable)));
-    assert(ri->rebaseable != NULL);
+    ri->rebaseable = xalloc(sizeof(*(ri->rebaseable)));
     TAILQ_INIT(ri->rebaseable);
 
     /* add all the entries to the rebaseable list */
@@ -1349,8 +1336,7 @@ bool init_politics(struct rpminspect *ri)
     }
 
     /* initialize the list */
-    ri->politics = calloc(1, sizeof(*(ri->politics)));
-    assert(ri->politics != NULL);
+    ri->politics = xalloc(sizeof(*(ri->politics)));
     TAILQ_INIT(ri->politics);
 
     /* add all the entries to the politics list */
@@ -1369,8 +1355,7 @@ bool init_politics(struct rpminspect *ri)
         }
 
         /* initialize a new list entry */
-        pentry = calloc(1, sizeof(*pentry));
-        assert(pentry != NULL);
+        pentry = xalloc(sizeof(*pentry));
 
         /* read the fields */
         while ((token = strsep(&line, " \t")) != NULL) {
@@ -1450,8 +1435,7 @@ bool init_security(struct rpminspect *ri)
     if (ri->security_initialized) {
         return true;
     } else {
-        ri->security = calloc(1, sizeof(*ri->security));
-        assert(ri->security != NULL);
+        ri->security = xalloc(sizeof(*ri->security));
         TAILQ_INIT(ri->security);
         ri->security_initialized = true;
     }
@@ -1509,8 +1493,7 @@ bool init_security(struct rpminspect *ri)
         /* add the entry */
         if (path && pkg && ver && rel && rules) {
             /* allocate a new entry */
-            sentry = calloc(1, sizeof(*sentry));
-            assert(sentry != NULL);
+            sentry = xalloc(sizeof(*sentry));
 
             /* the main values of a rule */
             sentry->path = strdup(path);
@@ -1562,8 +1545,7 @@ bool init_security(struct rpminspect *ri)
                 HASH_FIND_INT(sentry->rules, &stype, rule_entry);
 
                 if (rule_entry == NULL) {
-                    rule_entry = calloc(1, sizeof(*rule_entry));
-                    assert(rule_entry != NULL);
+                    rule_entry = xalloc(sizeof(*rule_entry));
                     rule_entry->type = stype;
                     rule_entry->severity = severity;
                     HASH_ADD_INT(sentry->rules, type, rule_entry);
@@ -1626,8 +1608,7 @@ bool init_icons(struct rpminspect *ri)
     }
 
     /* initialize the list */
-    ri->icons = calloc(1, sizeof(*(ri->icons)));
-    assert(ri->icons != NULL);
+    ri->icons = xalloc(sizeof(*(ri->icons)));
     TAILQ_INIT(ri->icons);
 
     /* add all the entries to the icons list */
@@ -1657,15 +1638,14 @@ bool init_icons(struct rpminspect *ri)
 /*
  * Memory initialization function for struct rpminspect.
  */
-struct rpminspect *calloc_rpminspect(struct rpminspect *ri)
+struct rpminspect *xalloc_rpminspect(struct rpminspect *ri)
 {
     if (ri != NULL) {
         return ri;
     }
 
     /* Only initialize if we were given NULL for ri */
-    ri = calloc(1, sizeof(*ri));
-    assert(ri != NULL);
+    ri = xalloc(sizeof(*ri));
 
     /* Initialize the struct before reading files */
     ri->workdir = strdup(DEFAULT_WORKDIR);
@@ -1701,8 +1681,7 @@ struct rpminspect *calloc_rpminspect(struct rpminspect *ri)
 
     /* Store full paths to all config files read */
     if (ri->cfgfiles == NULL) {
-        ri->cfgfiles = calloc(1, sizeof(*ri->cfgfiles));
-        assert(ri->cfgfiles != NULL);
+        ri->cfgfiles = xalloc(sizeof(*ri->cfgfiles));
         TAILQ_INIT(ri->cfgfiles);
     }
 
@@ -1733,13 +1712,12 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
     }
 
     if (ri == NULL) {
-        ri = calloc_rpminspect(ri);
+        ri = xalloc_rpminspect(ri);
     }
 
     /* Read in the config file */
     if (cfgfile) {
-        cfg = calloc(1, sizeof(*cfg));
-        assert(cfg != NULL);
+        cfg = xalloc(sizeof(*cfg));
         cfg->data = realpath(cfgfile, NULL);
 
         /* In case we have a missing configuration file */

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -43,15 +43,14 @@ static void add_header_path(const char *root, const char *arch, pair_list_t **he
 
     if (stat(incpath, &sb) == 0 && S_ISDIR(sb.st_mode)) {
         if (!pair_contains_key(*headers, incpath)) {
-            entry = calloc(1, sizeof(*entry));
+            entry = xalloc(sizeof(*entry));
             entry->key = strdup(incpath);
             assert(entry->key != NULL);
             entry->value = strdup(arch);
             assert(entry->value != NULL);
 
             if (*headers == NULL) {
-                *headers = calloc(1, sizeof(**headers));
-                assert(*headers != NULL);
+                *headers = xalloc(sizeof(**headers));
                 TAILQ_INIT(*headers);
             }
 

--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -27,12 +27,10 @@ bool inspect_arch(struct rpminspect *ri)
 
     assert(ri != NULL);
 
-    before_arches = calloc(1, sizeof(*before_arches));
-    assert(before_arches != NULL);
+    before_arches = xalloc(sizeof(*before_arches));
     TAILQ_INIT(before_arches);
 
-    after_arches = calloc(1, sizeof(*after_arches));
-    assert(after_arches != NULL);
+    after_arches = xalloc(sizeof(*after_arches));
     TAILQ_INIT(after_arches);
 
     init_result_params(&params);

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -237,10 +237,8 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             exitcode = filecmp(file->peer_file->fullpath, file->fullpath);
         } else {
             /* we can use diff on text files, so try that first */
-            bun = calloc(1, sizeof(*bun));
-            assert(bun != NULL);
-            aun = calloc(1, sizeof(*aun));
-            assert(aun != NULL);
+            bun = xalloc(sizeof(*bun));
+            aun = xalloc(sizeof(*aun));
 
             bun->fullpath = before_uncompressed_file;
             aun->fullpath = after_uncompressed_file;

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -39,8 +39,7 @@ static string_list_t *get_changelog(const Header hdr)
     }
 
     /* start the changelog */
-    changelog = calloc(1, sizeof(*changelog));
-    assert(changelog != NULL);
+    changelog = xalloc(sizeof(*changelog));
     TAILQ_INIT(changelog);
 
     /* Read this RPM header and construct a new changelog */
@@ -74,8 +73,7 @@ static string_list_t *get_changelog(const Header hdr)
              * %changelog section from the spec file entry by entry and the
              * actual number of blank lines may not be the same.
              */
-            entry = calloc(1, sizeof(*entry));
-            assert(entry != NULL);
+            entry = xalloc(sizeof(*entry));
             xasprintf(&entry->data, "* %s %s\n%s\n\n", tbuf, name, line);
 
             DEBUG_PRINT("\n%s\n", entry->data);

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -114,8 +114,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* Gather the DT_NEEDED entries */
     if (get_dynamic_tags(after_elf, DT_NEEDED, &dyn, &sz, &shdr)) {
-        after_needed = calloc(1, sizeof(*after_needed));
-        assert(after_needed != NULL);
+        after_needed = xalloc(sizeof(*after_needed));
         TAILQ_INIT(after_needed);
 
         for (i = 0; i < sz; i++) {
@@ -126,8 +125,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     if (get_dynamic_tags(before_elf, DT_NEEDED, &dyn, &sz, &shdr)) {
-        before_needed = calloc(1, sizeof(*before_needed));
-        assert(before_needed != NULL);
+        before_needed = xalloc(sizeof(*before_needed));
         TAILQ_INIT(before_needed);
 
         for (i = 0; i < sz; i++) {

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -455,8 +455,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
 
     if (after_execstack && !is_execstack_valid(after_elf, execstack_flags)) {
         if (elf_type == ET_REL) {
-            flaglist = calloc(1, sizeof(*flaglist));
-            assert(flaglist != NULL);
+            flaglist = xalloc(sizeof(*flaglist));
             TAILQ_INIT(flaglist);
 
             if (execstack_flags & SHF_WRITE) {

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -296,8 +296,7 @@ static void token_add(string_map_t **tags, const char *token)
 
     assert(token != NULL);
 
-    tag_entry = calloc(1, sizeof(*tag_entry));
-    assert(tag_entry != NULL);
+    tag_entry = xalloc(sizeof(*tag_entry));
     tag_entry->key = strdup(token);
     assert(tag_entry->key != NULL);
     tag_entry->value = NULL;
@@ -415,17 +414,12 @@ static string_list_t *get_paren_expressions(const char *license)
         end = strchr(start, ')');
 
         if ((end - start) > 0) {
-            entry = calloc(1, sizeof(*entry));
-            assert(entry != NULL);
-
-            entry->data = calloc(1, end - start + 1);
-            assert(entry->data != NULL);
-
+            entry = xalloc(sizeof(*entry));
+            entry->data = xalloc(end - start + 1);
             entry->data = strncpy(entry->data, start, end - start);
 
             if (list == NULL) {
-                list = calloc(1, sizeof(*list));
-                assert(list != NULL);
+                list = xalloc(sizeof(*list));
                 TAILQ_INIT(list);
             }
 

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -47,7 +47,7 @@ static bool find_lto_symbols(Elf *elf, __attribute__((unused)) string_list_t **u
         return true;
     }
 
-    specifics = calloc(1, sizeof(*specifics));
+    specifics = xalloc(sizeof(*specifics));
     TAILQ_INIT(specifics);
 
     names = get_elf_section_names(elf, SHT_PROGBITS);

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -667,8 +667,7 @@ bool inspect_patches(struct rpminspect *ri)
             /* get patch numbers unless automacro is in use */
             if (automacro) {
                 TAILQ_FOREACH(patch, patchfiles, items) {
-                    hentry = calloc(1, sizeof(*hentry));
-                    assert(hentry != NULL);
+                    hentry = xalloc(sizeof(*hentry));
                     hentry->patch = strdup(patch->data);
                     hentry->num = -1;                       /* automacro == true */
                     HASH_ADD_KEYPTR(hh, patches, hentry->patch, strlen(hentry->patch), hentry);
@@ -742,8 +741,7 @@ bool inspect_patches(struct rpminspect *ri)
                         }
 
                         /* add a new patch entry to the hash table */
-                        hentry = calloc(1, sizeof(*hentry));
-                        assert(hentry != NULL);
+                        hentry = xalloc(sizeof(*hentry));
                         hentry->patch = strdup(patchfile);
                         errno = 0;
                         hentry->num = strtoll(buf, NULL, 10);
@@ -829,8 +827,7 @@ bool inspect_patches(struct rpminspect *ri)
                             continue;
                         }
 
-                        aentry = calloc(1, sizeof(*aentry));
-                        assert(aentry != NULL);
+                        aentry = xalloc(sizeof(*aentry));
                         errno = 0;
                         aentry->num = strtoll(buf, NULL, 10);
 

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -26,24 +26,22 @@ bool inspect_subpackages(struct rpminspect *ri)
 
     assert(ri != NULL);
 
-    before_pkgs = calloc(1, sizeof(*before_pkgs));
-    assert(before_pkgs != NULL);
+    before_pkgs = xalloc(sizeof(*before_pkgs));
     TAILQ_INIT(before_pkgs);
 
-    after_pkgs = calloc(1, sizeof(*after_pkgs));
-    assert(after_pkgs != NULL);
+    after_pkgs = xalloc(sizeof(*after_pkgs));
     TAILQ_INIT(after_pkgs);
 
     /* Gather up all the package names */
     TAILQ_FOREACH(peer, ri->peers, items) {
         if (peer->before_hdr) {
-            entry = calloc(1, sizeof(*entry));
+            entry = xalloc(sizeof(*entry));
             xasprintf(&entry->data, "%s %s", headerGetString(peer->before_hdr, RPMTAG_NAME), get_rpm_header_arch(peer->before_hdr));
             TAILQ_INSERT_TAIL(before_pkgs, entry, items);
         }
 
         if (peer->after_hdr) {
-            entry = calloc(1, sizeof(*entry));
+            entry = xalloc(sizeof(*entry));
             xasprintf(&entry->data, "%s %s", headerGetString(peer->after_hdr, RPMTAG_NAME), get_rpm_header_arch(peer->after_hdr));
             TAILQ_INSERT_TAIL(after_pkgs, entry, items);
         }

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -215,8 +215,7 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
         }
 
         /* run through the %prep stage */
-        ba = calloc(1, sizeof(*ba));
-        assert(ba != NULL);
+        ba = xalloc(sizeof(*ba));
         ba->buildAmount |= RPMBUILD_PREP;
 
         ts = rpmtsCreate();
@@ -268,8 +267,7 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
 
         free(*details);
         *details = NULL;
-        buf = calloc(1, n);
-        assert(buf != NULL);
+        buf = xalloc(n);
 
         while (getline(&buf, &n, reader) != -1) {
             *details = strappend(*details, buf, NULL);
@@ -306,8 +304,7 @@ static char *rpm_prep_source(struct rpminspect *ri, const rpmfile_entry_t *file,
             tail[strcspn(tail, "\n")] = 0;
         }
 
-        *details = realloc(*details, strlen(*details) + 1);
-        assert(*details != NULL);
+        *details = xrealloc(*details, strlen(*details) + 1);
     }
 
     return build;
@@ -504,8 +501,7 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
         return 0;
     }
 
-    line = calloc(sz, sizeof(*line));
-    assert(line != NULL);
+    line = xcalloc(sz, sizeof(*line));
     linenum = 1;
 
     while (!u_feof(src)) {
@@ -516,20 +512,11 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
                 sz *= 2;
                 errno = 0;
 #ifdef _HAVE_REALLOCARRAY
-                line_new = reallocarray(line, sz, sizeof(*line));
+                line_new = xreallocarray(line, sz, sizeof(*line));
 #else
-                line_new = realloc(line, sz * sizeof(*line));
+                line_new = xrealloc(line, sz * sizeof(*line));
 #endif
-
-                if (errno == ENOMEM) {
-                    warn("*** realloc");
-                }
-
                 line = line_new;
-
-                if (line == NULL) {
-                    return 0;
-                }
             }
         }
 
@@ -610,8 +597,7 @@ static bool unicode_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     globalarch = get_rpm_header_arch(file->rpm_header);
     assert(globalarch != NULL);
 
-    globalfile = calloc(1, sizeof(*globalfile));
-    assert(globalfile != NULL);
+    globalfile = xalloc(sizeof(*globalfile));
     globalfile->rpm_header = file->rpm_header;
     assert(globalfile->rpm_header != NULL);
 
@@ -709,13 +695,11 @@ bool inspect_unicode(struct rpminspect *ri)
     /* only run if there are forbidden code points */
     if (ri->unicode_forbidden_codepoints != NULL && !TAILQ_EMPTY(ri->unicode_forbidden_codepoints)) {
         /* convert code points to UChar values */
-        forbidden = calloc(1, sizeof(*forbidden));
-        assert(forbidden != NULL);
+        forbidden = xalloc(sizeof(*forbidden));
         TAILQ_INIT(forbidden);
 
         TAILQ_FOREACH(sentry, ri->unicode_forbidden_codepoints, items) {
-            entry = calloc(1, sizeof(*entry));
-            assert(entry != NULL);
+            entry = xalloc(sizeof(*entry));
             errno = 0;
             entry->data = strtol(sentry->data, NULL, 16);
 

--- a/lib/joinpath.c
+++ b/lib/joinpath.c
@@ -53,8 +53,7 @@ char *joinpath(const char *path, ...)
     assert(path != NULL);
 
     /* Allocate a large buffer to use for building the path. */
-    built = calloc(1, PATH_MAX + 1);
-    assert(built != NULL);
+    built = xalloc(PATH_MAX + 1);
 
     /* Make sure the full path starts with a slash. */
     if (*path == '/') {
@@ -124,7 +123,7 @@ char *joinpath(const char *path, ...)
     }
 
     /* shrink memory allocation */
-    tmp = realloc(built, strlen(built) + 1);
+    tmp = xrealloc(built, strlen(built) + 1);
     built = tmp;
 
     return built;

--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -26,9 +26,7 @@ static string_list_t * modinfo_to_list(const struct kmod_list *list, modinfo_to_
     const struct kmod_list *iter = NULL;
     string_list_t *result;
 
-    result = calloc(1, sizeof(*result));
-    assert(result != NULL);
-
+    result = xalloc(sizeof(*result));
     TAILQ_INIT(result);
 
     kmod_list_foreach(iter, list) {
@@ -52,8 +50,7 @@ static void convert_module_parameters(string_list_t *list, const struct kmod_lis
         return;
     }
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
 
     /* The value is of the form <name>:<description>. Drop the description */
     value = kmod_module_info_get_value(modinfo);
@@ -252,8 +249,7 @@ kernel_alias_data_t *gather_module_aliases(const char *module_name, const struct
         HASH_FIND_STR(r, value, kentry);
 
         if (kentry == NULL) {
-            kentry = calloc(1, sizeof(*kentry));
-            assert(kentry != NULL);
+            kentry = xalloc(sizeof(*kentry));
 
             kentry->alias = strdup(value);
             assert(kentry->alias != NULL);

--- a/lib/koji.c
+++ b/lib/koji.c
@@ -271,13 +271,11 @@ static string_list_t *read_koji_descendent_results(xmlrpc_env *env, xmlrpc_value
     size = xmlrpc_array_size(env, value);
     xmlrpc_abort_on_fault(env);
 
-    results = calloc(1, sizeof(*results));
-    assert(results != NULL);
+    results = xalloc(sizeof(*results));
     TAILQ_INIT(results);
 
     for (i = 0; i < size; i++) {
-        entry = calloc(1, sizeof(*entry));
-        assert(entry != NULL);
+        entry = xalloc(sizeof(*entry));
         xmlrpc_array_read_item(env, value, i, &s);
         xmlrpc_abort_on_fault(env);
         xmlrpc_decompose_value(env, s, "s", &entry->data);
@@ -296,8 +294,7 @@ koji_buildlist_t *init_koji_buildlist(void)
 {
     koji_buildlist_t *builds = NULL;
 
-    builds = calloc(1, sizeof(*(builds)));
-    assert(builds != NULL);
+    builds = xalloc(sizeof(*(builds)));
     TAILQ_INIT(builds);
     return builds;
 }
@@ -346,8 +343,7 @@ koji_rpmlist_t *init_koji_rpmlist(void)
 {
     koji_rpmlist_t *rpms = NULL;
 
-    rpms = calloc(1, sizeof(*(rpms)));
-    assert(rpms != NULL);
+    rpms = xalloc(sizeof(*(rpms)));
     TAILQ_INIT(rpms);
     return rpms;
 }
@@ -477,22 +473,18 @@ void init_koji_task_entry(koji_task_entry_t *entry)
 {
     assert(entry != NULL);
 
-    entry->task = malloc(sizeof(*entry->task));
-    assert(entry->task != NULL);
+    entry->task = xalloc(sizeof(*entry->task));
     init_koji_task(entry->task);
 
     entry->brootid = -1;
 
-    entry->srpms = malloc(sizeof(*entry->srpms));
-    assert(entry->srpms != NULL);
+    entry->srpms = xalloc(sizeof(*entry->srpms));
     TAILQ_INIT(entry->srpms);
 
-    entry->rpms = malloc(sizeof(*entry->rpms));
-    assert(entry->rpms != NULL);
+    entry->rpms = xalloc(sizeof(*entry->rpms));
     TAILQ_INIT(entry->rpms);
 
-    entry->logs = malloc(sizeof(*entry->logs));
-    assert(entry->logs != NULL);
+    entry->logs = xalloc(sizeof(*entry->logs));
     TAILQ_INIT(entry->logs);
 
     return;
@@ -630,8 +622,7 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
     }
 
     /* initialize everything and get XMLRPC ready */
-    build = calloc(1, sizeof(*build));
-    assert(build != NULL);
+    build = xalloc(sizeof(*build));
     init_koji_build(build);
     xmlrpc_limit_set(XMLRPC_XML_SIZE_LIMIT_ID, SIZE_MAX);
     xmlrpc_env_init(&env);
@@ -724,8 +715,7 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
             xmlrpc_decompose_value(&env, value, "i", &build->id);
         } else if (!strcmp(keyname, "build_id")) {
             /* we hit this on regular packages, modules handled below */
-            buildentry = calloc(1, sizeof(*buildentry));
-            assert(buildentry != NULL);
+            buildentry = xalloc(sizeof(*buildentry));
 
             xmlrpc_decompose_value(&env, value, "i", &buildentry->build_id);
 
@@ -733,8 +723,7 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
                 buildentry->package_name = strdup(build->package_name);
             }
 
-            buildentry->rpms = calloc(1, sizeof(*buildentry->rpms));
-            assert(buildentry->rpms != NULL);
+            buildentry->rpms = xalloc(sizeof(*buildentry->rpms));
             TAILQ_INIT(buildentry->rpms);
 
             TAILQ_INSERT_TAIL(build->builds, buildentry, builditems);
@@ -909,9 +898,7 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
             subsize = xmlrpc_struct_size(&env, element);
             xmlrpc_abort_on_fault(&env);
 
-            buildentry = calloc(1, sizeof(*buildentry));
-            assert(buildentry != NULL);
-
+            buildentry = xalloc(sizeof(*buildentry));
             j = 0;
 
             while (j < subsize) {
@@ -988,8 +975,7 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
 
             xmlrpc_DECREF(element);
 
-            buildentry->rpms = calloc(1, sizeof(*buildentry->rpms));
-            assert(buildentry->rpms != NULL);
+            buildentry->rpms = xalloc(sizeof(*buildentry->rpms));
             TAILQ_INIT(buildentry->rpms);
 
             TAILQ_INSERT_TAIL(build->builds, buildentry, builditems);
@@ -1018,8 +1004,7 @@ struct koji_build *get_koji_build(struct rpminspect *ri, const char *buildspec)
             xmlrpc_abort_on_fault(&env);
 
             /* create a new rpm list entry */
-            rpm = calloc(1, sizeof(*rpm));
-            assert(rpm != NULL);
+            rpm = xalloc(sizeof(*rpm));
 
             for (j = 0; j < subsize; j++) {
                 xmlrpc_struct_read_member(&env, element, j, &key, &value);
@@ -1126,8 +1111,7 @@ struct koji_task *get_koji_task(struct rpminspect *ri, const char *taskspec)
     }
 
     /* initialize everything and get XMLRPC ready */
-    task = calloc(1, sizeof(*task));
-    assert(task != NULL);
+    task = xalloc(sizeof(*task));
     init_koji_task(task);
     xmlrpc_limit_set(XMLRPC_XML_SIZE_LIMIT_ID, SIZE_MAX);
     xmlrpc_env_init(&env);
@@ -1184,8 +1168,7 @@ struct koji_task *get_koji_task(struct rpminspect *ri, const char *taskspec)
     size = xmlrpc_struct_size(&env, result);
     xmlrpc_abort_on_fault(&env);
 
-    task->descendents = calloc(1, sizeof(*task->descendents));
-    assert(task->descendents != NULL);
+    task->descendents = xalloc(sizeof(*task->descendents));
     TAILQ_INIT(task->descendents);
 
     for (i = 0; i < size; i++) {
@@ -1206,8 +1189,7 @@ struct koji_task *get_koji_task(struct rpminspect *ri, const char *taskspec)
             xmlrpc_abort_on_fault(&env);
 
             /* initialize a struct and read the results */
-            descendent = calloc(1, sizeof(*descendent));
-            assert(descendent != NULL);
+            descendent = xalloc(sizeof(*descendent));
             init_koji_task_entry(descendent);
             read_koji_task_struct(&env, dstruct, descendent->task);
 
@@ -1247,13 +1229,11 @@ struct koji_task *get_koji_task(struct rpminspect *ri, const char *taskspec)
                 } else if (!strcmp(key, "srpm") && xmlrpc_value_type(tr_v) == XMLRPC_TYPE_STRING) {
                     /* we should not have both 'srpms' and 'srpm' */
                     if (descendent->srpms == NULL) {
-                        descendent->srpms = calloc(1, sizeof(*(descendent->srpms)));
-                        assert(descendent->srpms != NULL);
+                        descendent->srpms = xalloc(sizeof(*(descendent->srpms)));
                         TAILQ_INIT(descendent->srpms);
                     }
 
-                    entry = calloc(1, sizeof(*entry));
-                    assert(entry != NULL);
+                    entry = xalloc(sizeof(*entry));
                     xmlrpc_decompose_value(&env, tr_v, "s", &entry->data);
                     xmlrpc_abort_on_fault(&env);
                     assert(entry->data != NULL);

--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -69,8 +69,7 @@ char **list_to_array(const string_list_t *list)
 
     assert(list != NULL);
 
-    array = calloc(list_len(list), sizeof(*array));
-    assert(array != NULL);
+    array = xcalloc(list_len(list), sizeof(*array));
 
     TAILQ_FOREACH(entry, list, items) {
         array[i] = entry->data;
@@ -93,8 +92,7 @@ string_map_t *list_to_table(const string_list_t *list)
 
     /* Allocate the table */
     TAILQ_FOREACH(iter, list, items) {
-        hentry = calloc(1, sizeof(*hentry));
-        assert(hentry != NULL);
+        hentry = xalloc(sizeof(*hentry));
         hentry->key = strdup(iter->data);
         hentry->value = strdup(iter->data);
         HASH_ADD_KEYPTR(hh, table, hentry->key, strlen(hentry->key), hentry);
@@ -188,8 +186,7 @@ string_list_t *list_union(const string_list_t *a, const string_list_t *b)
         HASH_FIND_STR(u_table, iter->data, hentry);
 
         if (hentry == NULL) {
-            hentry = calloc(1, sizeof(*hentry));
-            assert(hentry != NULL);
+            hentry = xalloc(sizeof(*hentry));
             hentry->key = strdup(iter->data);
             HASH_ADD_KEYPTR(hh, u_table, hentry->key, strlen(hentry->key), hentry);
 
@@ -201,8 +198,7 @@ string_list_t *list_union(const string_list_t *a, const string_list_t *b)
         HASH_FIND_STR(u_table, iter->data, hentry);
 
         if (hentry == NULL) {
-            hentry = calloc(1, sizeof(*hentry));
-            assert(hentry != NULL);
+            hentry = xalloc(sizeof(*hentry));
             hentry->key = strdup(iter->data);
             HASH_ADD_KEYPTR(hh, u_table, hentry->key, strlen(hentry->key), hentry);
 
@@ -291,8 +287,7 @@ string_list_t *list_sort(const string_list_t *list)
 
     /* create a sorted hash table of the entries */
     TAILQ_FOREACH(iter, list, items) {
-        entry = calloc(1, sizeof(*entry));
-        assert(entry != NULL);
+        entry = xalloc(sizeof(*entry));
         entry->key = strdup(iter->data);
         assert(entry->key != NULL);
         HASH_ADD_KEYPTR_INORDER(hh, map, &entry->key, strlen(entry->key), entry, compare_entries);
@@ -412,13 +407,11 @@ string_list_t *list_add(string_list_t *list, const char *s)
     }
 
     if (list == NULL) {
-        list = calloc(1, sizeof(*list));
-        assert(list != NULL);
+        list = xalloc(sizeof(*list));
         TAILQ_INIT(list);
     }
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
     entry->data = strdup(s);
     assert(entry->data != NULL);
     TAILQ_INSERT_TAIL(list, entry, items);

--- a/lib/macros.c
+++ b/lib/macros.c
@@ -137,8 +137,7 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
 
         /* initialize the macros list if necessary */
         if (ri->macros == NULL) {
-            ri->macros = calloc(1, sizeof(*ri->macros));
-            assert(ri->macros != NULL);
+            ri->macros = xalloc(sizeof(*ri->macros));
             TAILQ_INIT(ri->macros);
         }
 
@@ -166,8 +165,7 @@ int get_specfile_macros(struct rpminspect *ri, const char *specfile)
         entry = TAILQ_FIRST(fields);
 
         /* add the macro */
-        pair = calloc(1, sizeof(*pair));
-        assert(pair != NULL);
+        pair = xalloc(sizeof(*pair));
 
         /* the macro key */
         TAILQ_REMOVE(fields, entry, items);

--- a/lib/magic.c
+++ b/lib/magic.c
@@ -81,8 +81,7 @@ const char *mime_type(struct rpminspect *ri, const char *file)
 
         if (entry == NULL) {
             /* start a new entry for this type */
-            entry = calloc(1, sizeof(*entry));
-            assert(entry != NULL);
+            entry = xalloc(sizeof(*entry));
             entry->data = strdup(type);
             HASH_ADD_KEYPTR(hh, ri->magic_types, entry->data, strlen(entry->data), entry);
         }

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -112,6 +112,7 @@ librpminspect_sources = [
     'tty.c',
     'uncompress.c',
     'unpack.c',
+    'xalloc.c',
 ]
 
 deps = [

--- a/lib/parse_yaml.c
+++ b/lib/parse_yaml.c
@@ -24,30 +24,6 @@
 #    define dprintf(...)
 #endif
 
-/* Always 0-initialized, unless the compiler disagrees. */
-static inline void *xalloc(size_t s)
-{
-    void *ret = NULL;
-
-    ret = calloc(1, s);
-    assert(ret != NULL);
-    return ret;
-}
-
-/* Note that xrealloc(NULL, ...) works the way you'd want. */
-static inline void *xrealloc(void *p, size_t s)
-{
-    void *ret;
-
-    if (p == NULL) {
-        return xalloc(s);
-    }
-
-    ret = realloc(p, s);
-    assert(ret);
-    return ret;
-}
-
 /*
  * Not only do they not give a method for this awfulness, and not only
  * do they put enums in their public headers, but they can't even be

--- a/lib/peers.c
+++ b/lib/peers.c
@@ -16,8 +16,7 @@ rpmpeer_t *init_peers(void)
 {
     rpmpeer_t *peers = NULL;
 
-    peers = calloc(1, sizeof(*(peers)));
-    assert(peers != NULL);
+    peers = xalloc(sizeof(*(peers)));
     TAILQ_INIT(peers);
     return peers;
 }
@@ -105,12 +104,7 @@ void add_peer(rpmpeer_t **peers, deprule_ignore_map_t *ignores, int whichbuild, 
 
     /* Add the peer if it doesn't already exist, otherwise add it */
     if (!found) {
-        peer = calloc(1, sizeof(*peer));
-
-        if (peer == NULL) {
-            warn("*** calloc");
-            return;
-        }
+        peer = xalloc(sizeof(*peer));
     }
 
     if (whichbuild == BEFORE_BUILD) {

--- a/lib/readelf.c
+++ b/lib/readelf.c
@@ -394,8 +394,7 @@ bool get_dynamic_tags(Elf *elf, const Elf64_Sxword tag, GElf_Dyn **out, size_t *
                  * alloc one more GElf_Dyn worth of memory and
                  * add to the end of the array
                  */
-                dyn_tmp = realloc(*out, ((*out_size) + 1) * (sizeof(GElf_Dyn)));
-                assert(dyn_tmp != NULL);
+                dyn_tmp = xrealloc(*out, ((*out_size) + 1) * (sizeof(GElf_Dyn)));
                 memmove(dyn_tmp + *out_size, &dyn, sizeof(GElf_Dyn));
                 *out = dyn_tmp;
                 (*out_size)++;

--- a/lib/readfile.c
+++ b/lib/readfile.c
@@ -69,8 +69,7 @@ void *read_file_bytes(const char *path, off_t *len)
     }
 
     /* break up the file in to lines */
-    data = calloc(1, *len + 1);
-    assert(data != NULL);
+    data = xalloc(*len + 1);
     data = memcpy(data, buf, *len);
     assert(data != NULL);
 

--- a/lib/results.c
+++ b/lib/results.c
@@ -35,8 +35,7 @@ results_t *init_results(void)
 {
     results_t *results = NULL;
 
-    results = calloc(1, sizeof(*results));
-    assert(results != NULL);
+    results = xalloc(sizeof(*results));
     TAILQ_INIT(results);
     return results;
 }
@@ -146,8 +145,7 @@ void add_result_entry(results_t **results, struct result_params *params)
         *results = init_results();
     }
 
-    entry = calloc(1, sizeof(*entry));
-    assert(entry != NULL);
+    entry = xalloc(sizeof(*entry));
 
     entry->severity = params->severity;
     entry->waiverauth = params->waiverauth;

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -78,8 +78,7 @@ Header get_rpm_header(struct rpminspect *ri, const char *pkg)
         return NULL;
     }
 
-    hentry = calloc(1, sizeof(*hentry));
-    assert(hentry != NULL);
+    hentry = xalloc(sizeof(*hentry));
     hentry->pkg = strdup(bpkg);
     assert(hentry->pkg != NULL);
 
@@ -416,9 +415,7 @@ char *extract_rpm_payload(const char *rpm)
 
     /* iterate over every entry in the payload */
     entry = archive_entry_new();
-
-    buf = calloc(1, BUFSIZ);
-    assert(buf != NULL);
+    buf = xalloc(BUFSIZ);
 
     while (rc >= 0) {
         rc = rpmfiNext(fi);

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -232,8 +232,7 @@ char *run_cmd_vp(int *exitcode, const char *workdir, char **argv)
         }
 
         output = NULL;
-        buf = calloc(1, n);
-        assert(buf != NULL);
+        buf = xalloc(n);
 
         while (getline(&buf, &n, reader) != -1) {
             xasprintf(&tail, "%s%s", (output == NULL) ? "" : output, buf);
@@ -321,8 +320,7 @@ char *run_cmd(int *exitcode, const char *workdir, const char *cmd, ...)
     assert(cmd != NULL);
 
     /* convert varargs to a string array */
-    argv = calloc(2, sizeof(*argv));
-    assert(argv != NULL);
+    argv = xcalloc(2, sizeof(*argv));
 
     /* add the command */
     argv[i] = strdup(cmd);
@@ -335,9 +333,7 @@ char *run_cmd(int *exitcode, const char *workdir, const char *cmd, ...)
 
     while ((element = va_arg(ap, char *)) != NULL) {
         i++;
-        argv = realloc(argv, sizeof(*argv) * (i + 1));
-        assert(argv != NULL);
-
+        argv = xrealloc(argv, sizeof(*argv) * (i + 1));
         argv[i - 1] = strdup(element);
         assert(argv[i - 1] != NULL);
         argv[i] = NULL;
@@ -373,9 +369,7 @@ char **build_argv(const char *cmd)
     assert(list != NULL);
 
     TAILQ_FOREACH(entry, list, items) {
-        r = realloc(r, sizeof(*r) * (i + 2));
-        assert(r != NULL);
-
+        r = xrealloc(r, sizeof(*r) * (i + 2));
         r[i] = strdup(entry->data);
         assert(r[i] != NULL);
         r[i + 1] = NULL;

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -414,8 +414,7 @@ char *strxmlescape(const char *s)
 
     /* allocate a buffer for the new string */
     len = BUFSIZ;
-    result = calloc(1, len);
-    assert(result != NULL);
+    result = xalloc(len);
 
     /* go through the string to build the new string */
     tmp = result;
@@ -440,8 +439,7 @@ char *strxmlescape(const char *s)
         if ((len - strlen(result)) <= 8) {
             /* grow the result string */
             len += BUFSIZ;
-            result = realloc(result, len);
-            assert(result != NULL);
+            result = xrealloc(result, len);
 
             /* reset the tmp pointer to the end of the new string */
             tmp = result;
@@ -453,8 +451,7 @@ char *strxmlescape(const char *s)
     }
 
     /* shrink down the buffer to just the size we need */
-    result = realloc(result, strlen(result) + 1);
-    assert(result != NULL);
+    result = xrealloc(result, strlen(result) + 1);
 
     return result;
 }
@@ -477,8 +474,7 @@ char *strappend(char *dest, ...)
             dest = strdup(s);
             assert(dest != NULL);
         } else {
-            dest = realloc(dest, strlen(dest) + strlen(s) + 1);
-            assert(dest != NULL);
+            dest = xrealloc(dest, strlen(dest) + strlen(s) + 1);
             dest = strcat(dest, s);
         }
     }
@@ -587,8 +583,7 @@ char *strshorten(const char *s, size_t width)
     }
 
     /* allocate the buffer for the shortened string */
-    r = calloc(1, width + 1);
-    assert(r != NULL);
+    r = xalloc(width + 1);
     tail = r;
 
     /* compute width of each half */

--- a/lib/xalloc.c
+++ b/lib/xalloc.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+
+/* Always 0-initialized, unless the compiler disagrees. */
+void *xcalloc(size_t n, size_t s)
+{
+    void *ret = NULL;
+
+    ret = calloc(n, s);
+    assert(ret != NULL);
+    return ret;
+}
+
+void *xalloc(size_t s)
+{
+    return xcalloc(1, s);
+}
+
+/* Note that xrealloc(NULL, ...) works the way you'd want. */
+void *xrealloc(void *p, size_t s)
+{
+    void *ret;
+
+    if (p == NULL) {
+        return xalloc(s);
+    }
+
+    ret = realloc(p, s);
+    assert(ret);
+    return ret;
+}
+
+#ifdef _HAVE_REALLOCARRAY
+void *xreallocarray(void *p, size_t n, size_t s)
+{
+    void *ret;
+
+    if (p == NULL) {
+        return xcalloc(n, s);
+    }
+
+    ret = reallocarray(p, n, s);
+    assert(ret);
+    return ret;
+}
+#endif

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -601,7 +601,7 @@ int main(int argc, char **argv)
     }
 
     /* Set up the main program data structure */
-    ri = calloc_rpminspect(ri);
+    ri = xalloc_rpminspect(ri);
     ri->progname = strdup(argv[0]);
     ri->verbose = verbose;
     ri->rebase_detection = rebase_detection;
@@ -881,7 +881,7 @@ int main(int argc, char **argv)
         cmdlen += strlen(argv[i]) + 1;
     }
 
-    params.details = calloc(1, cmdlen + 1);
+    params.details = xalloc(cmdlen + 1);
     assert(params.details != NULL);
     tail = params.details;
 


### PR DESCRIPTION
xalloc() and xrealloc() previously appeared in parse_yaml.c.  Move them out in to the main library and expand the list of wrappers so the rest of the code can start using these functions and we can drop lots of assert() statements.

Use these new xalloc.c functions throughout lib/ and src/