### PR TITLE
[fix] Unset DEBUGINFOD_URLS to prevent downloading debuginfo rpms

### DIFF
--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -677,6 +677,11 @@ bool inspect_annocheck(struct rpminspect *ri)
     }
 #endif
 
+    /* Prevent debuginfod from fetching debuginfo packages. */
+    if (unsetenv("DEBUGINFOD_URLS") == -1) {
+        warn("*** unsetenv");
+    }
+
     /* run the annocheck tests across all ELF files */
     result = foreach_peer_file(ri, NAME_ANNOCHECK, annocheck_driver);
 


### PR DESCRIPTION
If debuginfod is running and the environment where rpminspect runs has DEBUGINFOD_URLS set, then it will start trying to download debuginfo RPMs when you get to the annocheck inspection.

Fixes: #1399