### PR TITLE
Run clamav virus check on all CPUs, not on just one

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -5,6 +5,7 @@ install_headers(
     'init.h',
     'inspect.h',
     'output.h',
+    'parallel.h',
     'parser.h',
     'queue.h',
     'readelf.h',

--- a/include/parallel.h
+++ b/include/parallel.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifndef _LIBRPMINSPECT_PARALLEL_H
+#define _LIBRPMINSPECT_PARALLEL_H
+
+#include <poll.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+typedef struct {
+    pid_t    pid;
+    int      exit_status;
+    /*int    output_fd; - fd is in pfd[] */
+    unsigned output_len;
+    char     *output;
+} parallel_slot_t;
+
+typedef struct {
+    unsigned running;
+    unsigned max_pids;
+    unsigned max_len;
+    unsigned ready_fds;
+    struct pollfd *pfd;
+    parallel_slot_t *slot;
+} parallel_t;
+
+extern unsigned default_parallel_processes;
+
+parallel_t *new_parallel(int max);
+void delete_parallel(parallel_t *col, int kill_sig);
+
+parallel_slot_t* collect_one(parallel_t *col);
+/* unused yet: parallel_slot_t *collect_until_have_free_slot(parallel_t *col); */
+void insert_new_pid_and_fd(parallel_t *col, pid_t pid, int fd);
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -322,6 +322,9 @@ void dump_cfg(const struct rpminspect *);
 void *read_file_bytes(const char *path, off_t *len);
 string_list_t *read_file(const char *);
 
+/* io.c */
+ssize_t full_write(int fd, const void *buf, size_t len);
+
 /* release.c */
 char *read_release(const rpmfile_t *);
 const char *get_before_rel(struct rpminspect *);

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -11,19 +11,37 @@
 #include <sys/types.h>
 #include <clamav.h>
 #include "rpminspect.h"
+#include "parallel.h"
 
 static struct cl_engine *engine = NULL;
 #ifndef CL_SCAN_STDOPT
 struct cl_scan_options clamav_opts;
 #endif
 
-static struct result_params params;
+static parallel_t *col = NULL;
 
-static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
+/* these variables have different values in each child */
+static unsigned child_no = 0;
+static unsigned file_no = (unsigned)-1;
+static int virus_countdown = 4000;
+static int write_fd;
+
+static bool virus_driver(struct rpminspect *ri __attribute__((unused)), rpmfile_entry_t *file)
 {
-    bool result = true;
     int r = 0;
     const char *virus = NULL;
+
+    /* cyclically count from 0 to NCHILDREN-1 */
+    file_no++;
+
+    if (file_no == col->max_pids) {
+        file_no = 0;
+    }
+
+    /* handle only every Nth file */
+    if (file_no != child_no) {
+        return true;
+    }
 
     /* only check regular files */
     if (!S_ISREG(file->st.st_mode)) {
@@ -36,32 +54,37 @@ static bool virus_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 #else
     r = cl_scanfile(file->fullpath, &virus, NULL, engine, CL_SCAN_STDOPT);
 #endif
+#if 0 /* debug: uncomment for error injection - test that virus detection indeed works */
+    if (child_no == 0 && file_no == 0 && virus_countdown == 4000) {
+        virus = "b0g0virus";
+        r = CL_VIRUS;
+    }
+#endif
 
-    if (r == CL_VIRUS) {
-        params.severity = get_secrule_result_severity(ri, file, SECRULE_VIRUS);
-
-        if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
-            if (params.severity == RESULT_INFO) {
-                params.waiverauth = NOT_WAIVABLE;
-                params.verb = VERB_OK;
-            } else {
-                params.waiverauth = WAIVABLE_BY_SECURITY;
-                params.verb = VERB_FAILED;
-                result = false;
-            }
-
-            params.arch = get_rpm_header_arch(file->rpm_header);
-            params.file = file->localpath;
-            params.remedy = get_remedy(REMEDY_VIRUS);
-            xasprintf(&params.msg, _("Virus detected in %s in the %s package on %s: %s"), file->localpath, headerGetString(file->rpm_header, RPMTAG_NAME), params.arch, virus);
-            add_result(ri, &params);
-            free(params.msg);
-        }
-    } else if (r != CL_CLEAN) {
-        warnx("*** cl_scanfile(%s): %s", file->localpath, cl_strerror(r));
+    if (r != CL_CLEAN && r != CL_VIRUS) {
+        /* unexpected failure, bail out */
+        errx(EXIT_FAILURE, "*** cl_scanfile(%s): %s", file->localpath, cl_strerror(r));
     }
 
-    return result;
+    if (r == CL_VIRUS) {
+        if (!virus || !virus[0]) {
+            /* "nameless" virus? probably clamav bug, and our code would break on such: bail out */
+            errx(EXIT_FAILURE, "*** cl_scanfile(%s): virus with no name???", file->localpath);
+        }
+
+        /* Cap the number of reported infections.
+         * Receiving buffer has sanity limit, and we'd abort if it is exceeded.
+         * If we see thousands of "infected" files, we probably aren't
+         * interested in every one of them anyway.
+         */
+        if (virus_countdown != 0) {
+            virus_countdown--;
+            full_write(write_fd, virus, strlen(virus) + 1);
+            full_write(write_fd, &file, sizeof(file));
+        }
+    }
+
+    return true;
 }
 
 bool inspect_virus(struct rpminspect *ri)
@@ -72,8 +95,8 @@ bool inspect_virus(struct rpminspect *ri)
     struct dirent *de = NULL;
     char *cvdpath = NULL;
     struct cl_cvd *cvd = NULL;
-    bool result = false;
     int r = 0;
+    struct result_params params;
     unsigned int loaded_signatures; /* unused, exists to make cl_load() happy */
 
     /* initialize clamav */
@@ -189,11 +212,107 @@ bool inspect_virus(struct rpminspect *ri)
     params.msg = NULL;
     free(params.details);
     params.details = NULL;
-
-    /* run the virus check on each file */
     params.header = NAME_VIRUS;
     params.noun = _("virus or malware in ${FILE} on ${ARCH}");
-    result = foreach_peer_file(ri, NAME_VIRUS, virus_driver);
+
+    /* fork $NCPUS children */
+    fflush(NULL);
+    col = new_parallel(0); /* 0: will have one child per CPU */
+
+    for (child_no = 0; child_no < col->max_pids; child_no++) {
+        pid_t pid;
+        int pipefd[2];
+
+        if (pipe(pipefd)) {
+            err(EXIT_FAILURE, "pipe"); /* fatal */
+        }
+
+        int rnd = rand();
+        pid = fork();
+
+        if (pid < 0) {
+            err(EXIT_FAILURE, "fork"); /* fatal */
+        }
+
+        if (pid == 0) {
+            /* child */
+            close(pipefd[0]);
+            write_fd = pipefd[1];
+
+            /* "If you’re using libclamav with a forking daemon you
+             * should call srand() inside a forked child before making
+             * any calls to the libclamav functions" - clamav docs
+             */
+            srand(child_no ^ rnd);
+
+            /* run the virus check on each Nth file, then exit */
+            foreach_peer_file(ri, NAME_VIRUS, virus_driver);
+            _exit(0);
+        }
+
+        /* parent */
+        /* insert the child into collector */
+        close(pipefd[1]);
+        insert_new_pid_and_fd(col, pid, pipefd[0]);
+    } /* forking N children */
+
+    /* Let all children run, collecting their outputs.
+     * When any one of them finish, process its output.
+     * Repeat until all of them exit.
+     */
+    bool result = true;
+    parallel_slot_t *slot;
+    while ((slot = collect_one(col)) != NULL) {
+        int r = slot->exit_status;
+
+        if (!WIFEXITED(r)) {
+            errx(EXIT_FAILURE, "cl_scanfile() killed by signal %u", WTERMSIG(r));
+        }
+
+        if (WEXITSTATUS(r) != 0) {
+            errx(EXIT_FAILURE, "cl_scanfile() exited with %u", WEXITSTATUS(r));
+        }
+
+        char *output = slot->output;
+
+        if (output) {
+            /* consume all pairs of ("virusname",rpmfile_entry_t pointer) in output */
+            while (output[0]) {
+                rpmfile_entry_t *file;
+                const char *virus = output;
+
+                output += strlen(virus) + 1;
+                memcpy(&file, output, sizeof(file)); /* copy unaligned bytes */
+                output += sizeof(file);
+
+                params.severity = get_secrule_result_severity(ri, file, SECRULE_VIRUS);
+
+                if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
+                    if (params.severity == RESULT_INFO) {
+                        params.waiverauth = NOT_WAIVABLE;
+                        params.verb = VERB_OK;
+                    } else {
+                        params.waiverauth = WAIVABLE_BY_SECURITY;
+                        params.verb = VERB_FAILED;
+                        result = false;
+                    }
+
+                    params.arch = get_rpm_header_arch(file->rpm_header);
+                    params.file = file->localpath;
+                    params.remedy = get_remedy(REMEDY_VIRUS);
+                    xasprintf(&params.msg, _("Virus detected in %s in the %s package on %s: %s"), file->localpath, headerGetString(file->rpm_header, RPMTAG_NAME), params.arch, virus);
+                    add_result(ri, &params);
+                    free(params.msg);
+                }
+            } /* while (there is unprocessed output from this child) */
+
+            free(slot->output);
+            slot->output = NULL; /* avoid double-free in delete_parallel() */
+        }
+    } /* while (waiting for a child to finish) */
+
+    delete_parallel(col, /*signal:*/ 0);
+    col = NULL;
 
     /* hope the result is always this */
     if (result) {

--- a/lib/io.c
+++ b/lib/io.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <unistd.h>
+
+/*
+ * Write *all* of the supplied buffer out to a fd.
+ * Do multiple writes if necessary.
+ * Returns the amount written, or -1 if error was seen
+ * on the very first write.
+ * The write will be incomplete only if an error occurs
+ * on one of subsequent writes.
+ */
+ssize_t full_write(int fd, const void *buf, size_t len)
+{
+    ssize_t total = 0;
+
+    while (len != 0) {
+        ssize_t cc = write(fd, buf, len);
+
+        if (cc < 0) {
+            if (total) {
+                /* we already wrote some! */
+                /* user can do another write to know the error code */
+                return total;
+            }
+
+            return cc;  /* write() returns -1 on failure. */
+        }
+
+        total += cc;
+        buf = ((const char *)buf) + cc;
+        len -= cc;
+    }
+
+    return total;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -77,6 +77,7 @@ librpminspect_sources = [
     'inspect_upstream.c',
     'inspect_virus.c',
     'inspect_xml.c',
+    'io.c',
     'joinpath.c',
     'koji.c',
     'listfuncs.c',

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -91,6 +91,7 @@ librpminspect_sources = [
     'output_text.c',
     'output_xunit.c',
     'ownership.c',
+    'parallel.c',
     'parse_dson.c',
     'parse_json.c',
     'parse_yaml.c',

--- a/lib/parallel.c
+++ b/lib/parallel.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+#include <unistd.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <errno.h>
+#include <err.h>
+#include <sched.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdio.h>
+#include <string.h>
+#include "rpminspect.h"
+#include "parallel.h"
+
+unsigned default_parallel_processes = 0;
+
+static unsigned available_cpus(void)
+{
+#if 0
+    /* This reads /sys/devices/system/cpu/online, which isn't affected by CPU mask */
+    return sysconf(_SC_NPROCESSORS_ONLN);
+#else
+    /* We want "taskset 0x7 rpminspect ..." to correctly assume that only 3 CPUs are available */
+    int r;
+    uint32_t mask[4096 / 4];
+
+    memset(mask, 0, sizeof(mask));
+    r = sched_getaffinity(0, sizeof(mask), (void*)mask);
+
+    if (r != 0) {
+        errx(EXIT_FAILURE, "I am not prepared for machines with 4500+ CPUs");
+        /* we can write a (re)allocating/looping version when we need to */
+    }
+
+    r = 0;
+
+    for (unsigned i = 0; i < sizeof(mask)/sizeof(mask[0]); i++) {
+        uint32_t m = mask[i];
+
+        if (m == 0) continue;
+
+        if (~m == 0) { /* fully all-ones word (typical) */
+            r += sizeof(mask[0]) * 8;
+            continue;
+        }
+
+        /* obscure method to count bits in 32-bit word */
+        m = m - ((m >> 1) & 0x55555555);
+        m = (m & 0x33333333) + ((m >> 2) & 0x33333333);
+        r += (((m + (m >> 4)) & 0x0f0f0f0f) * 0x01010101) >> 24;
+    }
+
+    return r;
+#endif
+}
+
+/* If MAX > 0: prepare for up to MAX processes.
+ *
+ * If MAX is 0, default_parallel_processes is used
+ * (which, in turn, is set to sysconf(_SC_NPROCESSORS_ONLN)).
+ *
+ * If MAX < 0, use default_parallel_processes * (-MAX).
+ * For example, if we anticipate that children are simple,
+ * fast-finishing processes, it makes sense to spawn 3 * NUM_CPU of them,
+ * for system to have something more to do when some of them finish -
+ * then use new_parallel(-3).
+ */
+parallel_t *new_parallel(int max)
+{
+    parallel_t *col;
+    unsigned max_pids;
+    unsigned i;
+
+    max_pids = 1;
+
+    if (max < 0 && max > -20 /* new_parallel(-999999) is clearly a bug */) {
+        max_pids = -max;
+    }
+
+    if (max <= 0) {
+        max = default_parallel_processes;
+
+        if (max <= 0) {
+            max = available_cpus();
+
+            if ((int)max <= 0) { /* paranoia */
+                max = 1;
+            }
+
+            if (max > 1024) { /* paranoia */
+                max = 1024;
+            }
+
+            default_parallel_processes = max;
+        }
+    }
+
+    max_pids *= max;
+    col = xcalloc(1, sizeof(*col));
+    col->running = 0;
+    col->max_pids = max_pids;
+    col->max_len = 64 * 1024 * 1024; /* 64 Mb output sanity limit */
+    col->pfd = xcalloc(1, sizeof(*col->pfd) * max_pids);
+    col->slot = xcalloc(1, sizeof(*col->slot) * max_pids);
+
+    for (i = 0; i < max_pids; i++) {
+        col->pfd[i].fd = -1;
+        col->pfd[i].events = POLLIN;
+    }
+
+    return col;
+}
+
+void delete_parallel(parallel_t *col, int kill_sig)
+{
+    unsigned i;
+
+    for (i = 0; i < col->max_pids; i++) {
+        pid_t pid = col->slot[i].pid;
+
+        if (pid != 0) {
+            if (kill_sig) {
+                kill(pid, kill_sig);
+            } else {
+                /* this can be a bug, let user know */
+                printf("Note: pid %u is not processed before %s(), waiting for it\n",
+                                pid, __func__);
+            }
+
+            waitpid(pid, NULL, 0);
+        }
+
+        if (col->pfd[i].fd >= 0) {
+            close(col->pfd[i].fd);
+        }
+
+        free(col->slot[i].output);
+    }
+
+    free(col->pfd);
+    free(col->slot);
+    free(col);
+}
+
+parallel_slot_t* collect_one(parallel_t *col)
+{
+    if (col->running == 0) {
+        return NULL;
+    }
+
+    for (;;) {
+        unsigned i;
+        int poll_cnt = col->ready_fds;
+
+        /* Do we already have previous poll() result? */
+        if (poll_cnt == 0) {
+            /* No. Get new one. IOW: can't avoid doing poll() */
+            for (;;) {
+                poll_cnt = poll(col->pfd, col->max_pids, -1);
+
+                if (poll_cnt < 0) {
+                    if (errno == EINTR) {
+                        continue;
+                    }
+                    err(EXIT_FAILURE, "poll"); /* not supposed to happen */
+                }
+
+                if (poll_cnt == 0) { /* timeout??? we didn't ask for one! */
+                    err(EXIT_FAILURE, "poll");
+                }
+
+                col->ready_fds = poll_cnt;
+                break;
+            }
+        }
+
+        for (i = 0; i < col->max_pids && poll_cnt != 0; i++) {
+            char buf[16 * 1024];
+            parallel_slot_t *slot = &col->slot[i];
+
+            if (col->pfd[i].revents == 0) {
+                    continue;
+            }
+
+            /* this fd has data to read */
+            int r = read(col->pfd[i].fd, buf, sizeof(buf));
+#if 0
+            warnx("pfd[%u].revents:0x%x poll_cnt:%u max_pids:%u running:%u read:%d",
+                    i, col->pfd[i].revents, poll_cnt, col->max_pids, col->running, r);
+#endif
+            col->pfd[i].revents = 0; /* avoid checking it later */
+            col->ready_fds = --poll_cnt;
+
+            if (r > 0) {
+                unsigned newsz = slot->output_len + r;
+
+                if (newsz > col->max_len) { /* usually just paranoia check */
+                    errx(EXIT_FAILURE, "maximum length of output exceeded: %u", newsz);
+                }
+
+                slot->output = xrealloc(slot->output, newsz + 1);
+                char *end = mempcpy(slot->output + slot->output_len, buf, r);
+                *end = '\0';
+                slot->output_len = newsz;
+                continue;
+            }
+
+            /* r <= 0: eof/error */
+            close(col->pfd[i].fd);
+            col->pfd[i].fd = -1;
+            /* Wait for the process, get exit status */
+            slot->exit_status = 0;
+
+            if (waitpid(slot->pid, &slot->exit_status, 0) < 0) {
+                err(EXIT_FAILURE, "waitpid(%u)", slot->pid); /* should not happen */
+            }
+
+            col->running--;
+            slot->pid = 0;
+
+            /* return this slot */
+#if 0
+            warnx("returning [%u]: output:%u '%s'", i, slot->output_len, slot->output);
+#endif
+            return slot;
+        }
+
+        /* We are here if we read some data, but no EOFs were seen. */
+        /* Return to poll() and wait for more data. */
+        col->ready_fds = 0;
+    }
+}
+
+#if 0 /* unused yet */
+parallel_slot_t *collect_until_have_free_slot(parallel_t *col)
+{
+    if (col->running < col->max_pids) {
+        return NULL;
+    }
+
+    return collect_one(col);
+}
+#endif
+
+void insert_new_pid_and_fd(parallel_t *col, pid_t pid, int fd)
+{
+    unsigned i;
+
+    for (i = 0; i < col->max_pids; i++) {
+        parallel_slot_t *slot = &col->slot[i];
+
+        if (slot->pid == 0) {
+            col->running++;
+            col->pfd[i].fd = fd;
+            slot->pid = pid;
+            free(slot->output);
+            slot->output = NULL;
+            slot->output_len = 0;
+            return;
+        }
+    }
+
+    errx(EXIT_FAILURE, "BUG: no free slots");
+}

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -390,6 +390,16 @@ int main(int argc, char **argv)
     /* Be friendly to "rpminspect ... 2>&1 | tee" use case */
     setlinebuf(stdout);
 
+    /* clamav uses rand() to generate random temporary file names,
+     * call srand() to avoid name collisions.
+     * (In fact, source of clamav I examined isn't that bad, it calls
+     * srand itself once: "srand(curtime_microsec + clock() + rand())"
+     * but just to be safe, make sure _this_ call to rand() ^^^^^^^^
+     * isn't deterministic).
+     * Mixing in PID ensures that even two simultaneously
+     * started rpminspect instances get differing seeds */
+    srand(time(NULL) ^ getpid());
+
     /* SIGABRT handler since we use abort() in some failure cases */
     abrt.sa_handler = sigabrt_handler;
     sigemptyset(&abrt.sa_mask);


### PR DESCRIPTION
On a 8-thread CPU (Intel Tigerlake laptop), in test run a-la
rpminspect -c /usr/share/rpminspect/fedora.yaml -p rawhide
    -Dv -k -t VERIFY -a x86_64,noarch,src -T virus kernel-6.8.10-200.fc39
this cuts "virus inspection" run time from 19 to 8 minutes.

On a larger machine the benefits should be proportionately larger.