### PR TITLE
[lib] reduce struct size of rpmfile_entry_t

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -108,7 +108,10 @@ typedef struct _rpmfile_entry_t {
     Header rpm_header;
     char *fullpath;
     char *localpath;
-    struct stat st;
+    /* struct stat st; - 128 bytes on x86, store only fields we need: */
+    off_t st_size;
+    mode_t st_mode;
+    unsigned st_nlink;
     int idx;
     char *type;
     char *checksum;

--- a/lib/checksums.c
+++ b/lib/checksums.c
@@ -207,6 +207,6 @@ char *checksum(rpmfile_entry_t *file)
         return file->checksum;
     }
 
-    file->checksum = compute_checksum(file->fullpath, &file->st.st_mode, DEFAULT_MESSAGE_DIGEST);
+    file->checksum = compute_checksum(file->fullpath, &file->st_mode, DEFAULT_MESSAGE_DIGEST);
     return file->checksum;
 }

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -42,7 +42,7 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
     assert(ri != NULL);
     assert(file != NULL);
 
-    perms = get_interesting_perms(file->st.st_mode);
+    perms = get_interesting_perms(file->st_mode);
     pkg = headerGetString(file->rpm_header, RPMTAG_NAME);
 
     init_result_params(&params);
@@ -53,7 +53,7 @@ bool match_fileinfo_mode(struct rpminspect *ri, const rpmfile_entry_t *file, con
     if (init_fileinfo(ri)) {
         TAILQ_FOREACH(fientry, ri->fileinfo, items) {
             if (!strcmp(file->localpath, fientry->filename)) {
-                if (file->st.st_mode == fientry->mode) {
+                if (file->st_mode == fientry->mode) {
                     xasprintf(&params.msg, _("%s in %s on %s carries expected mode %04o"), file->localpath, pkg, params.arch, perms);
                     params.severity = RESULT_INFO;
                     params.waiverauth = NOT_WAIVABLE;
@@ -128,7 +128,7 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
         assert(fname != NULL);
     }
 
-    perms = get_interesting_perms(file->st.st_mode);
+    perms = get_interesting_perms(file->st_mode);
     pkg = headerGetString(file->rpm_header, RPMTAG_NAME);
 
     init_result_params(&params);
@@ -167,7 +167,7 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
     }
 
     /* catch anything not on the fileinfo list with setuid/setgid */
-    if (!(*reported) && (file->st.st_mode & (S_ISUID|S_ISGID))) {
+    if (!(*reported) && (file->st_mode & (S_ISUID|S_ISGID))) {
         params.severity = get_secrule_result_severity(ri, file, SECRULE_MODES);
 
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
@@ -214,7 +214,7 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
         assert(fname != NULL);
     }
 
-    perms = get_interesting_perms(file->st.st_mode);
+    perms = get_interesting_perms(file->st_mode);
     pkg = headerGetString(file->rpm_header, RPMTAG_NAME);
 
     init_result_params(&params);
@@ -253,7 +253,7 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
     }
 
     /* catch anything not on the fileinfo list with setuid/setgid */
-    if (!(*reported) && (file->st.st_mode & (S_ISUID|S_ISGID))) {
+    if (!(*reported) && (file->st_mode & (S_ISUID|S_ISGID))) {
         params.severity = get_secrule_result_severity(ri, file, SECRULE_MODES);
 
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {

--- a/lib/files.c
+++ b/lib/files.c
@@ -294,15 +294,14 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         file_entry->cap = NULL;
 #endif
 
-        memset(&(file_entry->st), 0, sizeof(file_entry->st));
-        file_entry->st.st_mode = get_rpm_header_num_array_value(file_entry, RPMTAG_FILEMODES);
-        file_entry->st.st_size = archive_entry_size(entry);
-        file_entry->st.st_nlink = archive_entry_nlink(entry);
+        file_entry->st_mode = get_rpm_header_num_array_value(file_entry, RPMTAG_FILEMODES);
+        file_entry->st_size = archive_entry_size(entry);
+        file_entry->st_nlink = archive_entry_nlink(entry);
 
         TAILQ_INSERT_TAIL(file_list, file_entry, items);
 
         /* Are we extracting this file? */
-        if (!(S_ISREG(file_entry->st.st_mode) || S_ISDIR(file_entry->st.st_mode) || S_ISLNK(file_entry->st.st_mode))) {
+        if (!(S_ISREG(file_entry->st_mode) || S_ISDIR(file_entry->st_mode) || S_ISLNK(file_entry->st_mode))) {
             continue;
         }
 
@@ -335,14 +334,14 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         archive_perm |= S_IRUSR | S_IWUSR;
         archive_perm &= ~S_IWOTH;
 
-        if (S_ISDIR(file_entry->st.st_mode)) {
+        if (S_ISDIR(file_entry->st_mode)) {
             archive_perm |= S_IXUSR;
         }
 
         archive_entry_set_perm(entry, archive_perm);
 
         /* If this is a hard link, update the hardlink destination path */
-        if (file_entry->st.st_nlink > 1) {
+        if (file_entry->st_nlink > 1) {
             xasprintf(&hardlinkpath, "%s/%s", *output_dir, archive_entry_hardlink(entry));
             archive_entry_set_link(entry, hardlinkpath);
             free(hardlinkpath);
@@ -786,7 +785,7 @@ static void find_one_peer(struct rpminspect *ri, rpmfile_entry_t *file, rpmfile_
     }
 
     /* See if this file peer moved */
-    if (file->peer_file == NULL && S_ISREG(file->st.st_mode)) {
+    if (file->peer_file == NULL && S_ISREG(file->st_mode)) {
         /* .build-id files can be ignored, they always move */
         if (strstr(file->localpath, BUILD_ID_DIR)) {
             return;
@@ -833,7 +832,7 @@ static void find_one_peer(struct rpminspect *ri, rpmfile_entry_t *file, rpmfile_
                     file->peer_file->moved_subpackage = true;
                     return;
                 }
-            } else if ((S_ISREG(file->st.st_mode) && S_ISREG(after_file->st.st_mode))
+            } else if ((S_ISREG(file->st_mode) && S_ISREG(after_file->st_mode))
                        || (is_elf(file) && is_elf(after_file))) {
                 /*
                  * Try to match libraries that have changed versions.

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -178,7 +178,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* skip anything that is not an ELF shared library file.  */
-    if (!S_ISREG(file->st.st_mode) || !is_elf_file(file)) {
+    if (!S_ISREG(file->st_mode) || !is_elf_file(file)) {
         return true;
     }
 

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -192,7 +192,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         peer_new = false;
     }
 
-    if (ri->security_path_prefix && S_ISREG(file->st.st_mode) && peer_new) {
+    if (ri->security_path_prefix && S_ISREG(file->st_mode) && peer_new) {
         TAILQ_FOREACH(entry, ri->security_path_prefix, items) {
             subpath = entry->data;
 

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -96,7 +96,7 @@ static bool badfuncs_driver(struct rpminspect *ri, rpmfile_entry_t *after)
         return true;
     }
 
-    if (!after->fullpath || !S_ISREG(after->st.st_mode)) {
+    if (!after->fullpath || !S_ISREG(after->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -108,7 +108,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only perform checks on regular files */
-    if (!S_ISREG(file->st.st_mode)) {
+    if (!S_ISREG(file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -40,7 +40,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* only compare regular files and symlinks */
-    if (S_ISDIR(file->st.st_mode) || S_ISCHR(file->st.st_mode) || S_ISBLK(file->st.st_mode) || S_ISFIFO(file->st.st_mode) || S_ISSOCK(file->st.st_mode)) {
+    if (S_ISDIR(file->st_mode) || S_ISCHR(file->st_mode) || S_ISBLK(file->st_mode) || S_ISFIFO(file->st_mode) || S_ISSOCK(file->st_mode)) {
         return true;
     }
 
@@ -86,9 +86,9 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
          * resolution works.  Absolutel symlinks will fail this
          * routine.
          */
-        if (S_ISLNK(file->st.st_mode) || S_ISLNK(file->peer_file->st.st_mode)) {
+        if (S_ISLNK(file->st_mode) || S_ISLNK(file->peer_file->st_mode)) {
             /* read the before link destination */
-            if (S_ISLNK(file->peer_file->st.st_mode)) {
+            if (S_ISLNK(file->peer_file->st_mode)) {
                 memset(before_dest, '\0', sizeof(before_dest));
                 n = readlink(file->peer_file->fullpath, before_dest, PATH_MAX);
 
@@ -99,7 +99,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             }
 
             /* read the after link destination */
-            if (S_ISLNK(file->st.st_mode)) {
+            if (S_ISLNK(file->st_mode)) {
                 memset(after_dest, '\0', sizeof(after_dest));
                 n = readlink(file->fullpath, after_dest, PATH_MAX);
 
@@ -110,7 +110,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             }
 
             /* report changes */
-            if (!S_ISLNK(file->peer_file->st.st_mode) && S_ISLNK(file->st.st_mode)) {
+            if (!S_ISLNK(file->peer_file->st_mode) && S_ISLNK(file->st_mode)) {
                 xasprintf(&params.msg, _("%%config file %s went from actual file to symlink (pointing to %s) in %s on %s"), file->localpath, after_dest, name, arch);
                 add_result(ri, &params);
                 free(params.msg);
@@ -119,7 +119,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 if (params.severity == RESULT_VERIFY) {
                     result = false;
                 }
-            } else if (S_ISLNK(file->peer_file->st.st_mode) && !S_ISLNK(file->st.st_mode)) {
+            } else if (S_ISLNK(file->peer_file->st_mode) && !S_ISLNK(file->st_mode)) {
                 xasprintf(&params.msg, _("%%config file %s was a symlink (pointing to %s), became an actual file in %s on %s"), file->peer_file->localpath, before_dest, name, arch);
                 add_result(ri, &params);
                 free(params.msg);

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -155,7 +155,7 @@ static bool is_desktop_entry_file(const char *desktop_entry_files_dir, const rpm
     }
 
     /* Is this a regular file? */
-    if (!file->fullpath || !S_ISREG(file->st.st_mode)) {
+    if (!file->fullpath || !S_ISREG(file->st_mode)) {
         return false;
     }
 

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -37,7 +37,7 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* only compare regular files and symlinks */
-    if (S_ISDIR(file->st.st_mode) || S_ISCHR(file->st.st_mode) || S_ISBLK(file->st.st_mode) || S_ISFIFO(file->st.st_mode) || S_ISSOCK(file->st.st_mode)) {
+    if (S_ISDIR(file->st_mode) || S_ISCHR(file->st_mode) || S_ISBLK(file->st_mode) || S_ISFIFO(file->st_mode) || S_ISSOCK(file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -48,7 +48,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only perform checks on regular files */
-    if (!S_ISREG(file->st.st_mode)) {
+    if (!S_ISREG(file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -859,7 +859,7 @@ static bool elf_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     }
 
     /* Skip anything that isn't a regular file */
-    if (!after->fullpath || !S_ISREG(after->st.st_mode)) {
+    if (!after->fullpath || !S_ISREG(after->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -43,7 +43,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only run this check on regular files */
-    if (!S_ISREG(file->st.st_mode) && !S_ISREG(file->peer_file->st.st_mode)) {
+    if (!S_ISREG(file->st_mode) && !S_ISREG(file->peer_file->st_mode)) {
         return true;
     }
 
@@ -56,7 +56,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
      * stat(2) in to the rpmfile_entry_t so it can be used by other
      * inspections.
      */
-    if ((file->st.st_nlink > 1) && (file->st.st_size == 0)) {
+    if ((file->st_nlink > 1) && (file->st_size == 0)) {
         errno = 0;
         r = stat(file->fullpath, &sb);
 
@@ -64,10 +64,10 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             warn("*** stat");
         }
 
-        file->st.st_size = sb.st_size;
+        file->st_size = sb.st_size;
     }
 
-    if ((file->peer_file->st.st_nlink > 1) && (file->peer_file->st.st_size == 0)) {
+    if ((file->peer_file->st_nlink > 1) && (file->peer_file->st_size == 0)) {
         errno = 0;
         r = stat(file->peer_file->fullpath, &sb);
 
@@ -75,11 +75,11 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             warn("*** stat");
         }
 
-        file->peer_file->st.st_size = sb.st_size;
+        file->peer_file->st_size = sb.st_size;
     }
 
     /* Nothing to do if the sizes are the same */
-    if (file->st.st_size == file->peer_file->st.st_size) {
+    if (file->st_size == file->peer_file->st_size) {
         return true;
     }
 
@@ -96,7 +96,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.verb = VERB_OK;
 
     /* Size checks and messaging */
-    if (file->st.st_size > 0 && file->peer_file->st.st_size == 0) {
+    if (file->st_size > 0 && file->peer_file->st_size == 0) {
         /* became non-empty */
         xasprintf(&params.msg, _("%s became a non-empty file on %s"), file->localpath, arch);
         params.severity = RESULT_VERIFY;
@@ -105,7 +105,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.noun = _("non-empty ${FILE} on ${ARCH}");
         params.remedy = get_remedy(REMEDY_FILESIZE_BECAME_NOT_EMPTY);
         result = false;
-    } else if (file->st.st_size == 0 && file->peer_file->st.st_size > 0) {
+    } else if (file->st_size == 0 && file->peer_file->st_size > 0) {
         /* became empty */
         xasprintf(&params.msg, _("%s became an empty file on %s"), file->localpath, arch);
         params.severity = RESULT_VERIFY;
@@ -115,7 +115,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.remedy = get_remedy(REMEDY_FILESIZE_BECAME_EMPTY);
         result = false;
     } else {
-        change = ((file->st.st_size - file->peer_file->st.st_size) * 100 / file->peer_file->st.st_size);
+        change = ((file->st_size - file->peer_file->st_size) * 100 / file->peer_file->st_size);
         params.severity = RESULT_INFO;
         params.waiverauth = NOT_WAIVABLE;
 

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -163,7 +163,7 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* skip anything that is not an ELF file */
-    if (!S_ISREG(file->st.st_mode) || !is_elf(file)) {
+    if (!S_ISREG(file->st_mode) || !is_elf(file)) {
         return true;
     }
 

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -92,7 +92,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only perform this inspection on regular files */
-    if (!S_ISREG(file->st.st_mode)) {
+    if (!S_ISREG(file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -115,7 +115,7 @@ static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only for regular files */
-    if (!S_ISREG(file->st.st_mode)) {
+    if (!S_ISREG(file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -270,7 +270,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Is this a man page? */
-    if (!file->fullpath || !S_ISREG(file->st.st_mode)) {
+    if (!file->fullpath || !S_ISREG(file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -501,8 +501,8 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (params.details) {
             /* more than whitespace changed */
-            oldsize = file->peer_file->st.st_size;
-            newsize = file->st.st_size;
+            oldsize = file->peer_file->st_size;
+            newsize = file->st_size;
             xasprintf(&params.msg, _("%s changed (%ld bytes -> %ld bytes)"), file->localpath, oldsize, newsize);
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -32,11 +32,11 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 #endif
 
     /* special files and directories can be skipped */
-    if (S_ISDIR(file->st.st_mode) ||
-        S_ISCHR(file->st.st_mode) ||
-        S_ISBLK(file->st.st_mode) ||
-        S_ISFIFO(file->st.st_mode) ||
-        S_ISSOCK(file->st.st_mode)) {
+    if (S_ISDIR(file->st_mode) ||
+        S_ISCHR(file->st_mode) ||
+        S_ISBLK(file->st_mode) ||
+        S_ISFIFO(file->st_mode) ||
+        S_ISSOCK(file->st_mode)) {
         return true;
     }
 
@@ -98,7 +98,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 matched = true;
                 allowed = pentry->allowed;
             } else {
-                digest = compute_checksum(file->fullpath, &file->st.st_mode, type);
+                digest = compute_checksum(file->fullpath, &file->st_mode, type);
 
                 if (!strcmp(pentry->digest, digest)) {
                     matched = true;

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -43,7 +43,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only perform checks on regular files */
-    if (!S_ISREG(file->st.st_mode)) {
+    if (!S_ISREG(file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -53,7 +53,7 @@ static bool build_contains(const struct rpminspect *ri, const char *working_path
         }
 
         TAILQ_FOREACH(file, peer->after_files, items) {
-            if (S_ISDIR(file->st.st_mode) && !strcmp(file->localpath, working_path)) {
+            if (S_ISDIR(file->st_mode) && !strcmp(file->localpath, working_path)) {
                 return true;
             }
         }
@@ -222,7 +222,7 @@ static bool runpath_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only perform checks on regular files */
-    if (!S_ISREG(file->st.st_mode)) {
+    if (!S_ISREG(file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -126,7 +126,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* only applies to symbolic links */
-    if (!S_ISLNK(file->st.st_mode)) {
+    if (!S_ISLNK(file->st_mode)) {
         return true;
     }
 
@@ -202,7 +202,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 target += 2;
             } else if (strprefix(target, "../") && !strcmp(reltarget, "")) {
                 /* relative symlink cannot be resolved */
-                xasprintf(&params.msg, _("%s %s has too many levels of redirects and cannot be resolved in %s on %s"), strtype(file->st.st_mode), params.file, name, params.arch);
+                xasprintf(&params.msg, _("%s %s has too many levels of redirects and cannot be resolved in %s on %s"), strtype(file->st_mode), params.file, name, params.arch);
                 xasprintf(&params.details, "%s -> %s", params.file, linktarget);
                 params.severity = RESULT_VERIFY;
                 params.verb = VERB_FAILED;
@@ -275,12 +275,12 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* check for things becoming symlinks to guard RPM */
-    if (file->fullpath && file->peer_file && !S_ISLNK(file->peer_file->st.st_mode)) {
+    if (file->fullpath && file->peer_file && !S_ISLNK(file->peer_file->st_mode)) {
         /* get the localpath link destination */
         len = readlink(file->fullpath, localpath, sizeof(localpath) - 1);
         localpath[len] = '\0';
 
-        if (S_ISDIR(file->peer_file->st.st_mode)) {
+        if (S_ISDIR(file->peer_file->st_mode)) {
             /* Some RPM versions cannot handle this on an upgrade */
             params.remedy = get_remedy(REMEDY_SYMLINKS_DIRECTORY);
             xasprintf(&params.msg, _("Directory %s became a symbolic link (to %s) in %s on %s; this is not allowed!"), file->peer_file->localpath, localpath, name, params.arch);
@@ -290,11 +290,11 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         } else {
             /* just report this change as information */
             if (is_linkdest_reachable(ri->peers, target, params.arch, NULL)) {
-                xasprintf(&params.msg, _("%s %s became a symbolic link (to %s) in %s on %s; and the link destination is reachable"), strtype(file->peer_file->st.st_mode), file->peer_file->localpath, localpath, name, params.arch);
+                xasprintf(&params.msg, _("%s %s became a symbolic link (to %s) in %s on %s; and the link destination is reachable"), strtype(file->peer_file->st_mode), file->peer_file->localpath, localpath, name, params.arch);
                 params.severity = RESULT_INFO;
                 params.waiverauth = NOT_WAIVABLE;
             } else {
-                xasprintf(&params.msg, _("%s %s became a symbolic link (to %s) in %s on %s; and the link destination is unreachable"), strtype(file->peer_file->st.st_mode), file->peer_file->localpath, localpath, name, params.arch);
+                xasprintf(&params.msg, _("%s %s became a symbolic link (to %s) in %s on %s; and the link destination is unreachable"), strtype(file->peer_file->st_mode), file->peer_file->localpath, localpath, name, params.arch);
                 params.severity = RESULT_VERIFY;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
                 params.remedy = get_remedy(REMEDY_SYMLINKS);
@@ -311,9 +311,9 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* linkdest unreachable?  report */
     if (file->localpath && !is_linkdest_reachable(ri->peers, target, params.arch, &linkerr)) {
         if (file->peer_file) {
-            xasprintf(&params.msg, _("%s %s became a dangling symbolic link in %s on %s"), strtype(file->st.st_mode), file->localpath, name, params.arch);
+            xasprintf(&params.msg, _("%s %s became a dangling symbolic link in %s on %s"), strtype(file->st_mode), file->localpath, name, params.arch);
         } else {
-            xasprintf(&params.msg, _("%s %s is a dangling symbolic link in %s on %s"), strtype(file->st.st_mode), file->localpath, name, params.arch);
+            xasprintf(&params.msg, _("%s %s is a dangling symbolic link in %s on %s"), strtype(file->st_mode), file->localpath, name, params.arch);
         }
 
         if (linkerr == ELOOP || linkerr == ENAMETOOLONG) {

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -38,7 +38,7 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Only run this check on regular files */
-    if (!S_ISREG(file->st.st_mode) && !S_ISREG(file->peer_file->st.st_mode)) {
+    if (!S_ISREG(file->st_mode) && !S_ISREG(file->peer_file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_udevrules.c
+++ b/lib/inspect_udevrules.c
@@ -33,7 +33,7 @@ static bool is_udev_rules_file(struct rpminspect *ri, const rpmfile_entry_t *fil
     }
 
     /* Is this a regular file? */
-    if (!file->fullpath || !S_ISREG(file->st.st_mode)) {
+    if (!file->fullpath || !S_ISREG(file->st_mode)) {
         return false;
     }
 

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -44,7 +44,7 @@ static bool virus_driver(struct rpminspect *ri __attribute__((unused)), rpmfile_
     }
 
     /* only check regular files */
-    if (!S_ISREG(file->st.st_mode)) {
+    if (!S_ISREG(file->st_mode)) {
         return true;
     }
 

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -180,7 +180,7 @@ static bool xml_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Is this an XML file? */
-    if (!file->fullpath || !S_ISREG(file->st.st_mode)) {
+    if (!file->fullpath || !S_ISREG(file->st_mode)) {
         return true;
     }
 

--- a/lib/ownership.c
+++ b/lib/ownership.c
@@ -155,7 +155,7 @@ bool check_ownership(struct rpminspect *ri, const rpmfile_entry_t *file, const c
 
                 /* Handle if CAP_SETUID is present or not */
                 if (have_setuid == CAP_SET) {
-                    if ((file->st.st_mode & S_IXOTH)
+                    if ((file->st_mode & S_IXOTH)
                         && ((ri->tests & INSPECT_OWNERSHIP) || force_non_security_checks)) {
                         params.severity = get_secrule_result_severity(ri, file, SECRULE_SETUID);
 
@@ -172,7 +172,7 @@ bool check_ownership(struct rpminspect *ri, const rpmfile_entry_t *file, const c
                         }
                     }
 
-                    if (file->st.st_mode & S_IWGRP) {
+                    if (file->st_mode & S_IWGRP) {
                         params.severity = get_secrule_result_severity(ri, file, SECRULE_SETUID);
 
                         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {

--- a/lib/permissions.c
+++ b/lib/permissions.c
@@ -61,11 +61,11 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
     params.file = file->localpath;
 
     /* Local working copies for display */
-    after_mode = file->st.st_mode & 0777;
+    after_mode = file->st_mode & 0777;
 
     /* Compare the modes */
     if (file->peer_file) {
-        before_mode = file->peer_file->st.st_mode & 0777;
+        before_mode = file->peer_file->st_mode & 0777;
     } else {
         memset(&before_mode, 0, sizeof(before_mode));
     }
@@ -77,7 +77,7 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
     id_bit = (!(before_mode & (S_ISUID|S_ISGID)) && (after_mode & (S_ISUID|S_ISGID)));
 
     /* have permissions been relaxed in cases we want to verify? */
-    relaxed = (S_ISDIR(file->st.st_mode) && !S_ISLNK(file->st.st_mode)) && (((mode_diff & S_ISVTX) && !(after_mode & S_ISVTX)) || ((after_mode & mode_diff) != 0));
+    relaxed = (S_ISDIR(file->st_mode) && !S_ISLNK(file->st_mode)) && (((mode_diff & S_ISVTX) && !(after_mode & S_ISVTX)) || ((after_mode & mode_diff) != 0));
 
     if (id_bit) {
         ignore = false;
@@ -90,7 +90,7 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
             params.severity = RESULT_VERIFY;
         }
 
-        if (S_ISDIR(file->st.st_mode) && !S_ISDIR(file->peer_file->st.st_mode)) {
+        if (S_ISDIR(file->st_mode) && !S_ISDIR(file->peer_file->st_mode)) {
             if (id_bit) {
                 if (relaxed) {
                     xasprintf(&params.msg, _("%s changed setuid/setgid; became a directory; permissions relaxed"), file->localpath);
@@ -104,7 +104,7 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
                     xasprintf(&params.msg, _("%s became a directory; permissions changed"), file->localpath);
                 }
             }
-        } else if (S_ISCHR(file->st.st_mode) && !S_ISCHR(file->peer_file->st.st_mode)) {
+        } else if (S_ISCHR(file->st_mode) && !S_ISCHR(file->peer_file->st_mode)) {
             if (id_bit) {
                 if (relaxed) {
                     xasprintf(&params.msg, _("%s changed setuid/setgid; became a character device; permissions relaxed"), file->localpath);
@@ -118,7 +118,7 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
                     xasprintf(&params.msg, _("%s became a character device; permissions changed"), file->localpath);
                 }
             }
-        } else if (S_ISBLK(file->st.st_mode) && !S_ISBLK(file->peer_file->st.st_mode)) {
+        } else if (S_ISBLK(file->st_mode) && !S_ISBLK(file->peer_file->st_mode)) {
             if (id_bit) {
                 if (relaxed) {
                     xasprintf(&params.msg, _("%s changed setuid/setgid; became a block device; permissions relaxed"), file->localpath);
@@ -132,7 +132,7 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
                     xasprintf(&params.msg, _("%s became a block device; permissions changed"), file->localpath);
                 }
             }
-        } else if (S_ISREG(file->st.st_mode) && !S_ISREG(file->peer_file->st.st_mode)) {
+        } else if (S_ISREG(file->st_mode) && !S_ISREG(file->peer_file->st_mode)) {
             if (id_bit) {
                 if (relaxed) {
                     xasprintf(&params.msg, _("%s changed setuid/setgid; became a regular file; permissions relaxed"), file->localpath);
@@ -146,7 +146,7 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
                     xasprintf(&params.msg, _("%s became a regular file; permissions changed"), file->localpath);
                 }
             }
-        } else if (S_ISFIFO(file->st.st_mode) && !S_ISFIFO(file->peer_file->st.st_mode)) {
+        } else if (S_ISFIFO(file->st_mode) && !S_ISFIFO(file->peer_file->st_mode)) {
             if (id_bit) {
                 if (relaxed) {
                     xasprintf(&params.msg, _("%s changed setuid/setgid; became a FIFO; permissions relaxed"), file->localpath);
@@ -160,7 +160,7 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
                     xasprintf(&params.msg, _("%s became a FIFO; permissions changed"), file->localpath);
                 }
             }
-        } else if (S_ISLNK(file->st.st_mode) && !S_ISLNK(file->peer_file->st.st_mode)) {
+        } else if (S_ISLNK(file->st_mode) && !S_ISLNK(file->peer_file->st_mode)) {
             if (id_bit) {
                 if (relaxed) {
                     xasprintf(&params.msg, _("%s changed setuid/setgid; became a symbolic link; permissions relaxed"), file->localpath);
@@ -174,7 +174,7 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
                     xasprintf(&params.msg, _("%s became a symbolic link; permissions changed"), file->localpath);
                 }
             }
-        } else if (S_ISSOCK(file->st.st_mode) && !S_ISSOCK(file->peer_file->st.st_mode)) {
+        } else if (S_ISSOCK(file->st_mode) && !S_ISSOCK(file->peer_file->st_mode)) {
             if (id_bit) {
                 if (relaxed) {
                     xasprintf(&params.msg, _("%s changed setuid/setgid; became a socket; permissions relaxed"), file->localpath);
@@ -216,7 +216,7 @@ bool check_permissions(struct rpminspect *ri, const rpmfile_entry_t *file, const
     }
 
     /* check for world-writability */
-    if (!allowed && !S_ISLNK(file->st.st_mode) && ((after_mode & (S_IWOTH|S_ISVTX)) || (after_mode & S_IWOTH))) {
+    if (!allowed && !S_ISLNK(file->st_mode) && ((after_mode & (S_IWOTH|S_ISVTX)) || (after_mode & S_IWOTH))) {
         params.severity = get_secrule_result_severity(ri, file, SECRULE_WORLDWRITABLE);
 
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {


### PR DESCRIPTION
On x86_64, struct stat st is 128 bytes, but we use ony three fields in it. Replacing it with
    off_t st_size;
    mode_t st_mode;
    unsigned st_nlink;
in rpmfile_entry_t reduces the latter from 240 bytes to 112 bytes.

In test run a-la
rpminspect -c /usr/share/rpminspect/fedora.yaml -p rawhide
    -Dv -k -t VERIFY -a x86_64,noarch,src -T virus kernel-6.8.10-200.fc39
after rpm unpacking memory consupmtion of the process fell from ~130 to ~100 megabytes.