### PR TITLE
[tst] Use newer %patch syntax in test_patches.py

### DIFF
--- a/test/test_patches.py
+++ b/test/test_patches.py
@@ -477,7 +477,7 @@ class PatchDefinedWithoutFieldSpaceSRPM(TestSRPM):
         self.rpm.patches[patchIndex] = patch
         self.rpm.section_patches += "Patch%s:%s\n" % (patchIndex, patch.sourceName)
         self.rpm.add_check(rpmfluff.CheckSourceFile(patch.sourceName))
-        self.rpm.section_prep += "%%patch%i\n" % patchIndex
+        self.rpm.section_prep += "%%patch -P %i\n" % patchIndex
 
         self.inspection = "patches"
         self.result = "INFO"
@@ -497,7 +497,7 @@ class PatchDefinedWithoutFieldSpaceCompareSRPM(TestCompareSRPM):
             patch.sourceName,
         )
         self.after_rpm.add_check(rpmfluff.CheckSourceFile(patch.sourceName))
-        self.after_rpm.section_prep += "%%patch%i\n" % patchIndex
+        self.after_rpm.section_prep += "%%patch -P %i\n" % patchIndex
 
         self.inspection = "patches"
         self.result = "INFO"


### PR DESCRIPTION
The latest releases of rpm are now erroring out on the older syntax. The now preferred syntax of '%patch -P N' has actually been supported forever, so this is safe to use on older releases too.  Update the test suite to use this syntax.