### PR TITLE
[ci] Remove openssl-fips-provider in UBI9 before updating everything

### DIFF
--- a/.github/workflows/ubi.yml
+++ b/.github/workflows/ubi.yml
@@ -61,6 +61,9 @@ jobs:
                               echo >> /etc/yum.repos.d/ubi.repo
                           done
 
+                          # Avoid package conflicts
+                          rpm -e --nodeps openssl-fips-provider
+
                           # Upgrade things
                           dnf upgrade -y
 


### PR DESCRIPTION
Without this, we hit a package conflicts problem.