### PR TITLE
[lib] Expand shellsyntax to ignore scripts that use 'exec PROG'

### DIFF
--- a/test/test_shellsyntax.py
+++ b/test/test_shellsyntax.py
@@ -52,6 +52,28 @@ then
 """
 
 
+wish_sh = """#! /usr/bin/sh
+# Tcl ignores the next line -*- tcl -*- \
+exec wish "$0" -- "$@"
+
+# Copyright © 2005-2016 Paul Mackerras.  All rights reserved.
+# This program is free software; it may be used, copied, modified
+# and distributed under the terms of the GNU General Public Licence,
+# either version 2, or (at your option) any later version.
+
+package require Tk
+
+proc hasworktree {} {
+    return [expr {[exec git rev-parse --is-bare-repository] == "false" &&
+                  [exec git rev-parse --is-inside-git-dir] == "false"}]
+}
+
+# (taken from /usr/bin/gitk, but only parts of it)
+
+set appname "gitk"
+"""
+
+
 class ShWellFormedRPM(TestRPMs):
     """
     Valid /bin/sh script is OK for RPMs
@@ -1731,3 +1753,49 @@ class BashWellMalformedCompareKoji(TestCompareKoji):
         self.inspection = "shellsyntax"
         self.result = "BAD"
         self.waiver_auth = "Anyone"
+
+
+class WishIgnoredRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_installed_file(
+            "/usr/bin/gitk-snippet", rpmfluff.SourceFile("gitk-snippet.tcl", wish_sh)
+        )
+        self.inspection = "shellsyntax"
+        self.result = "OK"
+
+
+class WishIgnoredKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.add_installed_file(
+            "/usr/bin/gitk-snippet", rpmfluff.SourceFile("gitk-snippet.tcl", wish_sh)
+        )
+        self.inspection = "shellsyntax"
+        self.result = "OK"
+
+
+class WishIgnoredCompareRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_installed_file(
+            "/usr/bin/gitk-snippet", rpmfluff.SourceFile("gitk-snippet.tcl", wish_sh)
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/gitk-snippet", rpmfluff.SourceFile("gitk-snippet.tcl", wish_sh)
+        )
+        self.inspection = "shellsyntax"
+        self.result = "OK"
+
+
+class WishIgnoredCompareKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+        self.before_rpm.add_installed_file(
+            "/usr/bin/gitk-snippet", rpmfluff.SourceFile("gitk-snippet.tcl", wish_sh)
+        )
+        self.after_rpm.add_installed_file(
+            "/usr/bin/gitk-snippet", rpmfluff.SourceFile("gitk-snippet.tcl", wish_sh)
+        )
+        self.inspection = "shellsyntax"
+        self.result = "OK"


### PR DESCRIPTION
Expand the shellsyntax inspection to ignore scripts that invoke 'exec PROG' where PROG is another interpreter that reloads the script you're in and starts running it.  This is commonly used for Tcl scripts using /usr/bin/wish or /usr/bin/tclsh.

What this patch does is check to see if PROG is a shell we know about and can check syntax for.  If it is, it adjusts the shell from what was originally found on the #! line to the one found with exec.  This assumes that the exec command is loading the script we're looking at, which is not required but at least is somewhat common from what I am seeing.

The end result is that tclsh and wish scripts that use exec should be skipped now if they start with #!/bin/sh or something like that.

Fixes: #1411