### PR TITLE
Report all %changelog differences as RESULT_INFO now

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -225,7 +225,7 @@ macrofiles:
     - /etc/rpm/macros
     - /etc/rpm/%{_target}/macros
 
-ignore:
+#ignore:
     # Sometimes you want certain files or directories ignored by
     # rpminspect.  This section lets you list paths--glob(7) syntax
     # allowed--that you want rpminspect to ignore for all inspections.

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -182,6 +182,7 @@ bool strsuffix(const char *, const char *);
 int printwrap(const char *, const size_t, const unsigned int, FILE *);
 bool versioned_match(const char *, Header, const char *, Header);
 char *strseverity(const severity_t);
+char *strverb(const verb_t verb);
 severity_t getseverity(const char *, const severity_t);
 char *strwaiverauth(const waiverauth_t);
 char *strreplace(const char *, const char *, const char *);

--- a/include/types.h
+++ b/include/types.h
@@ -238,7 +238,8 @@ typedef enum _verb_t {
     VERB_CHANGED = 3,   /* changed file or metadata */
     VERB_FAILED = 4,    /* check failing */
     VERB_OK = 5,        /* the everything is ok alarm */
-    VERB_SKIP = 6       /* for skipped inspections or checks */
+    VERB_SKIP = 6,      /* for skipped inspections or checks */
+    VERB_MISSING = 7    /* item sought is missing */
 } verb_t;
 
 /*

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -239,36 +239,30 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
         /* Perform checks */
         if (before_changelog && (after_changelog == NULL || TAILQ_EMPTY(after_changelog))) {
             xasprintf(&params.msg, "%%changelog lost between the %s and %s builds", before_nevr, after_nevr);
-            params.severity = RESULT_VERIFY;
-            params.waiverauth = WAIVABLE_BY_ANYONE;
+            params.severity = RESULT_INFO;
             params.verb = VERB_REMOVED;
         } else if ((before_changelog == NULL || TAILQ_EMPTY(before_changelog)) && after_changelog) {
             xasprintf(&params.msg, "Gained %%changelog between the %s and %s builds", before_nevr, after_nevr);
             params.severity = RESULT_INFO;
-            params.waiverauth = NOT_WAIVABLE;
             params.verb = VERB_ADDED;
         } else if ((before_changelog == NULL || TAILQ_EMPTY(before_changelog)) && (after_changelog == NULL || TAILQ_EMPTY(after_changelog))) {
             xasprintf(&params.msg, "No %%changelog present in the %s build", after_nevr);
-            params.severity = RESULT_BAD;
-            params.waiverauth = WAIVABLE_BY_ANYONE;
-            params.verb = VERB_FAILED;
+            params.severity = RESULT_INFO;
+            params.verb = VERB_MISSING;
         }
     } else if (before_changelog == NULL || after_changelog == NULL) {
         if (before_changelog == NULL && after_changelog != NULL) {
             xasprintf(&params.msg, "Gained %%changelog between the %s and %s builds", before_nevr, after_nevr);
             params.severity = RESULT_INFO;
-            params.waiverauth = NOT_WAIVABLE;
             params.verb = VERB_ADDED;
         } else if (before_changelog != NULL && after_changelog == NULL) {
             xasprintf(&params.msg, "%%changelog lost between the %s and %s builds", before_nevr, after_nevr);
-            params.severity = RESULT_VERIFY;
-            params.waiverauth = WAIVABLE_BY_ANYONE;
+            params.severity = RESULT_INFO;
             params.verb = VERB_REMOVED;
         } else if (before_changelog == NULL && after_changelog == NULL) {
             xasprintf(&params.msg, "No %%changelog present in the %s build", after_nevr);
-            params.severity = RESULT_BAD;
-            params.waiverauth = WAIVABLE_BY_ANYONE;
-            params.verb = VERB_FAILED;
+            params.severity = RESULT_INFO;
+            params.verb = VERB_MISSING;
         }
     } else if (before && after && !strcmp(before->data, after->data)) {
         /*
@@ -280,9 +274,8 @@ static bool check_src_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
             strcmp(headerGetString(peer->before_hdr, RPMTAG_VERSION), headerGetString(peer->after_hdr, RPMTAG_VERSION)) ||
             (get_before_rel(ri) && get_after_rel(ri) && strcmp(get_before_rel(ri), get_after_rel(ri)))) {
             xasprintf(&params.msg, "No new %%changelog entry in the %s build", after_nevr);
-            params.severity = RESULT_BAD;
-            params.waiverauth = WAIVABLE_BY_ANYONE;
-            params.verb = VERB_FAILED;
+            params.severity = RESULT_INFO;
+            params.verb = VERB_MISSING;
         }
     }
 
@@ -360,8 +353,6 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
 
     /* Set up result parameters */
     init_result_params(&params);
-    params.severity = RESULT_INFO;
-    params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_CHANGELOG;
     params.verb = VERB_CHANGED;
     params.noun = _("%%changelog");

--- a/lib/output_summary.c
+++ b/lib/output_summary.c
@@ -19,7 +19,6 @@ void output_summary(const results_t *results, const char *dest, __attribute__((u
     results_entry_t *result = NULL;
     int r = 0;
     FILE *fp = NULL;
-    char *verb = NULL;
     char *msg = NULL;
     char *tmp = NULL;
     size_t width = tty_width();
@@ -50,23 +49,8 @@ void output_summary(const results_t *results, const char *dest, __attribute__((u
             }
         }
 
-        /* get a string representing the verb */
-        if (result->verb == VERB_ADDED) {
-            verb = _("added");
-        } else if (result->verb == VERB_REMOVED) {
-            verb = _("removed");
-        } else if (result->verb == VERB_CHANGED) {
-            verb = _("changed");
-        } else if (result->verb == VERB_FAILED) {
-            verb = _("FAILED");
-        } else if (result->verb == VERB_OK) {
-            verb = _("ok");
-        } else {
-            verb = _("unknown");
-        }
-
         /* construct the basic message */
-        xasprintf(&msg, "%-12s %s (%s)\n", verb, result->noun, result->header);
+        xasprintf(&msg, "%-12s %s (%s)\n", strverb(result->verb), result->noun, result->header);
 
         /* replace ${FILE} */
         if (strstr(msg, "${FILE}") && result->file != NULL) {

--- a/lib/results.c
+++ b/lib/results.c
@@ -76,36 +76,7 @@ void free_results(results_t *results)
  */
 void debug_print_result(const results_entry_t *result)
 {
-    char *v = NULL;
-
     assert(result != NULL);
-
-    switch (result->verb) {
-        case VERB_NIL:
-            v = "nil";
-            break;
-        case VERB_ADDED:
-            v = "added";
-            break;
-        case VERB_REMOVED:
-            v = "removed";
-            break;
-        case VERB_CHANGED:
-            v = "changed";
-            break;
-        case VERB_FAILED:
-            v = "failed";
-            break;
-        case VERB_OK:
-            v = "ok";
-            break;
-        case VERB_SKIP:
-            v = "skip";
-            break;
-        default:
-            v = "UnKnOwN";
-            break;
-    }
 
     DEBUG_PRINT("result:\n");
     DEBUG_PRINT("    severity=|%s|\n", strseverity(result->severity));
@@ -114,7 +85,7 @@ void debug_print_result(const results_entry_t *result)
     DEBUG_PRINT("         msg=|%s|\n", result->msg ? result->msg : "(null)");
     DEBUG_PRINT("     details=|%s|\n", result->details ? result->details : "(null)");
     DEBUG_PRINT("      remedy=|%s|\n", result->remedy ? result->remedy : "(null)");
-    DEBUG_PRINT("        verb=|%s|\n", v);
+    DEBUG_PRINT("        verb=|%s|\n", strverb(result->verb));
     DEBUG_PRINT("        noun=|%s|\n", result->noun ? result->noun : "(noun)");
     DEBUG_PRINT("        arch=|%s|\n", result->arch ? result->arch : "(arch)");
     DEBUG_PRINT("        file=|%s|\n", result->file ? result->file : "(null)");

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -268,6 +268,35 @@ char *strseverity(const severity_t severity)
 }
 
 /*
+ * Given a verb_t, return a string representing the value.
+ */
+char *strverb(const verb_t verb)
+{
+    switch (verb) {
+        case VERB_NIL:
+            return _("nil");
+        case VERB_ADDED:
+            return _("added");
+        case VERB_REMOVED:
+            return _("removed");
+        case VERB_CHANGED:
+            return _("changed");
+        case VERB_FAILED:
+            return _("failed");
+        case VERB_OK:
+            return _("ok");
+        case VERB_SKIP:
+            return _("skip");
+        case VERB_MISSING:
+            return _("missing");
+        default:
+            return _("UnKnOwN");
+    }
+
+    return NULL;
+}
+
+/*
  * Given a severity string, return a severity_t matching it.
  * Or return the default.
  */

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -30,8 +30,8 @@ class LostChangeLogCompareSRPM(TestCompareSRPM):
         self.after_rpm.section_changelog = None
 
         self.inspection = "changelog"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class LostChangeLogCompareRPMs(TestCompareRPMs):
@@ -72,8 +72,8 @@ class LostChangeLogCompareKoji(TestCompareKoji):
         self.after_rpm.section_changelog = None
 
         self.inspection = "changelog"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # 2) Prevent a %changelog in the before build but add one in the after
@@ -156,8 +156,8 @@ class SameChangeLogCompareSRPM(TestCompareSRPM):
         self.after_rpm.section_changelog = clog
 
         self.inspection = "changelog"
-        self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 class SameChangeLogCompareKoji(TestCompareKoji):
@@ -176,8 +176,8 @@ class SameChangeLogCompareKoji(TestCompareKoji):
         self.after_rpm.section_changelog = clog
 
         self.inspection = "changelog"
-        self.result = "BAD"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
 
 
 # In the binary RPM:


### PR DESCRIPTION
I'm not sure the exact reason why missing changelogs or formerly present and then removed changelogs were reported as either RESULT_VERIFY or RESULT_BAD.  Reporting these changes that way is inconsistent with current best practices and guidelines, but also with have automatic changelog generators and stuff like that.  So continue to report findings but just use RESULT_INFO.
    
For the missing changelog sections, make use of the new VERB_MISSING verb for findings.

VERB_MISSING is a new verb_t type that can be used by inspections when reporting.  strverb() takes a verb_t and returns a string describing the verb, similar to strseverity().