### PR TITLE
[fix] Report removedfile findings as INFO except for security paths

### DIFF
--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -14,7 +14,6 @@
 
 #include "rpminspect.h"
 
-static bool rebase = false;
 static bool reported = false;
 
 /*
@@ -96,11 +95,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (sentry || params.waiverauth == WAIVABLE_BY_SECURITY) {
             params.severity = get_secrule_result_severity(ri, file, SECRULE_SECURITYPATH);
         } else {
-            if (rebase) {
-                params.severity = RESULT_INFO;
-            } else {
-                params.severity = RESULT_VERIFY;
-            }
+            params.severity = RESULT_INFO;
         }
 
         if (params.severity <= RESULT_INFO) {
@@ -164,9 +159,6 @@ bool inspect_removedfiles(struct rpminspect *ri)
     struct result_params params;
 
     assert(ri != NULL);
-
-    /* is this a rebase comparison? */
-    rebase = is_rebase(ri);
 
     /*
      * This is like our after_files loop helper in inspect.c, but

--- a/test/test_removedfiles.py
+++ b/test/test_removedfiles.py
@@ -49,6 +49,7 @@ class FileNoRemovedKoji(TestCompareKoji):
         self.result = "OK"
 
 
+# File removed from an after build but it's not a security-related file (OK)
 class FileRemovedRPMs(TestCompareRPMs):
     def setUp(self):
         super().setUp()
@@ -62,8 +63,25 @@ class FileRemovedRPMs(TestCompareRPMs):
         )
 
         self.inspection = "removedfiles"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# File removed from an after build from a security path (BAD)
+class SecurityFileRemovedRPMs(TestCompareRPMs):
+    def setUp(self):
+        super().setUp()
+
+        # create the test packages
+        self.before_rpm.add_installed_file(
+            "etc/sudoers.d/s3kr1t",
+            rpmfluff.SourceFile("s3kr1t.sudo", "# This is a security related file!"),
+            mode="0644",
+        )
+
+        self.inspection = "removedfiles"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
 
 
 class FileRemovedRebaseRPMs(TestCompareRPMs):
@@ -114,8 +132,24 @@ class FileRemovedKoji(TestCompareKoji):
         )
 
         self.inspection = "removedfiles"
-        self.result = "VERIFY"
-        self.waiver_auth = "Anyone"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class SecurityFileRemovedKoji(TestCompareKoji):
+    def setUp(self):
+        super().setUp()
+
+        # create the test packages
+        self.before_rpm.add_installed_file(
+            "etc/sudoers.d/s3kr1t",
+            rpmfluff.SourceFile("s3kr1t.sudo", "# This is a security related file!"),
+            mode="0644",
+        )
+
+        self.inspection = "removedfiles"
+        self.result = "BAD"
+        self.waiver_auth = "Security"
 
 
 class FileRemovedRebaseKoji(TestCompareKoji):


### PR DESCRIPTION
Unless a removed file is tied to a security path prefix or has a defined security rule, report the change as INFO.

Fixes: #1409