### PR TITLE
Recognize %autorelease in Release field with options

### DIFF
--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -121,6 +121,7 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 {
     bool result = true;
     string_list_t *contents = NULL;
+    string_list_t *fields = NULL;
     string_entry_t *entry = NULL;
     char *buf = NULL;
     char *release = NULL;
@@ -167,9 +168,16 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* Allow %autorelease as the Release tag value */
-    if (release && !strcmp(release, SPEC_AUTORELEASE)) {
-        list_free(contents, free);
-        return true;
+    if (release && strprefix(release, SPEC_AUTORELEASE)) {
+        fields = strsplit(release, " \t");
+
+        if (list_contains(fields, SPEC_AUTORELEASE)) {
+            list_free(contents, free);
+            list_free(fields, free);
+            return true;
+        }
+
+        list_free(fields, free);
     }
 
     /* Expand macros in the release value */

--- a/test/test_disttag.py
+++ b/test/test_disttag.py
@@ -143,6 +143,24 @@ class AutoReleaseDistTagKoji(TestKoji):
         self.inspection = "disttag"
 
 
+# Verify system wide macros in the dist tag work in SRPM (OK)
+class AutoReleaseOptionsDistTagSRPM(TestSRPM):
+    @unittest.skipIf(missing_rpmautospec, "test requires the rpmautospec macros")
+    def setUp(self):
+        super().setUp()
+        self.rpm.release = "%autorelease -b 3"
+        self.inspection = "disttag"
+
+
+# Verify system wide macros in the dist tag work in Koji build (OK)
+class AutoReleaseOptionsDistTagKoji(TestKoji):
+    @unittest.skipIf(missing_rpmautospec, "test requires the rpmautospec macros")
+    def setUp(self):
+        super().setUp()
+        self.rpm.release = "%autorelease -b 3"
+        self.inspection = "disttag"
+
+
 ########################################################################
 # The test cases below do not use rpmfluff due to limitations in that  #
 # Python module.  Instead these test cases inherit RequiresRpminspect  #


### PR DESCRIPTION
The %autorelease macro may have options.  The disttag inspection sees %autorelease, but was not handling options.  This patch fixes that for packages that may be using %autorelease with options.