### PR TITLE
[ci] Use actions/checkout@v4 in amazonlinux.yml and centos8.yml

### DIFF
--- a/.github/workflows/amazonlinux.yml
+++ b/.github/workflows/amazonlinux.yml
@@ -47,7 +47,7 @@ jobs:
                   yum install -y git
 
             # This means clone the git repo
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             # Within the container, install the dependencies, build,
             # and run the test suite

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -91,7 +91,7 @@ jobs:
                   yum install -y epel-release git
 
             # This means clone the git repo
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             # Within the container, install the dependencies, build,
             # and run the test suite


### PR DESCRIPTION
The previous actions/checkout@v2 fails to run now.  Complains of glibc symbol mismatches.