### PR TITLE
[ci] Try forcing use of node16 on Amazon Linux job

### DIFF
--- a/.github/workflows/amazonlinux.yml
+++ b/.github/workflows/amazonlinux.yml
@@ -29,6 +29,11 @@ jobs:
         # Use containers on their ubuntu latest image
         runs-on: ubuntu-latest
 
+        # Necessary to run against older libraries
+        env:
+            ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+            ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
         # Set up the matrix of distributions to test
         strategy:
             matrix:


### PR DESCRIPTION
The problem with the git clone action is that is uses node and node20 wants a glibc newer than what the environment offers.  Trying this trick I found online to see if it will work with an older release.