### PR TITLE
[ci] On Fedora rawhide, remove duplicate __debug_package in macros

### DIFF
--- a/osdeps/fedora-rawhide.i686/post.sh
+++ b/osdeps/fedora-rawhide.i686/post.sh
@@ -20,5 +20,10 @@ if [ -d /usr/lib/udev/rules.d ]; then
     done
 fi
 
+# This change to /usr/lib/rpm/macros was introduced on 24-Aug-2024 in
+# commit 1a9803d0f8daf15bb706dc17783ab19589906487 to rpm, but it
+# causes problems for the rpminspect test suite.  Undo the change.
+sed -i -e '/^%%global\ __debug_package\ 1\\/d' /usr/lib/rpm/macros
+
 # Update the clamav database
 freshclam

--- a/osdeps/fedora-rawhide/post.sh
+++ b/osdeps/fedora-rawhide/post.sh
@@ -20,5 +20,10 @@ if [ -d /usr/lib/udev/rules.d ]; then
     done
 fi
 
+# This change to /usr/lib/rpm/macros was introduced on 24-Aug-2024 in
+# commit 1a9803d0f8daf15bb706dc17783ab19589906487 to rpm, but it
+# causes problems for the rpminspect test suite.  Undo the change.
+sed -i -e '/^%%global\ __debug_package\ 1\\/d' /usr/lib/rpm/macros
+
 # Update the clamav database
 freshclam


### PR DESCRIPTION
The '%%global __debug_package 1\' causes the debuginfo test suite to fail, so if it's present we want to remove the line.