### PR TITLE
[lib] Disable file and scan size limits in clamav

### DIFF
--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -175,6 +175,19 @@ bool inspect_virus(struct rpminspect *ri)
         errx(RI_PROGRAM_ERROR, _("*** cl_engine_new returned NULL, check clamav library"));
     }
 
+    /* scan large files, but dump error as warning if this doesn't work */
+    r = cl_engine_set_num(engine, CL_ENGINE_MAX_FILESIZE, 0);
+
+    if (r != CL_SUCCESS) {
+        warnx("*** cl_engine_set_num: %s", cl_strerror(r));
+    }
+
+    r = cl_engine_set_num(engine, CL_ENGINE_MAX_SCANSIZE, 0);
+
+    if (r != CL_SUCCESS) {
+        warnx("*** cl_engine_set_num: %s", cl_strerror(r));
+    }
+
     /* load clamav databases */
     r = cl_load(dbpath, engine, &loaded_signatures, CL_DB_STDOPT);
 


### PR DESCRIPTION
By default libclamav enforces file size and scan size limits.  I assume this is to cover most file types by default and not appear to hang or stall.  We want to scan all files and some files that appear in RPMs may be beyond that limit.  So disable those limits when we run the virus inspection.