### PR TITLE
[lib] Honor locally defined ignore list for the 'unicode' inspection

### DIFF
--- a/data/generic.yaml
+++ b/data/generic.yaml
@@ -1001,6 +1001,15 @@ unicode:
         - '0x2068'
         - '0x2069'
 
+    # Optional list of glob(7) specifications or path prefixes to
+    # match files to ignore for this inspection.  The format of this
+    # list is the same as the global 'ignore' list.  The difference is
+    # the items specified here will only be used during this
+    # inspection.  If globbing characters are used, be sure to wrap
+    # the string in single quotes.
+    #ignore:
+    #    - '/usr/lib*/libexample.so*'
+
 rpmdeps:
     # Optional list of regular expressions to match against
     # requirement names to ignore.  For example, a dependency of the

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -79,7 +79,7 @@ struct inspect inspections[] = {
     { INSPECT_SYMLINKS,      "symlinks",      false, true,  &inspect_symlinks },
     { INSPECT_TYPES,         "types",         false, false, &inspect_types },
     { INSPECT_UDEVRULES,     "udevrules",     false, true,  &inspect_udevrules },
-    { INSPECT_UNICODE,       "unicode",       true,  true,  &inspect_unicode },
+    { INSPECT_UNICODE,       "unicode",       false, true,  &inspect_unicode },
     { INSPECT_UPSTREAM,      "upstream",      false, false, &inspect_upstream },
     { INSPECT_VIRUS,         "virus",         true,  true,  &inspect_virus },
     { INSPECT_XML,           "xml",           false, true,  &inspect_xml },


### PR DESCRIPTION
This functionality has been requested numerous times.  Developers need the ability to ignore files known to fail this inspection.  Sometimes they appear in test suites, or known broken test cases, or documentation, and so on.

This patch honors an ignore list under the unicode inspection in a local rpminspect.yaml file, such as:

    ---
    unicode:
        ignore:
            - 'sourcecode-*/test/cases/some/file/with/codepoints.txt'

It is recommended that you document your local rpminspect.yaml file to explain why you are adjusting how an inspection runs so that other people and your future self know why the change had to be made.

Fixes: #1434