### PR TITLE
[fix] Strip UNPACK_BASE directory in unicode inspection

### DIFF
--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -467,13 +467,15 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
         while (*localpath == '/' && *localpath != '\0') {
             localpath++;
         }
-    } else if (uses_unpack_base && strprefix(localpath, UNPACK_BASE)) {
-        /*
-         * for manual_prep_source() runs, also account for a potential
-         * unpack-XXXXXX/ leading directory and trim that too
-         */
 
-        localpath += strlen(UNPACK_TEMPLATE);
+        if (uses_unpack_base && strprefix(localpath, UNPACK_BASE)) {
+            /*
+            * for manual_prep_source() runs, also account for a potential
+            * unpack-XXXXXX/ leading directory and trim that too
+            */
+
+            localpath += strlen(UNPACK_TEMPLATE);
+        }
     } else if (root && strprefix(localpath, root)) {
         /* this is a source file directly in the SRPM */
         localpath += strlen(root);


### PR DESCRIPTION
This patch fixes a problem where the directory where sources are unpacked were not stripped properly causing ignore rules to not match, because the branch where this adjustment was done was never reached.

Fixes: #1440