### PR TITLE
[ci] Fix broken Debian Testing and Alpine Linux CI jobs

### DIFF
--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -96,5 +96,10 @@ echo '%dist .ri47' >> "${HOME}"/.rpmmacros
 # Alpine Linux gets find-debuginfo via this script
 echo '%__find_debuginfo /usr/bin/find-debuginfo' >> "${HOME}"/.rpmmacros
 
+# This change to /usr/lib/rpm/macros was introduced on 24-Aug-2024 in
+# commit 1a9803d0f8daf15bb706dc17783ab19589906487 to rpm, but it
+# causes problems for the rpminspect test suite.  Undo the change.
+sed -i -e '/^%%global\ __debug_package\ 1\\/d' /usr/lib/rpm/macros
+
 # Update the clamav database
 freshclam

--- a/osdeps/alpine/reqs.txt
+++ b/osdeps/alpine/reqs.txt
@@ -47,5 +47,7 @@ sed
 tar
 tcsh
 xmlrpc-c-dev
+xxhash
+xxhash-dev
 yaml-dev
 zsh

--- a/osdeps/debian-testing/post.sh
+++ b/osdeps/debian-testing/post.sh
@@ -63,6 +63,11 @@ ninja -C build install
 cd "${CWD}" || exit 1
 rm -rf cdson
 
+# This change to /usr/lib/rpm/macros was introduced on 24-Aug-2024 in
+# commit 1a9803d0f8daf15bb706dc17783ab19589906487 to rpm, but it
+# causes problems for the rpminspect test suite.  Undo the change.
+sed -i -e '/^%%global\ __debug_package\ 1\\/d' /usr/lib/rpm/macros
+
 # Update clamav database
 service clamav-freshclam stop
 freshclam


### PR DESCRIPTION
These had some build failures and missing dependencies so the test suite passes again on these platform.