### PR TITLE
Two fixes for librpminspect

### DIFF
--- a/include/remedy.h
+++ b/include/remedy.h
@@ -8,6 +8,7 @@ extern "C"
 {
 #endif
 
+#include <stdbool.h>
 #include "i18n.h"
 
 #ifndef _LIBRPMINSPECT_REMEDY_H
@@ -102,14 +103,14 @@ extern "C"
 #define REMEDY_XML                       86
 #define REMEDY_MIXED_LICENSE_TAGS        87
 
-/* Initialize default remedy strings */
-void init_remedy_strings(void);
-
 /* Get the remedy string for the specified remedy ID */
 const char *get_remedy(const unsigned int id);
 
 /* Set remedy override string */
-bool set_remedy(const char *name, const char *remedy);
+bool set_remedy(const char *name, char *remedy);
+
+/* Free remedy strings read in from config files */
+void free_remedy_strings(void);
 
 #endif /* _LIBRPMINSPECT_REMEDY_H */
 

--- a/include/types.h
+++ b/include/types.h
@@ -252,7 +252,7 @@ struct result_params {
     const char *header;
     char *msg;
     char *details;
-    const char *remedy;
+    unsigned int remedy;
     verb_t verb;
     const char *noun;
     const char *arch;
@@ -265,7 +265,7 @@ typedef struct _results_entry_t {
     const char *header;       /* header string for reporting */
     char *msg;                /* the result message */
     char *details;            /* details (optional, can be NULL) */
-    const char *remedy;       /* suggested correction for the result */
+    unsigned int remedy;      /* suggested correction for the result */
     verb_t verb;              /* verb indicating what happened */
     char *noun;               /* noun impacted by 'verb', one line
                                  (e.g., a file path or an RPM dependency
@@ -859,7 +859,7 @@ struct remedy {
     const char *name;
 
     /* the default remedy string */
-    const char *remedy;
+    char *remedy;
 };
 
 /*

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -172,7 +172,7 @@ bool match_fileinfo_owner(struct rpminspect *ri, const rpmfile_entry_t *file, co
 
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
             params.waiverauth = WAIVABLE_BY_SECURITY;
-            params.remedy = get_remedy(REMEDY_FILEINFO_RULE);
+            params.remedy = REMEDY_FILEINFO_RULE;
             xasprintf(&params.msg, _("%s in %s on %s carries insecure mode %04o but has no fileinfo rule for owner specification, Security Team review may be required"), file->localpath, pkg, params.arch, perms);
             add_result(ri, &params);
             free(params.msg);
@@ -258,7 +258,7 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
 
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
             params.waiverauth = WAIVABLE_BY_SECURITY;
-            params.remedy = get_remedy(REMEDY_FILEINFO_RULE);
+            params.remedy = REMEDY_FILEINFO_RULE;
             xasprintf(&params.msg, _("%s in %s on %s carries insecure mode %04o but has no fileinfo rule for owner specification, Security Team review may be required"), file->localpath, pkg, params.arch, perms);
             add_result(ri, &params);
             free(params.msg);

--- a/lib/free.c
+++ b/lib/free.c
@@ -5,6 +5,7 @@
 
 #include <regex.h>
 #include <stdlib.h>
+#include "remedy.h"
 #include "queue.h"
 #include "rpminspect.h"
 
@@ -327,6 +328,8 @@ void free_rpminspect(struct rpminspect *ri)
     free_string_hash(ri->magic_types);
     list_free(ri->remedy_overrides, free);
     free_results(ri->results);
+
+    free_remedy_strings();
 
     return;
 }

--- a/lib/init.c
+++ b/lib/init.c
@@ -17,7 +17,6 @@
 #include "parser.h"
 #include "rpminspect.h"
 #include "init.h"
-#include "remedy.h"
 #include "queue.h"
 #include "uthash.h"
 
@@ -58,9 +57,6 @@ static const char *CFG_FILENAME_EXTENSIONS[] = {"yaml", "json", "dson", NULL};
  * may reside.
  */
 static const char *UDEV_RULES_DIRS[] = {"/etc/udev/rules.d/", "/usr/lib/udev/rules.d/", NULL};
-
-/* flag indicating the remedy strings have been initialized */
-static bool remedy_initialized = false;
 
 static int add_regex(const char *pattern, regex_t **regex_out)
 {
@@ -602,8 +598,6 @@ static inline void _remedy_walker(struct toml_node *node, void *data)
                 free(entry);
             }
         }
-
-        free(r);
     }
 
     free(n);
@@ -1700,12 +1694,6 @@ struct rpminspect *init_rpminspect(struct rpminspect *ri, const char *cfgfile, c
     char *bn = NULL;
     char *kernelnames[] = KERNEL_FILENAMES;
     string_entry_t *cfg = NULL;
-
-    /* initialize the default remedy strings */
-    if (!remedy_initialized) {
-        init_remedy_strings();
-        remedy_initialized = true;
-    }
 
     if (ri == NULL) {
         ri = xalloc_rpminspect(ri);

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -254,7 +254,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.header = NAME_ABIDIFF;
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
-    params.remedy = get_remedy(REMEDY_ABIDIFF);
+    params.remedy = REMEDY_ABIDIFF;
     params.arch = arch;
     params.file = file->localpath;
 

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -122,7 +122,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.arch = arch;
     params.file = file->localpath;
     params.verb = VERB_FAILED;
-    params.remedy = get_remedy(REMEDY_ADDEDFILES);
+    params.remedy = REMEDY_ADDEDFILES;
 
     if (!ignore) {
         /* Check for any forbidden path prefixes */

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -349,7 +349,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.header = NAME_ANNOCHECK;
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
-    params.remedy = get_remedy(REMEDY_ANNOCHECK);
+    params.remedy = REMEDY_ANNOCHECK;
     params.verb = VERB_OK;
     params.arch = arch;
     params.file = file->localpath;
@@ -456,7 +456,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             if ((!strcmp(annotests[i].name, "fortify") || !strcmp(annotests[i].name, "optimization")) &&
                 (annotests[i].state == libannocheck_test_state_maybe || annotests[i].state == libannocheck_test_state_failed)) {
                 params.waiverauth = WAIVABLE_BY_SECURITY;
-                params.remedy = get_remedy(REMEDY_ANNOCHECK_FORTIFY_SOURCE);
+                params.remedy = REMEDY_ANNOCHECK_FORTIFY_SOURCE;
                 params.verb = VERB_REMOVED;
                 params.noun = _("lost -D_FORTIFY_SOURCE in ${FILE} on ${ARCH}");
                 params.severity = get_secrule_result_severity(ri, file, SECRULE_FORTIFYSOURCE);
@@ -606,7 +606,7 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                     init_result_params(&params);
                     params.header = NAME_ANNOCHECK;
                     params.waiverauth = WAIVABLE_BY_SECURITY;
-                    params.remedy = get_remedy(REMEDY_ANNOCHECK_FORTIFY_SOURCE);
+                    params.remedy = REMEDY_ANNOCHECK_FORTIFY_SOURCE;
                     params.arch = arch;
                     params.file = file->localpath;
                     params.verb = VERB_REMOVED;

--- a/lib/inspect_arch.c
+++ b/lib/inspect_arch.c
@@ -70,7 +70,7 @@ bool inspect_arch(struct rpminspect *ri)
         TAILQ_FOREACH(entry, lost, items) {
             if (allowed_arch(ri, entry->data)) {
                 params.severity = RESULT_VERIFY;
-                params.remedy = get_remedy(REMEDY_ARCH_LOST);
+                params.remedy = REMEDY_ARCH_LOST;
                 params.verb = VERB_REMOVED;
                 params.noun = _("lost ${ARCH}");
                 params.arch = entry->data;
@@ -87,7 +87,7 @@ bool inspect_arch(struct rpminspect *ri)
         TAILQ_FOREACH(entry, gain, items) {
             if (allowed_arch(ri, entry->data)) {
                 params.severity = RESULT_INFO;
-                params.remedy = get_remedy(REMEDY_ARCH_GAIN);
+                params.remedy = REMEDY_ARCH_GAIN;
                 params.verb = VERB_ADDED;
                 params.noun = _("gained ${ARCH}");
                 params.arch = entry->data;

--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -169,7 +169,7 @@ static bool badfuncs_driver(struct rpminspect *ri, rpmfile_entry_t *after)
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_BADFUNCS;
-    params.remedy = get_remedy(REMEDY_BADFUNCS);
+    params.remedy = REMEDY_BADFUNCS;
     params.details = output_buffer;
     params.verb = VERB_FAILED;
     params.noun = _("forbidden functions in ${FILE} on ${ARCH}");

--- a/lib/inspect_capabilities.c
+++ b/lib/inspect_capabilities.c
@@ -84,7 +84,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
                 xasprintf(&params.msg, _("File capabilities for %s changed from '%s' to '%s' in %s on %s\n"), file->localpath, before, after, name, arch);
-                params.remedy = get_remedy(REMEDY_CAPABILITIES);
+                params.remedy = REMEDY_CAPABILITIES;
                 params.waiverauth = WAIVABLE_BY_SECURITY;
                 params.verb = VERB_CHANGED;
                 params.noun = _("${FILE} capabilities on ${ARCH}");
@@ -146,7 +146,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
                 if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
                     xasprintf(&params.msg, _("File capabilities list mismatch for %s: expected '%s', got '%s' in %s on %s\n"), file->localpath, flcaps->caps, after, name, arch);
-                    params.remedy = get_remedy(REMEDY_CAPABILITIES);
+                    params.remedy = REMEDY_CAPABILITIES;
                     params.waiverauth = WAIVABLE_BY_SECURITY;
                     params.verb = VERB_FAILED;
                     params.noun = _("${FILE} capabilities list on ${ARCH}");
@@ -165,7 +165,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
                 xasprintf(&params.msg, _("File capabilities for %s (%s) not found on the capabilities list in %s on %s\n"), file->localpath, after, name, arch);
-                params.remedy = get_remedy(REMEDY_CAPABILITIES);
+                params.remedy = REMEDY_CAPABILITIES;
                 params.waiverauth = WAIVABLE_BY_SECURITY;
                 params.verb = VERB_REMOVED;
                 params.noun = _("${FILE} capabilities list on ${ARCH}");
@@ -183,7 +183,7 @@ static bool capabilities_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
             if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
                 xasprintf(&params.msg, _("File capabilities expected for %s in %s but not found on %s: expected '%s'\n"), file->localpath, name, arch, flcaps->caps);
-                params.remedy = get_remedy(REMEDY_CAPABILITIES);
+                params.remedy = REMEDY_CAPABILITIES;
                 params.waiverauth = WAIVABLE_BY_SECURITY;
                 params.verb = VERB_FAILED;
                 params.noun = _("${FILE} capabilities list on ${ARCH}");

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -331,7 +331,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             nvr = get_nevr(file->rpm_header);
             xasprintf(&params.msg, _("Error running msgunfmt on %s in %s on %s; malformed mo file?"), file->localpath, nvr, arch);
             params.severity = RESULT_BAD;
-            params.remedy = get_remedy(REMEDY_CHANGEDFILES);
+            params.remedy = REMEDY_CHANGEDFILES;
             params.verb = VERB_FAILED;
             params.noun = _("msgunfmt on ${FILE}");
             add_result(ri, &params);
@@ -345,7 +345,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             nvr = get_nevr(file->peer_file->rpm_header);
             xasprintf(&params.msg, _("Error running msgunfmt on %s in %s on %s; malformed mo file?"), file->peer_file->localpath, nvr, arch);
             params.severity = RESULT_BAD;
-            params.remedy = get_remedy(REMEDY_CHANGEDFILES);
+            params.remedy = REMEDY_CHANGEDFILES;
             params.verb = VERB_FAILED;
             params.noun = _("msgunfmt on ${FILE}");
             add_result(ri, &params);
@@ -360,7 +360,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             nvr = get_nevr(file->rpm_header);
             xasprintf(&params.msg, _("Message catalog %s changed content in %s on %s"), file->localpath, nvr, arch);
             params.severity = RESULT_INFO;
-            params.remedy = get_remedy(REMEDY_CHANGEDFILES);
+            params.remedy = REMEDY_CHANGEDFILES;
             params.verb = VERB_CHANGED;
             params.noun = _("${FILE}");
             add_result(ri, &params);

--- a/lib/inspect_changelog.c
+++ b/lib/inspect_changelog.c
@@ -375,7 +375,7 @@ static bool check_bin_rpm_changelog(struct rpminspect *ri, const rpmpeer_entry_t
             xasprintf(&params.msg, "%%changelog entry has unprofessional language in the %s build", after_nevr);
             params.severity = RESULT_BAD;
             params.waiverauth = NOT_WAIVABLE;
-            params.remedy = get_remedy(REMEDY_CHANGELOG);
+            params.remedy = REMEDY_CHANGELOG;
             params.details = entry->data;
             params.verb = VERB_FAILED;
             params.noun = entry->data;

--- a/lib/inspect_config.c
+++ b/lib/inspect_config.c
@@ -60,7 +60,7 @@ static bool config_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.header = NAME_CONFIG;
     params.arch = arch;
     params.file = file->localpath;
-    params.remedy = get_remedy(REMEDY_CONFIG);
+    params.remedy = REMEDY_CONFIG;
     params.verb = VERB_CHANGED;
     params.noun = _("%config ${FILE}");
 

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -212,7 +212,7 @@ static bool validate_desktop_contents(struct rpminspect *ri, const rpmfile_entry
     /* Set up result parameters */
     init_result_params(&params);
     params.header = NAME_DESKTOP;
-    params.remedy = get_remedy(REMEDY_DESKTOP);
+    params.remedy = REMEDY_DESKTOP;
     params.arch = arch;
     params.file = file->localpath;
 
@@ -454,7 +454,7 @@ static bool desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     params.header = NAME_DESKTOP;
-    params.remedy = get_remedy(REMEDY_DESKTOP);
+    params.remedy = REMEDY_DESKTOP;
     params.arch = arch;
     params.file = file->localpath;
     params.verb = VERB_CHANGED;

--- a/lib/inspect_disttag.c
+++ b/lib/inspect_disttag.c
@@ -188,7 +188,7 @@ static bool disttag_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.severity = RESULT_BAD;
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_DISTTAG;
-    params.remedy = get_remedy(REMEDY_DISTTAG);
+    params.remedy = REMEDY_DISTTAG;
     params.details = release;
     params.arch = get_rpm_header_arch(file->rpm_header);
     params.file = file->localpath;

--- a/lib/inspect_doc.c
+++ b/lib/inspect_doc.c
@@ -66,7 +66,7 @@ static bool doc_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.header = NAME_DOC;
     params.arch = arch;
     params.file = file->localpath;
-    params.remedy = get_remedy(REMEDY_DOC);
+    params.remedy = REMEDY_DOC;
     params.verb = VERB_CHANGED;
     params.noun = _("%doc ${FILE}");
 

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -86,7 +86,7 @@ static bool dsodeps_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_DSODEPS;
-    params.remedy = get_remedy(REMEDY_DSODEPS);
+    params.remedy = REMEDY_DSODEPS;
     params.arch = arch;
     params.file = file->localpath;
 

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -439,7 +439,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
         }
 
         if (params.msg != NULL && params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
-            params.remedy = get_remedy(REMEDY_ELF_EXECSTACK_MISSING);
+            params.remedy = REMEDY_ELF_EXECSTACK_MISSING;
             params.verb = VERB_CHANGED;
             params.noun = _("GNU_STACK in ${FILE} on ${ARCH}");
             add_result(ri, &params);
@@ -505,7 +505,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
             params.severity = get_secrule_result_severity(ri, file, SECRULE_EXECSTACK);
 
             if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
-                params.remedy = get_remedy(REMEDY_ELF_EXECSTACK_INVALID);
+                params.remedy = REMEDY_ELF_EXECSTACK_INVALID;
                 params.verb = VERB_FAILED;
                 params.noun = _("execstack in ${FILE} on ${ARCH}");
                 add_result(ri, &params);
@@ -535,7 +535,7 @@ static bool inspect_elf_execstack(struct rpminspect *ri, Elf *after_elf, Elf *be
         }
 
         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
-            params.remedy = get_remedy(REMEDY_ELF_EXECSTACK_EXECUTABLE);
+            params.remedy = REMEDY_ELF_EXECSTACK_EXECUTABLE;
             params.verb = VERB_FAILED;
             params.noun = _("execstack in ${FILE} on ${ARCH}");
             add_result(ri, &params);
@@ -571,7 +571,7 @@ static bool check_relro(struct rpminspect *ri, Elf *before_elf, Elf *after_elf, 
         params.severity = get_secrule_result_severity(ri, file, SECRULE_RELRO);
         params.waiverauth = WAIVABLE_BY_SECURITY;
         params.header = NAME_ELF;
-        params.remedy = get_remedy(REMEDY_ELF_GNU_RELRO);
+        params.remedy = REMEDY_ELF_GNU_RELRO;
         params.arch = arch;
         params.file = file->localpath;
         params.verb = VERB_REMOVED;
@@ -755,7 +755,7 @@ static bool elf_archive_tests(struct rpminspect *ri, Elf *after_elf, int after_e
     xasprintf(&params.msg, _("%s in %s has objects built without -fPIC on %s"), file->localpath, name, arch);
     params.waiverauth = WAIVABLE_BY_SECURITY;
     params.header = NAME_ELF;
-    params.remedy = get_remedy(REMEDY_ELF_FPIC);
+    params.remedy = REMEDY_ELF_FPIC;
     params.details = screendump;
     params.arch = arch;
     params.file = file->localpath;
@@ -793,7 +793,7 @@ static bool elf_regular_tests(struct rpminspect *ri, Elf *after_elf, Elf *before
     params.severity = get_secrule_result_severity(ri, file, SECRULE_TEXTREL);
     params.header = NAME_ELF;
     params.waiverauth = WAIVABLE_BY_SECURITY;
-    params.remedy = get_remedy(REMEDY_ELF_TEXTREL);
+    params.remedy = REMEDY_ELF_TEXTREL;
     params.arch = arch;
     params.file = file->localpath;
     params.noun = _("TEXTREL relocations in ${FILE} on ${ARCH}");

--- a/lib/inspect_emptyrpm.c
+++ b/lib/inspect_emptyrpm.c
@@ -99,7 +99,7 @@ bool inspect_emptyrpm(struct rpminspect *ri)
                 params.noun = NULL;
                 params.file = NULL;
                 params.arch = NULL;
-                params.remedy = NULL;
+                params.remedy = 0;
                 reported = true;
             } else if (payload_only_ghosts(peer->after_hdr)) {
                 xasprintf(&params.msg, _("New package %s is empty (no payloads); this is expected because the package only contains %%ghost entries"), bn);
@@ -109,7 +109,7 @@ bool inspect_emptyrpm(struct rpminspect *ri)
                 params.noun = NULL;
                 params.file = NULL;
                 params.arch = NULL;
-                params.remedy = NULL;
+                params.remedy = 0;
                 reported = true;
             } else {
                 an = basename(peer->after_rpm);
@@ -120,7 +120,7 @@ bool inspect_emptyrpm(struct rpminspect *ri)
                 params.noun = _("${FILE} has empty payload");
                 params.file = an;
                 params.arch = get_rpm_header_arch(peer->after_hdr);
-                params.remedy = get_remedy(REMEDY_EMPTYRPM);
+                params.remedy = REMEDY_EMPTYRPM;
                 good = false;
                 reported = true;
             }

--- a/lib/inspect_files.c
+++ b/lib/inspect_files.c
@@ -59,7 +59,7 @@ static bool files_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_FILES;
-    params.remedy = get_remedy(REMEDY_FILE_PATHS);
+    params.remedy = REMEDY_FILE_PATHS;
     params.file = file->localpath;
     params.arch = get_rpm_header_arch(file->rpm_header);
     params.verb = VERB_FAILED;

--- a/lib/inspect_filesize.c
+++ b/lib/inspect_filesize.c
@@ -103,7 +103,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
         params.noun = _("non-empty ${FILE} on ${ARCH}");
-        params.remedy = get_remedy(REMEDY_FILESIZE_BECAME_NOT_EMPTY);
+        params.remedy = REMEDY_FILESIZE_BECAME_NOT_EMPTY;
         result = false;
     } else if (file->st_size == 0 && file->peer_file->st_size > 0) {
         /* became empty */
@@ -112,7 +112,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
         params.noun = _("empty ${FILE} on ${ARCH}");
-        params.remedy = get_remedy(REMEDY_FILESIZE_BECAME_EMPTY);
+        params.remedy = REMEDY_FILESIZE_BECAME_EMPTY;
         result = false;
     } else {
         change = ((file->st_size - file->peer_file->st_size) * 100 / file->peer_file->st_size);
@@ -131,12 +131,12 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             /* file grew */
             xasprintf(&params.msg, _("%s grew by %lld%% on %s"), file->localpath, llabs(change), arch);
             params.noun = _("${FILE} size grew on ${ARCH}");
-            params.remedy = get_remedy(REMEDY_FILESIZE_GREW);
+            params.remedy = REMEDY_FILESIZE_GREW;
         } else if (change < 0) {
             /* file shrank */
             xasprintf(&params.msg, _("%s shrank by %lld%% on %s"), file->localpath, llabs(change), arch);
             params.noun = _("${FILE} size shrank on ${ARCH}");
-            params.remedy = get_remedy(REMEDY_FILESIZE_SHRANK);
+            params.remedy = REMEDY_FILESIZE_SHRANK;
         }
     }
 
@@ -144,7 +144,7 @@ static bool filesize_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (ri->size_threshold == -1) {
         params.severity = RESULT_INFO;
         params.verb = VERB_OK;
-        params.remedy = NULL;
+        params.remedy = 0;
         result = true;
     }
 

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -118,7 +118,7 @@ static bool check_class_file(struct rpminspect *ri, const char *fullpath, const 
     params.header = NAME_JAVABYTECODE;
     params.verb = VERB_FAILED;
     params.file = localpath;
-    params.remedy = get_remedy(REMEDY_JAVABYTECODE);
+    params.remedy = REMEDY_JAVABYTECODE;
 
     /* try to see if this is just a .class file */
     major = get_jvm_major(fullpath, localpath, container);

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -234,7 +234,7 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     init_result_params(&params);
     params.header = NAME_KMIDIFF;
     params.waiverauth = WAIVABLE_BY_ANYONE;
-    params.remedy = get_remedy(REMEDY_KMIDIFF);
+    params.remedy = REMEDY_KMIDIFF;
     params.arch = arch;
     params.file = file->localpath;
 

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -24,7 +24,7 @@ static void lost_alias(const char *alias, const string_list_t *before_modules, c
     assert(before_modules != NULL);
     assert(ri != NULL);
 
-    params.remedy = get_remedy(REMEDY_KMOD_ALIAS);
+    params.remedy = REMEDY_KMOD_ALIAS;
     params.noun = _("${FILE} kernel module alias on ${ARCH}");
 
     TAILQ_FOREACH(entry, before_modules, items) {
@@ -186,7 +186,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (!result_parm && lost != NULL && !TAILQ_EMPTY(lost)) {
         TAILQ_FOREACH(entry, lost, items) {
             xasprintf(&params.msg, _("Kernel module %s removes parameter '%s' (was present in %s)."), file->localpath, entry->data, file->peer_file->localpath);
-            params.remedy = get_remedy(REMEDY_KMOD_PARM);
+            params.remedy = REMEDY_KMOD_PARM;
             params.verb = VERB_REMOVED;
             params.noun = _("${FILE} kernel module parameter on ${ARCH}");
             params.file = file->localpath;
@@ -203,7 +203,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (gain != NULL && !TAILQ_EMPTY(gain)) {
         TAILQ_FOREACH(entry, gain, items) {
             xasprintf(&params.msg, _("Kernel module %s adds parameter '%s' (was not present in %s)."), file->localpath, entry->data, file->peer_file->localpath);
-            params.remedy = NULL;
+            params.remedy = 0;
             params.verb = VERB_ADDED;
             params.noun = _("${FILE} kernel module parameter on ${ARCH}");
             params.file = file->localpath;
@@ -224,7 +224,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (!result_deps && lost != NULL && !TAILQ_EMPTY(lost)) {
         TAILQ_FOREACH(entry, lost, items) {
             xasprintf(&params.msg, _("Kernel module %s removes dependency '%s' (was present in %s)."), file->localpath, entry->data, file->peer_file->localpath);
-            params.remedy = get_remedy(REMEDY_KMOD_DEPS);
+            params.remedy = REMEDY_KMOD_DEPS;
             params.verb = VERB_REMOVED;
             params.noun = _("${FILE} kernel module dependency on ${ARCH}");
             params.file = file->localpath;
@@ -241,7 +241,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (gain != NULL && !TAILQ_EMPTY(gain)) {
         TAILQ_FOREACH(entry, gain, items) {
             xasprintf(&params.msg, _("Kernel module %s adds dependency '%s' (was not present in %s)."), file->localpath, entry->data, file->peer_file->localpath);
-            params.remedy = get_remedy(REMEDY_KMOD_DEPS);
+            params.remedy = REMEDY_KMOD_DEPS;
             params.verb = VERB_ADDED;
             params.noun = _("${FILE} kernel module parameter");
             params.file = file->localpath;

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -472,7 +472,7 @@ static bool is_valid_license(struct rpminspect *ri, struct result_params *params
 
     /* Set up the result parameters */
     params->severity = RESULT_BAD;
-    params->remedy = get_remedy(REMEDY_UNAPPROVED_LICENSE);
+    params->remedy = REMEDY_UNAPPROVED_LICENSE;
 
     /* check for matching parens */
     for (i = 0; i < strlen(license); i++) {
@@ -606,7 +606,7 @@ static bool is_valid_license(struct rpminspect *ri, struct result_params *params
                 }
 
                 params->severity = RESULT_BAD;
-                params->remedy = get_remedy(REMEDY_UNAPPROVED_LICENSE);
+                params->remedy = REMEDY_UNAPPROVED_LICENSE;
                 xasprintf(&params->msg, _("Unapproved license in %s: %s"), nevra, tagtoken->key);
                 add_result(ri, params);
                 result = get_result(result, params->severity);
@@ -634,7 +634,7 @@ static bool is_valid_license(struct rpminspect *ri, struct result_params *params
                 r = false;
 
                 params->severity = RESULT_BAD;
-                params->remedy = get_remedy(REMEDY_INVALID_BOOLEAN);
+                params->remedy = REMEDY_INVALID_BOOLEAN;
                 xasprintf(&params->msg, _("SPDX license expressions in use in %s, but an invalid boolean was found: %s; when using SPDX expression the booleans must be in all caps."), nevra, entry->data);
                 xasprintf(&params->details, _("License: %s"), license);
                 add_result(ri, params);
@@ -649,7 +649,7 @@ static bool is_valid_license(struct rpminspect *ri, struct result_params *params
     /* mixed SPDX and legacy tags are forbidden */
     if (nlegacy > 0 && nspdx > 0 && ndual == 0) {
         params->severity = RESULT_BAD;
-        params->remedy = get_remedy(REMEDY_MIXED_LICENSE_TAGS);
+        params->remedy = REMEDY_MIXED_LICENSE_TAGS;
         xasprintf(&params->msg, _("Mixed SPDX and legacy license identifiers found in %s."), nevra);
         xasprintf(&params->details, _("License: %s"), license);
         add_result(ri, params);
@@ -684,7 +684,7 @@ static int check_peer_license(struct rpminspect *ri, struct result_params *param
     if (license == NULL) {
         xasprintf(&params->msg, _("Empty License Tag in %s"), nevra);
         params->severity = RESULT_BAD;
-        params->remedy = get_remedy(REMEDY_LICENSE);
+        params->remedy = REMEDY_LICENSE;
         params->verb = VERB_FAILED;
         params->noun = _("missing License tag in ${FILE}");
         add_result(ri, params);
@@ -698,7 +698,7 @@ static int check_peer_license(struct rpminspect *ri, struct result_params *param
         if (valid) {
             xasprintf(&params->msg, _("Valid License Tag in %s: %s"), nevra, license);
             params->severity = RESULT_INFO;
-            params->remedy = NULL;
+            params->remedy = 0;
             params->verb = VERB_OK;
             params->noun = NULL;
             params->file = NULL;
@@ -713,7 +713,7 @@ static int check_peer_license(struct rpminspect *ri, struct result_params *param
         if (has_bad_word(license, ri->badwords)) {
             xasprintf(&params->msg, _("License Tag contains unprofessional language in %s: %s"), nevra, license);
             params->severity = RESULT_BAD;
-            params->remedy = get_remedy(REMEDY_LICENSE);
+            params->remedy = REMEDY_LICENSE;
             params->verb = VERB_FAILED;
             params->noun = _("unprofessional language in License tag in ${FILE}");
             add_result(ri, params);
@@ -765,7 +765,7 @@ bool inspect_license(struct rpminspect *ri)
     if (ri->licensedb == NULL || TAILQ_EMPTY(ri->licensedb)) {
         xasprintf(&params.msg, _("Missing license database(s)."));
         params.severity = RESULT_BAD;
-        params.remedy = get_remedy(REMEDY_LICENSEDB);
+        params.remedy = REMEDY_LICENSEDB;
         params.verb = VERB_FAILED;
         params.noun = _("missing license database");
         params.file = NULL;

--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -66,7 +66,7 @@ bool inspect_lostpayload(struct rpminspect *ri)
             params.noun = _("missing subpackage ${FILE} on ${ARCH}");
             params.file = bn;
             params.arch = ba;
-            params.remedy = get_remedy(REMEDY_LOSTPAYLOAD);
+            params.remedy = REMEDY_LOSTPAYLOAD;
             add_result(ri, &params);
             free(params.msg);
             good = false;
@@ -86,7 +86,7 @@ bool inspect_lostpayload(struct rpminspect *ri)
                 params.noun = _("existing empty subpackage ${FILE} on ${ARCH}");
                 params.file = an;
                 params.arch = aa;
-                params.remedy = NULL;
+                params.remedy = 0;
                 add_result(ri, &params);
                 free(params.msg);
             } else {
@@ -97,7 +97,7 @@ bool inspect_lostpayload(struct rpminspect *ri)
                 params.noun = _("subpackage ${FILE} on ${ARCH} now has empty payload");
                 params.file = an;
                 params.arch = aa;
-                params.remedy = get_remedy(REMEDY_LOSTPAYLOAD);
+                params.remedy = REMEDY_LOSTPAYLOAD;
                 add_result(ri, &params);
                 free(params.msg);
                 good = false;

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -137,7 +137,7 @@ static bool lto_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.severity = RESULT_BAD;
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_LTO;
-    params.remedy = get_remedy(REMEDY_LTO);
+    params.remedy = REMEDY_LTO;
     params.verb = VERB_FAILED;
     params.arch = arch;
     params.file = file->localpath;

--- a/lib/inspect_manpage.c
+++ b/lib/inspect_manpage.c
@@ -297,7 +297,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (r == 0 && sb.st_size == 0) {
             xasprintf(&params.msg, _("Man page %s is possibly empty on %s in %s"), file->localpath, params.arch, pkg);
-            params.remedy = get_remedy(REMEDY_MAN_ERRORS);
+            params.remedy = REMEDY_MAN_ERRORS;
             params.details = NULL;
             params.noun = _("empty man page ${FILE} on ${ARCH}");
             add_result(ri, &params);
@@ -313,7 +313,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* check man page validity */
     if ((manpage_errors = inspect_manpage_validity(file->fullpath, file->localpath)) != NULL) {
         xasprintf(&params.msg, _("Man page checker reported problems with %s on %s in %s"), file->localpath, params.arch, pkg);
-        params.remedy = get_remedy(REMEDY_MAN_ERRORS);
+        params.remedy = REMEDY_MAN_ERRORS;
         params.details = manpage_errors;
         params.noun = _("man page ${FILE} on ${ARCH} has errors");
         add_result(ri, &params);
@@ -325,7 +325,7 @@ static bool manpage_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* check man page location on the filesystem */
     if (!inspect_manpage_path(file->fullpath)) {
         xasprintf(&params.msg, _("Man page %s has incorrect path on %s in %s"), file->localpath, params.arch, pkg);
-        params.remedy = get_remedy(REMEDY_MAN_PATH);
+        params.remedy = REMEDY_MAN_PATH;
         params.details = NULL;
         params.noun = _("man page ${FILE} on ${ARCH} has incorrect path");
         add_result(ri, &params);

--- a/lib/inspect_metadata.c
+++ b/lib/inspect_metadata.c
@@ -44,7 +44,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         params.noun = NULL;
         params.file = NULL;
         params.arch = NULL;
-        params.remedy = get_remedy(REMEDY_VENDOR);
+        params.remedy = REMEDY_VENDOR;
         add_result(ri, &params);
         free(params.msg);
     } else if (after_vendor && strcmp(after_vendor, ri->vendor)) {
@@ -55,7 +55,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         params.noun = _("invalid vendor ${FILE} on ${ARCH}");
         params.file = after_vendor;
         params.arch = get_rpm_header_arch(after_hdr);
-        params.remedy = get_remedy(REMEDY_VENDOR);
+        params.remedy = REMEDY_VENDOR;
         add_result(ri, &params);
         free(params.msg);
         ret = false;
@@ -80,7 +80,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
             params.noun = _("invalid build host ${FILE} on ${ARCH}");
             params.file = after_buildhost;
             params.arch = get_rpm_header_arch(after_hdr);
-            params.remedy = get_remedy(REMEDY_BUILDHOST);
+            params.remedy = REMEDY_BUILDHOST;
             add_result(ri, &params);
             free(params.msg);
             ret = false;
@@ -97,7 +97,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         params.noun = _("Summary contains unprofessional words on ${ARCH}");
         params.file = NULL;
         params.arch = get_rpm_header_arch(after_hdr);
-        params.remedy = get_remedy(REMEDY_BADWORDS);
+        params.remedy = REMEDY_BADWORDS;
         add_result(ri, &params);
         free(params.msg);
         free(params.details);
@@ -114,7 +114,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
         params.noun = _("Description contains unprofessional words on ${ARCH}");
         params.file = NULL;
         params.arch = get_rpm_header_arch(after_hdr);
-        params.remedy = get_remedy(REMEDY_BADWORDS);
+        params.remedy = REMEDY_BADWORDS;
         add_result(ri, &params);
         free(params.msg);
         free(params.details);
@@ -147,7 +147,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
             }
 
             params.waiverauth = WAIVABLE_BY_ANYONE;
-            params.remedy = NULL;
+            params.remedy = 0;
             add_result(ri, &params);
             free(params.msg);
         }
@@ -160,7 +160,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
             params.noun = NULL;
             params.file = NULL;
             params.arch = NULL;
-            params.remedy = NULL;
+            params.remedy = 0;
             add_result(ri, &params);
             free(params.msg);
         }
@@ -174,7 +174,7 @@ static bool valid_peers(struct rpminspect *ri, const Header before_hdr, const He
             params.noun = NULL;
             params.file = NULL;
             params.arch = NULL;
-            params.remedy = NULL;
+            params.remedy = 0;
             add_result(ri, &params);
             free(params.msg);
             free(params.details);

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -119,13 +119,13 @@ static bool check_static_context(struct rpminspect *ri)
         xasprintf(&after_compliance, _("The /data/static_context value in %s is %s, but the product release rules forbid the presence of /data/static_context in the module metadata."), ri->after, asc ? "true" : "false");
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.remedy = get_remedy(REMEDY_MODULARITY_STATIC_CONTEXT);
+        params.remedy = REMEDY_MODULARITY_STATIC_CONTEXT;
         r = false;
     } else if (!asc && ri->modularity_static_context == STATIC_CONTEXT_REQUIRED) {
         xasprintf(&after_compliance, _("The /data/static_context value in %s is %s, but the product release rules require the presence of /data/static_context in the module metadata."), ri->after, asc ? "true" : "false");
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.remedy = get_remedy(REMEDY_MODULARITY_STATIC_CONTEXT);
+        params.remedy = REMEDY_MODULARITY_STATIC_CONTEXT;
         r = false;
     } else if (!asc && ri->modularity_static_context == STATIC_CONTEXT_RECOMMEND) {
         xasprintf(&after_compliance, _("The /data/static_context value in %s is %s, but the product release rules recommend the presence of /data/static_context in the module metadata."), ri->after, asc ? "true" : "false");
@@ -176,7 +176,7 @@ static bool check_release(struct rpminspect *ri, regex_t *release_regex, Header 
     params.severity = RESULT_BAD;
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_MODULARITY;
-    params.remedy = get_remedy(REMEDY_MODULARITY_RELEASE);
+    params.remedy = REMEDY_MODULARITY_RELEASE;
 
     /* Get the tag from the header */
     release = headerGetString(h, RPMTAG_RELEASE);
@@ -225,7 +225,7 @@ static bool check_modularitylabel(struct rpminspect *ri, Header h)
     params.severity = RESULT_BAD;
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_MODULARITY;
-    params.remedy = get_remedy(REMEDY_MODULARITY_LABEL);
+    params.remedy = REMEDY_MODULARITY_LABEL;
 
     /* Build the message we'll use for errors */
     xasprintf(&params.msg, _("Package \"%s\" is part of a module but lacks the '%%{modularitylabel}' header tag."), headerGetString(h, RPMTAG_NAME));

--- a/lib/inspect_movedfiles.c
+++ b/lib/inspect_movedfiles.c
@@ -41,12 +41,12 @@ static bool movedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.severity = RESULT_INFO;
         params.waiverauth = NOT_WAIVABLE;
         params.verb = VERB_OK;
-        params.remedy = NULL;
+        params.remedy = 0;
     } else {
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
-        params.remedy = get_remedy(REMEDY_MOVEDFILES);
+        params.remedy = REMEDY_MOVEDFILES;
     }
 
     xasprintf(&noun, _("%s moved to ${FILE} on ${ARCH}"), file->peer_file->localpath);

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -394,11 +394,11 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             /* a defined patch without an apply macro is a problem */
             if (aentry == NULL) {
                 xasprintf(&params.msg, _("Patch number %ld (%s) is missing a corresponding %%patch%ld macro, usually in %%prep."), pentry->num, pentry->patch, pentry->num);
-                params.remedy = get_remedy(REMEDY_PATCHES_MISSING_MACRO);
+                params.remedy = REMEDY_PATCHES_MISSING_MACRO;
                 params.noun = _("missing %%patch macro for ${FILE}");
             } else if (pentry->num != aentry->num) {
                 xasprintf(&params.msg, _("Patch number %ld (%s) is mismatched with %%patch%ld macro."), pentry->num, pentry->patch, pentry->num);
-                params.remedy = get_remedy(REMEDY_PATCHES_MISMATCHED_MACRO);
+                params.remedy = REMEDY_PATCHES_MISMATCHED_MACRO;
                 params.noun = _("mismatched %%patch macro for ${FILE}");
             }
 
@@ -469,7 +469,7 @@ static bool patches_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.details = NULL;
-        params.remedy = get_remedy(REMEDY_PATCHES_CORRUPT);
+        params.remedy = REMEDY_PATCHES_CORRUPT;
         params.verb = VERB_FAILED;
         params.noun = _("corrupt patch ${FILE}");
 
@@ -634,7 +634,7 @@ bool inspect_patches(struct rpminspect *ri)
     /* Set default parameters */
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
-    params.remedy = NULL;
+    params.remedy = 0;
 
     /* Run the main inspection */
     TAILQ_FOREACH(peer, ri->peers, items) {
@@ -722,7 +722,7 @@ bool inspect_patches(struct rpminspect *ri)
                         if (!list_contains(patchfiles, patchfile)) {
                             params.severity = RESULT_VERIFY;
                             params.waiverauth = WAIVABLE_BY_ANYONE;
-                            params.remedy = get_remedy(REMEDY_PATCHES_UNHANDLED_PATCH);
+                            params.remedy = REMEDY_PATCHES_UNHANDLED_PATCH;
                             xasprintf(&params.msg, _("Unhandled patch file `%s` defined in spec file"), patchfile);
                             add_result(ri, &params);
                             free(params.msg);

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -58,7 +58,7 @@ static bool pathmigration_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_PATHMIGRATION;
-    params.remedy = get_remedy(REMEDY_PATHMIGRATION);
+    params.remedy = REMEDY_PATHMIGRATION;
     params.verb = VERB_FAILED;
     params.file = file->localpath;
     params.arch = arch;

--- a/lib/inspect_politics.c
+++ b/lib/inspect_politics.c
@@ -120,7 +120,7 @@ static bool politics_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.arch = get_rpm_header_arch(file->rpm_header);
         params.file = file->localpath;
         params.header = NAME_POLITICS;
-        params.remedy = get_remedy(REMEDY_POLITICS);
+        params.remedy = REMEDY_POLITICS;
 
         if (allowed) {
             xasprintf(&params.msg, _("Possible politically sensitive file (%s) found in %s on %s: rules allow this file."), file->localpath, name, params.arch);

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -90,7 +90,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
      * File has been removed, report results.
      */
     if (params.waiverauth == WAIVABLE_BY_SECURITY || (ri->tests & INSPECT_REMOVEDFILES)) {
-        params.remedy = get_remedy(REMEDY_REMOVEDFILES);
+        params.remedy = REMEDY_REMOVEDFILES;
 
         if (sentry || params.waiverauth == WAIVABLE_BY_SECURITY) {
             params.severity = get_secrule_result_severity(ri, file, SECRULE_SECURITYPATH);

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -130,7 +130,7 @@ static bool have_unexpanded_macros(struct rpminspect *ri, const char *name, cons
     init_result_params(&params);
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_RPMDEPS;
-    params.remedy = get_remedy(REMEDY_RPMDEPS_MACROS);
+    params.remedy = REMEDY_RPMDEPS_MACROS;
     params.file = specfile;
 
     /* check all dependencies */
@@ -496,10 +496,10 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
 
                 if (epoch > 0) {
                     rulestr = "%{epoch}:%{version}-%{release}";
-                    params.remedy = get_remedy(REMEDY_RPMDEPS_EXPLICIT_EPOCH);
+                    params.remedy = REMEDY_RPMDEPS_EXPLICIT_EPOCH;
                 } else {
                     rulestr = "%{version}-%{release}";
-                    params.remedy = get_remedy(REMEDY_RPMDEPS_EXPLICIT);
+                    params.remedy = REMEDY_RPMDEPS_EXPLICIT;
                 }
 
                 xasprintf(&params.msg, _("Subpackage %s on %s carries '%s' which comes from subpackage %s but does not carry an explicit package version requirement.  Please add 'Requires: %s = %s' to the spec file to avoid the need to test interoperability between various combinations of old and new subpackages."), name, arch, r, pn, pn, rulestr);
@@ -530,7 +530,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
             params.severity = RESULT_VERIFY;
             params.file = r;
             params.arch = arch;
-            params.remedy = get_remedy(REMEDY_RPMDEPS_MULTIPLE);
+            params.remedy = REMEDY_RPMDEPS_MULTIPLE;
             params.verb = VERB_FAILED;
             params.noun = noun;
             add_result(ri, &params);
@@ -621,7 +621,7 @@ static bool check_explicit_epoch(struct rpminspect *ri, Header h, deprule_list_t
                 xasprintf(&params.msg, _("Missing epoch prefix on the version-release in '%s' for %s on %s"), drs, pname, arch);
                 xasprintf(&noun, _("'${FILE}' needs epoch in %s on ${ARCH}"), name);
 
-                params.remedy = get_remedy(REMEDY_RPMDEPS_EPOCH);
+                params.remedy = REMEDY_RPMDEPS_EPOCH;
                 params.verb = VERB_FAILED;
                 params.noun = noun;
                 params.arch = arch;
@@ -978,7 +978,7 @@ bool inspect_rpmdeps(struct rpminspect *ri)
                         }
 
                         xasprintf(&noun, _("'${FILE}' in %s on ${ARCH}"), name);
-                        params.remedy = get_remedy(REMEDY_RPMDEPS_GAINED);
+                        params.remedy = REMEDY_RPMDEPS_GAINED;
                         params.verb = VERB_ADDED;
                     } else if (deprules_match(deprule, deprule->peer_deprule)) {
                         if (!strcmp(arch, SRPM_ARCH_NAME)) {
@@ -996,7 +996,7 @@ bool inspect_rpmdeps(struct rpminspect *ri)
                         }
 
                         xasprintf(&noun, _("'${FILE}' in %s on ${ARCH}"), name);
-                        params.remedy = NULL;
+                        params.remedy = 0;
                         params.verb = VERB_OK;
                     } else {
                         if (!strcmp(arch, SRPM_ARCH_NAME)) {
@@ -1014,7 +1014,7 @@ bool inspect_rpmdeps(struct rpminspect *ri)
                         }
 
                         xasprintf(&noun, _("'%s' became '${FILE}' in %s on ${ARCH}"), pdrs, name);
-                        params.remedy = get_remedy(REMEDY_RPMDEPS_CHANGED);
+                        params.remedy = REMEDY_RPMDEPS_CHANGED;
                         params.verb = VERB_CHANGED;
                     }
 
@@ -1043,7 +1043,7 @@ bool inspect_rpmdeps(struct rpminspect *ri)
                         }
 
                         params.details = NULL;
-                        params.remedy = get_remedy(REMEDY_RPMDEPS_LOST);
+                        params.remedy = REMEDY_RPMDEPS_LOST;
                         params.verb = VERB_REMOVED;
                         xasprintf(&noun, _("'${FILE}' in %s on ${ARCH}"), name);
                         params.noun = noun;

--- a/lib/inspect_runpath.c
+++ b/lib/inspect_runpath.c
@@ -104,7 +104,7 @@ static bool check_runpath(struct rpminspect *ri, const rpmfile_entry_t *file, co
     params.severity = RESULT_VERIFY;
     params.waiverauth = WAIVABLE_BY_ANYONE;
     params.header = NAME_RUNPATH;
-    params.remedy = get_remedy(REMEDY_RUNPATH);
+    params.remedy = REMEDY_RUNPATH;
     params.arch = arch;
     params.file = file->localpath;
 
@@ -264,7 +264,7 @@ static bool runpath_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.header = NAME_RUNPATH;
         params.severity = RESULT_BAD;
         params.waiverauth = NOT_WAIVABLE;
-        params.remedy = get_remedy(REMEDY_RUNPATH_BOTH);
+        params.remedy = REMEDY_RUNPATH_BOTH;
         params.file = file->localpath;
         params.arch = arch;
         params.verb = VERB_FAILED;

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -201,7 +201,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (params.msg) {
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
-            params.remedy = get_remedy(REMEDY_SHELLSYNTAX_GAINED_SHELL);
+            params.remedy = REMEDY_SHELLSYNTAX_GAINED_SHELL;
             params.verb = VERB_OK;
             params.noun = _("changed shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
@@ -246,7 +246,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("%s is no longer a valid %s script on %s"), file->localpath, shell, arch);
             params.severity = RESULT_BAD;
             params.waiverauth = WAIVABLE_BY_ANYONE;
-            params.remedy = get_remedy(REMEDY_SHELLSYNTAX_BAD);
+            params.remedy = REMEDY_SHELLSYNTAX_BAD;
             params.details = errors;
             params.verb = VERB_FAILED;
             params.noun = _("invalid shell script ${FILE} on ${ARCH}");
@@ -263,7 +263,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
             params.details = before_errors;
-            params.remedy = NULL;
+            params.remedy = 0;
             params.verb = VERB_OK;
             params.noun = _("valid shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
@@ -272,7 +272,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             xasprintf(&params.msg, _("%s is not a valid %s script on %s"), file->localpath, shell, arch);
             params.severity = RESULT_BAD;
             params.waiverauth = WAIVABLE_BY_ANYONE;
-            params.remedy = get_remedy(REMEDY_SHELLSYNTAX_BAD);
+            params.remedy = REMEDY_SHELLSYNTAX_BAD;
             params.details = errors;
             params.verb = VERB_FAILED;
             params.noun = _("invalid shell script ${FILE} on ${ARCH}");
@@ -286,7 +286,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.severity = RESULT_INFO;
             params.waiverauth = NOT_WAIVABLE;
             params.details = NULL;
-            params.remedy = NULL;
+            params.remedy = 0;
             params.verb = VERB_OK;
             params.noun = _("valid shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
@@ -296,7 +296,7 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.severity = RESULT_BAD;
             params.waiverauth = WAIVABLE_BY_ANYONE;
             params.details = errors;
-            params.remedy = get_remedy(REMEDY_SHELLSYNTAX_BAD);
+            params.remedy = REMEDY_SHELLSYNTAX_BAD;
             params.noun = _("invalid shell script ${FILE} on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);

--- a/lib/inspect_specname.c
+++ b/lib/inspect_specname.c
@@ -61,7 +61,7 @@ static bool specname_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         params.severity = RESULT_BAD;
         params.waiverauth = NOT_WAIVABLE;
         params.header = NAME_SPECNAME;
-        params.remedy = get_remedy(REMEDY_SPECNAME);
+        params.remedy = REMEDY_SPECNAME;
         params.file = file->localpath;
         params.verb = VERB_FAILED;
         params.noun = _("unexpected spec filename");

--- a/lib/inspect_subpackages.c
+++ b/lib/inspect_subpackages.c
@@ -66,7 +66,7 @@ bool inspect_subpackages(struct rpminspect *ri)
                 xasprintf(&params.msg, _("Subpackage '%s' has disappeared on '%s'"), entry->data, arch);
                 params.severity = RESULT_VERIFY;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
-                params.remedy = get_remedy(REMEDY_SUBPACKAGES_LOST);
+                params.remedy = REMEDY_SUBPACKAGES_LOST;
                 params.arch = arch;
                 params.file = entry->data;
                 params.verb = VERB_REMOVED;
@@ -90,7 +90,7 @@ bool inspect_subpackages(struct rpminspect *ri)
                 xasprintf(&params.msg, _("Subpackage '%s' has appeared on '%s'"), entry->data, arch);
                 params.severity = RESULT_INFO;
                 params.waiverauth = NOT_WAIVABLE;
-                params.remedy = get_remedy(REMEDY_SUBPACKAGES_GAIN);
+                params.remedy = REMEDY_SUBPACKAGES_GAIN;
                 params.arch = arch;
                 params.file = entry->data;
                 params.verb = VERB_ADDED;

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -282,7 +282,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
         if (S_ISDIR(file->peer_file->st_mode)) {
             /* Some RPM versions cannot handle this on an upgrade */
-            params.remedy = get_remedy(REMEDY_SYMLINKS_DIRECTORY);
+            params.remedy = REMEDY_SYMLINKS_DIRECTORY;
             xasprintf(&params.msg, _("Directory %s became a symbolic link (to %s) in %s on %s; this is not allowed!"), file->peer_file->localpath, localpath, name, params.arch);
             params.severity = RESULT_BAD;
             params.waiverauth = WAIVABLE_BY_ANYONE;
@@ -297,7 +297,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 xasprintf(&params.msg, _("%s %s became a symbolic link (to %s) in %s on %s; and the link destination is unreachable"), strtype(file->peer_file->st_mode), file->peer_file->localpath, localpath, name, params.arch);
                 params.severity = RESULT_VERIFY;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
-                params.remedy = get_remedy(REMEDY_SYMLINKS);
+                params.remedy = REMEDY_SYMLINKS;
             }
         }
 

--- a/lib/inspect_types.c
+++ b/lib/inspect_types.c
@@ -62,7 +62,7 @@ static bool types_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     params.severity = RESULT_INFO;
     params.waiverauth = NOT_WAIVABLE;
     params.header = NAME_TYPES;
-    params.remedy = get_remedy(REMEDY_TYPES);
+    params.remedy = REMEDY_TYPES;
     params.arch = arch;
     params.file = file->localpath;
     params.verb = VERB_CHANGED;

--- a/lib/inspect_udevrules.c
+++ b/lib/inspect_udevrules.c
@@ -126,7 +126,7 @@ static bool udevrules_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     } else {
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.remedy = get_remedy(REMEDY_UDEVRULES);
+        params.remedy = REMEDY_UDEVRULES;
         params.details = details;
         result = false;
     }

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -503,7 +503,7 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
     params.arch = globalarch;
     params.file = localpath;
     params.noun = _("forbidden code point in ${FILE} on ${ARCH}");
-    params.remedy = get_remedy(REMEDY_UNICODE);
+    params.remedy = REMEDY_UNICODE;
 
     /* Read in the file as Unicode data */
     src = u_fopen(fpath, "r", NULL, NULL);
@@ -645,7 +645,7 @@ static bool unicode_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             params.file = file->localpath;
             params.noun = _("unable to run %prep in ${FILE}");
             params.verb = VERB_FAILED;
-            params.remedy = get_remedy(REMEDY_UNICODE_PREP_FAILED);
+            params.remedy = REMEDY_UNICODE_PREP_FAILED;
             xasprintf(&params.msg, _("Unable to run through the %%prep section in %s or manually unpack sources for further scanning."), file->localpath);
             add_result(globalri, &params);
             free(params.msg);

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -157,7 +157,7 @@ bool inspect_upstream(struct rpminspect *ri)
         /* versions are the same, likely maintenance */
         params.severity = RESULT_VERIFY;
         params.waiverauth = WAIVABLE_BY_ANYONE;
-        params.remedy = get_remedy(REMEDY_UPSTREAM);
+        params.remedy = REMEDY_UPSTREAM;
     }
 
     /* Run the main inspection */
@@ -209,7 +209,7 @@ bool inspect_upstream(struct rpminspect *ri)
     }
 
     params.msg = NULL;
-    params.remedy = NULL;
+    params.remedy = 0;
 
     /* Sound the everything-is-ok alarm if everything is, in fact, ok */
     if (result && !reported) {

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -312,7 +312,7 @@ bool inspect_virus(struct rpminspect *ri)
 
                     params.arch = get_rpm_header_arch(file->rpm_header);
                     params.file = file->localpath;
-                    params.remedy = get_remedy(REMEDY_VIRUS);
+                    params.remedy = REMEDY_VIRUS;
                     xasprintf(&params.msg, _("Virus detected in %s in the %s package on %s: %s"), file->localpath, headerGetString(file->rpm_header, RPMTAG_NAME), params.arch, virus);
                     add_result(ri, &params);
                     free(params.msg);

--- a/lib/inspect_xml.c
+++ b/lib/inspect_xml.c
@@ -207,7 +207,7 @@ static bool xml_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Set up result parameters */
     init_result_params(&params);
     params.header = NAME_XML;
-    params.remedy = get_remedy(REMEDY_XML);
+    params.remedy = REMEDY_XML;
     params.arch = get_rpm_header_arch(file->rpm_header);
     params.file = file->localpath;
 

--- a/lib/output_json.c
+++ b/lib/output_json.c
@@ -74,8 +74,8 @@ void output_json(const results_t *results, const char *dest, __attribute__((unus
             json_object_object_add(jr, "details", json_object_new_string(result->details));
         }
 
-        if (result->remedy != NULL) {
-            json_object_object_add(jr, "remedy", json_object_new_string(result->remedy));
+        if (result->remedy != REMEDY_NULL) {
+            json_object_object_add(jr, "remedy", json_object_new_string(get_remedy(result->remedy)));
         }
 
         /* add this result data to the inspection array */

--- a/lib/output_text.c
+++ b/lib/output_text.c
@@ -99,13 +99,13 @@ void output_text(const results_t *results, const char *dest, __attribute__((unus
                 fprintf(fp, _("Details:\n%s\n\n"), result->details);
             }
 
-            if (result->remedy != NULL) {
-                xasprintf(&msg, _("Suggested Remedy:\n%s"), result->remedy);
+            if (result->remedy != REMEDY_NULL) {
+                xasprintf(&msg, _("Suggested Remedy:\n%s"), get_remedy(result->remedy));
 
                 if (width) {
                     printwrap(msg, width, 0, fp);
                 } else {
-                   fprintf(fp, "%s", msg);
+                    fprintf(fp, "%s", msg);
                 }
 
                 free(msg);

--- a/lib/output_xunit.c
+++ b/lib/output_xunit.c
@@ -114,8 +114,8 @@ void output_xunit(const results_t *results, const char *dest, const severity_t t
             free(rawcdata);
         }
 
-        if (result->remedy != NULL) {
-            xasprintf(&rawcdata, _("Suggested Remedy:\n%s"), result->remedy);
+        if (result->remedy != REMEDY_NULL) {
+            xasprintf(&rawcdata, _("Suggested Remedy:\n%s"), get_remedy(result->remedy));
             assert(rawcdata != NULL);
             msg = strappend(msg, rawcdata, NULL);
             assert(msg != NULL);

--- a/lib/ownership.c
+++ b/lib/ownership.c
@@ -75,7 +75,7 @@ bool check_ownership(struct rpminspect *ri, const rpmfile_entry_t *file, const c
         && list_contains(ri->forbidden_owners, owner)
         && ((ri->tests & INSPECT_OWNERSHIP) || force_non_security_checks)) {
         xasprintf(&params.msg, _("File %s has forbidden owner `%s` on %s"), file->localpath, owner, arch);
-        params.remedy = get_remedy(REMEDY_OWNERSHIP_DEFATTR);
+        params.remedy = REMEDY_OWNERSHIP_DEFATTR;
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
@@ -92,7 +92,7 @@ bool check_ownership(struct rpminspect *ri, const rpmfile_entry_t *file, const c
         && list_contains(ri->forbidden_groups, group)
         && ((ri->tests & INSPECT_OWNERSHIP) || force_non_security_checks)) {
         xasprintf(&params.msg, _("File %s has forbidden group `%s` on %s"), file->localpath, owner, arch);
-        params.remedy = get_remedy(REMEDY_OWNERSHIP_DEFATTR);
+        params.remedy = REMEDY_OWNERSHIP_DEFATTR;
         params.severity = RESULT_BAD;
         params.waiverauth = WAIVABLE_BY_ANYONE;
         params.verb = VERB_FAILED;
@@ -118,7 +118,7 @@ bool check_ownership(struct rpminspect *ri, const rpmfile_entry_t *file, const c
                 && !match_fileinfo_owner(ri, file, owner, header, NULL, NULL, &result, reported)
                 && ((ri->tests & INSPECT_OWNERSHIP) || force_non_security_checks)) {
                 xasprintf(&params.msg, _("File %s has owner `%s` on %s, but should be `%s`"), file->localpath, owner, arch, ri->bin_owner);
-                params.remedy = get_remedy(REMEDY_OWNERSHIP_BIN_OWNER);
+                params.remedy = REMEDY_OWNERSHIP_BIN_OWNER;
                 params.severity = RESULT_BAD;
                 params.waiverauth = WAIVABLE_BY_ANYONE;
                 params.verb = VERB_FAILED;
@@ -161,7 +161,7 @@ bool check_ownership(struct rpminspect *ri, const rpmfile_entry_t *file, const c
 
                         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
                             xasprintf(&params.msg, _("File %s on %s has CAP_SETUID capability but group `%s` and is world executable"), file->localpath, arch, group);
-                            params.remedy = get_remedy(REMEDY_OWNERSHIP_IXOTH);
+                            params.remedy = REMEDY_OWNERSHIP_IXOTH;
                             params.waiverauth = WAIVABLE_BY_SECURITY;
                             params.verb = VERB_FAILED;
                             params.noun = _("CAP_SETUID and o+x for ${FILE} on ${ARCH}");
@@ -177,7 +177,7 @@ bool check_ownership(struct rpminspect *ri, const rpmfile_entry_t *file, const c
 
                         if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
                             xasprintf(&params.msg, _("File %s on %s has CAP_SETUID capability but group `%s` and is group writable"), file->localpath, arch, group);
-                            params.remedy = get_remedy(REMEDY_OWNERSHIP_IWGRP);
+                            params.remedy = REMEDY_OWNERSHIP_IWGRP;
                             params.waiverauth = WAIVABLE_BY_SECURITY;
                             params.verb = VERB_FAILED;
                             params.noun = _("CAP_SETUID and g+w for ${FILE} on ${ARCH}");
@@ -196,7 +196,7 @@ bool check_ownership(struct rpminspect *ri, const rpmfile_entry_t *file, const c
                     && ((ri->tests & INSPECT_OWNERSHIP) || force_non_security_checks)) {
 #endif
                     xasprintf(&params.msg, _("File %s has group `%s` on %s, but should be `%s`"), file->localpath, group, arch, ri->bin_group);
-                    params.remedy = get_remedy(REMEDY_OWNERSHIP_BIN_GROUP);
+                    params.remedy = REMEDY_OWNERSHIP_BIN_GROUP;
                     params.severity = RESULT_BAD;
                     params.waiverauth = WAIVABLE_BY_ANYONE;
                     params.verb = VERB_FAILED;
@@ -265,7 +265,7 @@ bool check_ownership(struct rpminspect *ri, const rpmfile_entry_t *file, const c
 
             free(params.msg);
             xasprintf(&params.msg, _("File %s changed %s from `%s` to `%s` on %s"), file->localpath, what, before_val, after_val, arch);
-            params.remedy = get_remedy(REMEDY_OWNERSHIP_CHANGED);
+            params.remedy = REMEDY_OWNERSHIP_CHANGED;
             params.noun = _("${FILE} changed owner on ${ARCH}");
             add_result(ri, &params);
             free(params.msg);

--- a/lib/remedy.c
+++ b/lib/remedy.c
@@ -107,122 +107,209 @@ struct remedy remedies[] = {
 };
 
 /*
- * Initialize the default remedy strings with the internal translated strings.
- */
-void init_remedy_strings(void)
-{
-    remedies[REMEDY_ABIDIFF].remedy = _("ABI changes introduced during maintenance updates can lead to problems for users.  See the abidiff(1) documentation and the distribution ABI policies to determine if this detected change is allowed.");
-    remedies[REMEDY_ADDEDFILES].remedy = _("Unexpected file additions were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file additions between builds.  If they are correct, update the fileinfo list for this product release and send a patch to the rpminspect data project owning that file so rpminspect knows to expect this change.  You may also need to update the data package or local configuration file and change the forbidden_path_prefixes or forbidden_path_suffixes list.");
-    remedies[REMEDY_ANNOCHECK_FORTIFY_SOURCE].remedy = _("Ensure all object files are compiled with '-O2 -D_FORTIFY_SOURCE=2', and that all appropriate headers are included (no implicit function declarations). Symbols may also appear as unfortified if the compiler is unable to determine the size of a buffer, which is not necessarily an error.");
-    remedies[REMEDY_ANNOCHECK].remedy = _("See annocheck(1) for more information.");
-    remedies[REMEDY_ARCH_GAIN].remedy = _("A new architecture has appeared in the after build.  This may indicate progress in the world of computing.");
-    remedies[REMEDY_ARCH_LOST].remedy = _("An architecture present in the before build is now missing in the after build.  This may be deliberate, but check to make sure you do not have any unexpected ExclusiveArch lines in the spec file.");
-    remedies[REMEDY_BADFUNCS].remedy = _("Forbidden symbols were found in an ELF file in the package.  The configuration settings for rpminspect indicate the named symbols are forbidden in packages.  If this is deliberate, you may want to disable the badfuncs inspection.  If it is not deliberate, check the man pages for the named symbols to see what API functions have replaced the forbidden symbols.  Usually a function is marked as deprecated but still provided in order to allow for backwards compatibility.  Whenever possible the deprecated functions should not be used.");
-    remedies[REMEDY_BADWORDS].remedy = _("Unprofessional language as defined in the configuration file was found in the text shown.  Remove or change the offending words and rebuild.");
-    remedies[REMEDY_BUILDHOST].remedy = _("Make sure the SRPM is built on a host within the expected subdomain.");
-    remedies[REMEDY_CAPABILITIES].remedy = _("Unexpected capabilities were found on the indicated file.  Consult capabilities(7) and either adjust the files in the package or modify the capabilities list in the rpminspect vendor data package.  The security team may also be of help for this situation.  If necessary, update the capabilities file for this product release with the changes found here and send a patch to the project that owns the rpminspect data file.");
-    remedies[REMEDY_CHANGEDFILES].remedy = _("File changes were found.  In most cases these are expected, but it is a good idea to verify the changes found are deliberate.");
-    remedies[REMEDY_CHANGELOG].remedy = _("Make sure the spec file in the after build contains a valid %changelog section.");
-    remedies[REMEDY_CONFIG].remedy = _("Changes to %config should be done carefully.  Make sure you have installed the correct file and in the correct location.  If a package is restructuring configuration files, make sure the package can handle upgrading an existing package -or- honor the old file locations.");
-    remedies[REMEDY_DESKTOP].remedy = _("Refer to the Desktop Entry Specification at https://standards.freedesktop.org/desktop-entry-spec/latest/ for help correcting the errors and warnings.");
-    remedies[REMEDY_DISTTAG].remedy = _("The Release: tag in the spec file must include a '%{?dist}' string.  Please add this to the spec file per the distribution packaging guidelines.");
-    remedies[REMEDY_DOC].remedy = _("Changes found among the %doc files.  Verify these changes are intended if the package is not a rebase.  Sometimes upstream projects rename or move documentation files and the spec file needs to account for those changes.");
-    remedies[REMEDY_DSODEPS].remedy = _("DT_NEEDED symbols have been added or removed.  This happens when the build environment has different versions of the required libraries.  Sometimes this is deliberate but sometimes not.  Verify these changes are expected.  If they are not, modify the package spec file to ensure the build links with the correct shared libraries.");
-    remedies[REMEDY_ELF_EXECSTACK_EXECUTABLE].remedy = _("An ELF stack is marked as executable. Ensure that no execstack options are being passed to the linker, and that no functions are defined on the stack.");
-    remedies[REMEDY_ELF_EXECSTACK_INVALID].remedy = _("The data in an ELF file appears to be corrupt; ensure that packaged ELF files are not being truncated or incorrectly modified.");
-    remedies[REMEDY_ELF_EXECSTACK_MISSING].remedy = _("Ensure that the package is being built with the correct compiler and compiler flags.");
-    remedies[REMEDY_ELF_FPIC].remedy = _("Ensure all object files are compiled with -fPIC.");
-    remedies[REMEDY_ELF_GNU_RELRO].remedy = _("Ensure executables are linked with with '-z relro -z now'.");
-    remedies[REMEDY_ELF_TEXTREL].remedy = _("Ensure all object files are compiled with -fPIC.");
-    remedies[REMEDY_EMPTYRPM].remedy = _("Check to see if you eliminated a subpackage but still have the %package and/or the %files section for it.");
-    remedies[REMEDY_FILEINFO_RULE].remedy = _("rpminspect is expecting a fileinfo rule from the vendor data package for this file. Usually this means the file carries a non-standard set of permissions (e.g., setuid) which is a condition where rpminspect would check the fileinfo list to ensure the package conforms to the vendor rules. To remedy, add a fileinfo rule for this file to the vendor data package under the appropriate product release file.");
-    remedies[REMEDY_FILESIZE_BECAME_EMPTY].remedy = _("A previously non-empty file is now empty.  Make sure this change is intended and fix the package space file if necessary.");
-    remedies[REMEDY_FILESIZE_BECAME_NOT_EMPTY].remedy = _("A previously empty file is no longer empty.  Make sure this change is intended and fix the package spec file if necessary.");
-    remedies[REMEDY_FILESIZE_GREW].remedy = _("A file grew by a noticeable amount.  Ensure this change is intended.  If it is, you can adjust the filesize inspection settings in the rpminspect.yaml file.");
-    remedies[REMEDY_FILESIZE_SHRANK].remedy = _("A file shrank by a noticeable amount.  Ensure this change is intended.  If it is, you can adjust the filesize inspection settings in the rpminspect.yaml file.");
-    remedies[REMEDY_FILE_PATHS].remedy = _("Remove forbidden path references from the indicated line in the %files section.  In many cases you can use RPM macros to specify path locations.  See the RPM documentation or distribution package maintainer guide for more information.");
-    remedies[REMEDY_INVALID_BOOLEAN].remedy = _("The License tag contains SPDX license identifiers.  When SPDX identifiers are used, the boolean joining terms must be written in all capital letters per the spec.  The actual SPDX identifiers are case-insensitive.  It is only the boolean terms that must be in all capital letters.");
-    remedies[REMEDY_JAVABYTECODE].remedy = _("The Java bytecode version for one or more class files in the build was not met for the product release.  Ensure you are using the correct JDK for the build.");
-    remedies[REMEDY_KMIDIFF].remedy = _("Kernel Module Interface introduced during maintenance updates can lead to problems for users.  See the libabigail documentation and the distribution KMI policy to determine if this detected change is allowed.");
-    remedies[REMEDY_KMOD_ALIAS].remedy = _("Kernel module device aliases changed between builds.  This may present usability problems for users if module device aliases changed in a maintenance update.");
-    remedies[REMEDY_KMOD_DEPS].remedy = _("Kernel module dependencies changed between builds.  This may present usability problems for users if module dependencies changed in a maintenance update.");
-    remedies[REMEDY_KMOD_PARM].remedy = _("Kernel module parameters were removed between builds.  This may present usability problems for users if module parameters were removed in a maintenance update.");
-    remedies[REMEDY_LICENSEDB].remedy = _("Make sure the licensedb setting in the rpminspect configuration is set to a valid licensedb file.  This is also commonly due to a missing vendor specific rpminspect-data package on the system.");
-    remedies[REMEDY_LICENSE].remedy = _("The License tag must contain an approved license string as defined by the distribution (e.g., GPLv2+).  If the license in question is approved, the license database needs updating in the rpminspect-data package.");
-    remedies[REMEDY_LOSTPAYLOAD].remedy = _("Check to see if you eliminated a subpackage but still have the %package and/or the %files section for it.");
-    remedies[REMEDY_LTO].remedy = _("ELF .o and .a files should not carry LTO (Link Time Optimization) bytecode.  Make sure you have stripped LTO bytecode from those files at install time.");
-    remedies[REMEDY_MAN_ERRORS].remedy = _("Correct the errors in the man page as reported by the libmandoc parser.");
-    remedies[REMEDY_MAN_PATH].remedy = _("Correct the installation path for the man page. Man pages must be installed in the directory beneath /usr/share/man that matches the section number of the page.");
-    remedies[REMEDY_MODULARITY_LABEL].remedy = _("This package is part of a module but is missing the %{modularitylabel} header tag.  Add this as a %define in the spec file and rebuild.");
-    remedies[REMEDY_MODULARITY_RELEASE].remedy = _("This package is part of a module but lacks a conformant Release tag value.  A Release tag in a modular RPM needs to carry a substring that is more specific than a major release dist tag (e.g., el8.9.0 rather than el8) and must carry '+module' as a substring before that specific dist tag.");
-    remedies[REMEDY_MODULARITY_STATIC_CONTEXT].remedy = _("This build either contains a valid or invalid /data/static_context setting.  Refer to the module rules for the product you are building to determine what the setting should be.  The rpminspect configuration settings also set the rules determining if the /data/static_context setting is required, forbidden, or recommend.");
-    remedies[REMEDY_MOVEDFILES].remedy = _("Unexpected file moves were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file moves between builds.");
-    remedies[REMEDY_OWNERSHIP_BIN_GROUP].remedy = _("Bin path files must be owned by the bin_group set in the rpminspect configuration, which is usually root. If this ownership is expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
-    remedies[REMEDY_OWNERSHIP_BIN_OWNER].remedy = _("Bin path files must be owned by the bin_owner set in the rpminspect configuration, which is usually root. If this ownership is expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
-    remedies[REMEDY_OWNERSHIP_CHANGED].remedy = _("Verify the ownership changes are expected. If not, adjust the package build process to set correct owner and group information. If expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
-    remedies[REMEDY_OWNERSHIP_DEFATTR].remedy = _("Make sure the %files section includes the %defattr macro. If these permissions are expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
-    remedies[REMEDY_OWNERSHIP_IWGRP].remedy = _("Either chgrp the file to the bin_group set in the rpminspect configuration or remove the group write bit on the file (chmod g-w). If this ownership is expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
-    remedies[REMEDY_OWNERSHIP_IXOTH].remedy = _("Either chgrp the file to the bin_group set in the rpminspect configuration or remove the world execute bit on the file (chmod o-x). If this ownership is expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
-    remedies[REMEDY_PATCHES_CORRUPT].remedy = _("An invalid patch file was found.  This is usually the result of generating a collection of patches by comparing two trees.  When files disappear that can lead to zero length patches in the resulting collection.  Check to see if the source package has any zero length or otherwise invalid patches and correct the problem.");
-    remedies[REMEDY_PATCHES_MISMATCHED_MACRO].remedy = _("The named patch is defined but is mismatched by number with the %patch macro.  Make sure all numbered patches have corresponding %patch macros.  For example, Patch47 needs to have either a '%patch 47', '%patch -P 47', '%patch -P47', or '%patch47' macro.");
-    remedies[REMEDY_PATCHES_MISSING_MACRO].remedy = _("The named patch is defined in the source RPM header (this means it has a PatchN: definition in the spec file) but is not applied anywhere in the spec file.  It is missing a corresponding %patch macro and the spec file lacks the %autosetup or %autopatch macros.  You can fix this by adding the appropriate %patch macro in the spec file (usually in the %prep section).  The number specified with the %patch macro corresponds to the number used to define the patch at the top of the spec file.  So Patch47 is applied with either a '%patch 47', '%patch -P 47', '%patch -P47', or '%patch47' macro.");
-    remedies[REMEDY_PATCHES_UNHANDLED_PATCH].remedy = _("The defined patch file is not something rpminspect can handle.  This is likely a bug and should be reported to the upstream rpminspect project.");
-    remedies[REMEDY_PATHMIGRATION].remedy = _("Files should not be installed in old directory names.  Modify the package to install the affected file to the preferred directory.");
-    remedies[REMEDY_POLITICS].remedy = _("A file with potential politically sensitive content was found in the package.  If this file is permitted, it should be added to the rpminspect vendor data package for the product.  Modify the politics allow/deny list file for this product release and send a patch to the project that owns the rpminspect data files.");
-    remedies[REMEDY_REMOVEDFILES].remedy = _("Unexpected file removals were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file removals between builds.");
-    remedies[REMEDY_RPMDEPS_CHANGED].remedy = _("A dependency listed in the before build changed to the indicated dependency in the after build.  If this is a VERIFY result, it means rpminspect noticed the change in what it considers a maintenance update in a package.  An INFO result means it noticed this change, but deems it ok because it is comparing a rebased build.");
-    remedies[REMEDY_RPMDEPS_EPOCH].remedy = _("The package has an Epoch value greater than zero, but the explicit subpackage dependencies are not consistently using it.  For the dependency reported, the '= %{version}-%{release}' needs to change to '= %{epoch}:%{version}-%{release}' to capture the package Epoch in the dependency.");
-    remedies[REMEDY_RPMDEPS_EXPLICIT].remedy = _("Add the indicated explicit Requires to the spec file for the named subpackage.  Subpackages depending on shared libraries in another subpackage must carry an explicit 'Requires: SUBPACKAGE_NAME = %{version}-%{release}' in the spec file.");
-    remedies[REMEDY_RPMDEPS_EXPLICIT_EPOCH].remedy = _("Add the indicated explicit Requires to the spec file for the named subpackage.  Subpackages depending on shared libraries in another subpackage must carry an explicit 'Requires: SUBPACKAGE_NAME = %{epoch}:%{version}-%{release}' in the spec file.");
-    remedies[REMEDY_RPMDEPS_GAINED].remedy = _("A new dependency is seen in the after build that was not present in the before build.  If this is a VERIFY result, it means rpminspect noticed the change in what it considers a maintenance update in a package.  An INFO result means it noticed this change, but deems it ok because it is comparing a rebased build.");
-    remedies[REMEDY_RPMDEPS_LOST].remedy = _("A dependency seen in the before build is not seen in the after build meaning it was removed or lost.  If this is a VERIFY result, it means rpminspect noticed the change in what it considers a maintenance update in a package.  An INFO result means it noticed this change, but deems it ok because it is comparing a rebased build.");
-    remedies[REMEDY_RPMDEPS_MACROS].remedy = _("Unexpanded RPM spec file macros were found in the noted dependency rule.  Check the spec file for this dependency and ensure you have not misspelled a macro or used a macro name that does not exist.");
-    remedies[REMEDY_RPMDEPS_MULTIPLE].remedy = _("Check subpackage %files sections and explicit Provides statements.  Only one subpackage should provide a given shared library.  Shared library names are automatically added as Provides, so there is no need to specify them in the spec file but you do need to make sure only one subpackage is packaging up the shared library in question.");
-    remedies[REMEDY_RUNPATH_BOTH].remedy = _("Both DT_RPATH and DT_RUNPATH properties were found in an ELF shared object.  This indicates a linker error and should not happen.  ELF objects should only carry DT_RPATH or DT_RUNPATH, never both.");
-    remedies[REMEDY_RUNPATH].remedy = _("Either DT_RPATH or DT_RUNPATH properties were found on ELF shared objects in this package.  The use of DT_RPATH and DT_RUNPATH is discouraged except in certain situations.  Check to see that you are disabling rpath during the %build stage of the spec file.  If you are unable to do this easily, you can try using a program such as patchelf to remove these properties from the ELF files.");
-    remedies[REMEDY_SHELLSYNTAX_BAD].remedy = _("The referenced shell script is invalid. Consider debugging it with the '-n' option on the shell to find and fix the problem.");
-    remedies[REMEDY_SHELLSYNTAX].remedy = _("Consult the shell documentation for proper syntax.");
-    remedies[REMEDY_SHELLSYNTAX_GAINED_SHELL].remedy = _("The file referenced was not a known shell script in the before build but is now a shell script in the after build.");
-    remedies[REMEDY_SPECNAME].remedy = _("The spec file name does not match the expected NAME.spec format.  Rename the spec file to conform to this policy.");
-    remedies[REMEDY_SUBPACKAGES_GAIN].remedy = _("A new subpackage has appeared in the after build.  This may indicate progress in the world of computing.");
-    remedies[REMEDY_SUBPACKAGES_LOST].remedy = _("A subpackage present in the before build is now missing in the after build.  This may be deliberate, but check to make sure you have correct syntax defining the subpackage in the spec file.");
-    remedies[REMEDY_SYMLINKS_DIRECTORY].remedy = _("Make sure symlinks point to a valid destination in one of the subpackages of the build; dangling symlinks are not allowed.  If you are comparing builds and have a non-symlink turn in to a symlink, ensure this is deliberate.  NOTE:  You cannot turn a directory in to a symlink due to RPM limitations.  If you absolutely must do that, make sure you include the %pretrans scriptlet for replacing a directory.  See the packaging guidelines for 'Scriptlet to replace a directory' for more information.");
-    remedies[REMEDY_SYMLINKS].remedy = _("Make sure symlinks point to a valid destination in one of the subpackages of the build; dangling symlinks are not allowed.  If you are comparing builds and have a non-symlink turn in to a symlink, ensure this is deliberate.  NOTE:  You cannot turn a directory in to a symlink due to RPM limitations.");
-    remedies[REMEDY_TYPES].remedy = _("In many cases the changing MIME type is deliberate.  Verify that the change is intended and if necessary fix the spec file so the correct file is included in the built package.");
-    remedies[REMEDY_UDEVRULES].remedy = _("Refer to the udev documentation at https://www.freedesktop.org/software/systemd/man/udev.html for help correcting the errors and warnings.");
-    remedies[REMEDY_UNAPPROVED_LICENSE].remedy = _("The specified license abbreviation is not listed as approved in the license database.  The license database is specified in the rpminspect configuration file.  Check this file and send a pull request to the appropriate upstream project to update the database.  If the license is listed in the database but marked unapproved, you may need to work with the legal team regarding options for this software.");
-    remedies[REMEDY_UNICODE_PREP_FAILED].remedy = _("The %prep section of the spec file could not be executed for some reason.  This usually results from a failure in librpmbuild, which is usually tied to archive extraction problems or the filesystem changing while rpminspect is running.  A common cause is removal of the working directory while the program is executing.");
-    remedies[REMEDY_UNICODE].remedy = _("The rpminspect configuration file contains a list of forbidden Unicode code points.  One was found in the extracted and patched source tree or in one of the text source files in the source RPM.  Either remove this code point or discuss the situation with the Product Security Team to determine the correct course of action.");
-    remedies[REMEDY_UPSTREAM].remedy = _("Unexpected changed source archive content. The version of the package did not change between builds, but the source archive content did. This may be deliberate, but needs inspection. If this change is expected, update the rebaseable exception list for this product release and send a patch to the project that owns the rpminspect data files.");
-    remedies[REMEDY_VENDOR].remedy = _("Change the string specified on the 'Vendor:' line in the spec file.");
-    remedies[REMEDY_VIRUS].remedy = _("ClamAV has found a virus in the named file.  This may be a false positive, but you should manually inspect the file in question to ensure it is clean.  This may be a problem with the ClamAV database or detection.  If you are sure the file in question is clean, please file a bug with rpminspect for further help.");
-    remedies[REMEDY_XML].remedy = _("Correct the reported errors in the XML document.");
-    remedies[REMEDY_MIXED_LICENSE_TAGS].remedy = _("The License tag contains mixed used of SPDX and legacy license identifiers.  You must use either all SPDX license identifiers or all legacy license identifiers; you cannot mix the two systems.");
-
-    return;
-}
-
-/*
  * Return the remedy string for the given remedy ID.
  */
 const char *get_remedy(const unsigned int id)
 {
+    char *r = NULL;
     unsigned int i = 0;
 
     for (i = 0; remedies[i].name != NULL; i++) {
         if (remedies[i].id == id) {
-            return remedies[i].remedy;
+            if (remedies[i].remedy != NULL) {
+                r = remedies[i].remedy;
+            } else {
+                if (id == REMEDY_ABIDIFF) {
+                    r = _("ABI changes introduced during maintenance updates can lead to problems for users.  See the abidiff(1) documentation and the distribution ABI policies to determine if this detected change is allowed.");
+                } else if (id == REMEDY_ADDEDFILES) {
+                    r = _("Unexpected file additions were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file additions between builds.  If they are correct, update the fileinfo list for this product release and send a patch to the rpminspect data project owning that file so rpminspect knows to expect this change.  You may also need to update the data package or local configuration file and change the forbidden_path_prefixes or forbidden_path_suffixes list.");
+                } else if (id == REMEDY_ANNOCHECK_FORTIFY_SOURCE) {
+                    r = _("Ensure all object files are compiled with '-O2 -D_FORTIFY_SOURCE=2', and that all appropriate headers are included (no implicit function declarations). Symbols may also appear as unfortified if the compiler is unable to determine the size of a buffer, which is not necessarily an error.");
+                } else if (id == REMEDY_ANNOCHECK) {
+                    r = _("See annocheck(1) for more information.");
+                } else if (id == REMEDY_ARCH_GAIN) {
+                    r = _("A new architecture has appeared in the after build.  This may indicate progress in the world of computing.");
+                } else if (id == REMEDY_ARCH_LOST) {
+                    r = _("An architecture present in the before build is now missing in the after build.  This may be deliberate, but check to make sure you do not have any unexpected ExclusiveArch lines in the spec file.");
+                } else if (id == REMEDY_BADFUNCS) {
+                    r = _("Forbidden symbols were found in an ELF file in the package.  The configuration settings for rpminspect indicate the named symbols are forbidden in packages.  If this is deliberate, you may want to disable the badfuncs inspection.  If it is not deliberate, check the man pages for the named symbols to see what API functions have replaced the forbidden symbols.  Usually a function is marked as deprecated but still provided in order to allow for backwards compatibility.  Whenever possible the deprecated functions should not be used.");
+                } else if (id == REMEDY_BADWORDS) {
+                    r = _("Unprofessional language as defined in the configuration file was found in the text shown.  Remove or change the offending words and rebuild.");
+                } else if (id == REMEDY_BUILDHOST) {
+                    r = _("Make sure the SRPM is built on a host within the expected subdomain.");
+                } else if (id == REMEDY_CAPABILITIES) {
+                    r = _("Unexpected capabilities were found on the indicated file.  Consult capabilities(7) and either adjust the files in the package or modify the capabilities list in the rpminspect vendor data package.  The security team may also be of help for this situation.  If necessary, update the capabilities file for this product release with the changes found here and send a patch to the project that owns the rpminspect data file.");
+                } else if (id == REMEDY_CHANGEDFILES) {
+                    r = _("File changes were found.  In most cases these are expected, but it is a good idea to verify the changes found are deliberate.");
+                } else if (id == REMEDY_CHANGELOG) {
+                    r = _("Make sure the spec file in the after build contains a valid %changelog section.");
+                } else if (id == REMEDY_CONFIG) {
+                    r = _("Changes to %config should be done carefully.  Make sure you have installed the correct file and in the correct location.  If a package is restructuring configuration files, make sure the package can handle upgrading an existing package -or- honor the old file locations.");
+                } else if (id == REMEDY_DESKTOP) {
+                    r = _("Refer to the Desktop Entry Specification at https://standards.freedesktop.org/desktop-entry-spec/latest/ for help correcting the errors and warnings.");
+                } else if (id == REMEDY_DISTTAG) {
+                    r = _("The Release: tag in the spec file must include a '%{?dist}' string.  Please add this to the spec file per the distribution packaging guidelines.");
+                } else if (id == REMEDY_DOC) {
+                    r = _("Changes found among the %doc files.  Verify these changes are intended if the package is not a rebase.  Sometimes upstream projects rename or move documentation files and the spec file needs to account for those changes.");
+                } else if (id == REMEDY_DSODEPS) {
+                    r = _("DT_NEEDED symbols have been added or removed.  This happens when the build environment has different versions of the required libraries.  Sometimes this is deliberate but sometimes not.  Verify these changes are expected.  If they are not, modify the package spec file to ensure the build links with the correct shared libraries.");
+                } else if (id == REMEDY_ELF_EXECSTACK_EXECUTABLE) {
+                    r = _("An ELF stack is marked as executable. Ensure that no execstack options are being passed to the linker, and that no functions are defined on the stack.");
+                } else if (id == REMEDY_ELF_EXECSTACK_INVALID) {
+                    r = _("The data in an ELF file appears to be corrupt; ensure that packaged ELF files are not being truncated or incorrectly modified.");
+                } else if (id == REMEDY_ELF_EXECSTACK_MISSING) {
+                    r = _("Ensure that the package is being built with the correct compiler and compiler flags.");
+                } else if (id == REMEDY_ELF_FPIC) {
+                    r = _("Ensure all object files are compiled with -fPIC.");
+                } else if (id == REMEDY_ELF_GNU_RELRO) {
+                    r = _("Ensure executables are linked with with '-z relro -z now'.");
+                } else if (id == REMEDY_ELF_TEXTREL) {
+                    r = _("Ensure all object files are compiled with -fPIC.");
+                } else if (id == REMEDY_EMPTYRPM) {
+                    r = _("Check to see if you eliminated a subpackage but still have the %package and/or the %files section for it.");
+                } else if (id == REMEDY_FILEINFO_RULE) {
+                    r = _("rpminspect is expecting a fileinfo rule from the vendor data package for this file. Usually this means the file carries a non-standard set of permissions (e.g., setuid) which is a condition where rpminspect would check the fileinfo list to ensure the package conforms to the vendor rules. To remedy, add a fileinfo rule for this file to the vendor data package under the appropriate product release file.");
+                } else if (id == REMEDY_FILESIZE_BECAME_EMPTY) {
+                    r = _("A previously non-empty file is now empty.  Make sure this change is intended and fix the package space file if necessary.");
+                } else if (id == REMEDY_FILESIZE_BECAME_NOT_EMPTY) {
+                    r = _("A previously empty file is no longer empty.  Make sure this change is intended and fix the package spec file if necessary.");
+                } else if (id == REMEDY_FILESIZE_GREW) {
+                    r = _("A file grew by a noticeable amount.  Ensure this change is intended.  If it is, you can adjust the filesize inspection settings in the rpminspect.yaml file.");
+                } else if (id == REMEDY_FILESIZE_SHRANK) {
+                    r = _("A file shrank by a noticeable amount.  Ensure this change is intended.  If it is, you can adjust the filesize inspection settings in the rpminspect.yaml file.");
+                } else if (id == REMEDY_FILE_PATHS) {
+                    r = _("Remove forbidden path references from the indicated line in the %files section.  In many cases you can use RPM macros to specify path locations.  See the RPM documentation or distribution package maintainer guide for more information.");
+                } else if (id == REMEDY_INVALID_BOOLEAN) {
+                    r = _("The License tag contains SPDX license identifiers.  When SPDX identifiers are used, the boolean joining terms must be written in all capital letters per the spec.  The actual SPDX identifiers are case-insensitive.  It is only the boolean terms that must be in all capital letters.");
+                } else if (id == REMEDY_JAVABYTECODE) {
+                    r = _("The Java bytecode version for one or more class files in the build was not met for the product release.  Ensure you are using the correct JDK for the build.");
+                } else if (id == REMEDY_KMIDIFF) {
+                    r = _("Kernel Module Interface introduced during maintenance updates can lead to problems for users.  See the libabigail documentation and the distribution KMI policy to determine if this detected change is allowed.");
+                } else if (id == REMEDY_KMOD_ALIAS) {
+                    r = _("Kernel module device aliases changed between builds.  This may present usability problems for users if module device aliases changed in a maintenance update.");
+                } else if (id == REMEDY_KMOD_DEPS) {
+                    r = _("Kernel module dependencies changed between builds.  This may present usability problems for users if module dependencies changed in a maintenance update.");
+                } else if (id == REMEDY_KMOD_PARM) {
+                    r = _("Kernel module parameters were removed between builds.  This may present usability problems for users if module parameters were removed in a maintenance update.");
+                } else if (id == REMEDY_LICENSEDB) {
+                    r = _("Make sure the licensedb setting in the rpminspect configuration is set to a valid licensedb file.  This is also commonly due to a missing vendor specific rpminspect-data package on the system.");
+                } else if (id == REMEDY_LICENSE) {
+                    r = _("The License tag must contain an approved license string as defined by the distribution (e.g., GPLv2+).  If the license in question is approved, the license database needs updating in the rpminspect-data package.");
+                } else if (id == REMEDY_LOSTPAYLOAD) {
+                    r = _("Check to see if you eliminated a subpackage but still have the %package and/or the %files section for it.");
+                } else if (id == REMEDY_LTO) {
+                    r = _("ELF .o and .a files should not carry LTO (Link Time Optimization) bytecode.  Make sure you have stripped LTO bytecode from those files at install time.");
+                } else if (id == REMEDY_MAN_ERRORS) {
+                    r = _("Correct the errors in the man page as reported by the libmandoc parser.");
+                } else if (id == REMEDY_MAN_PATH) {
+                    r = _("Correct the installation path for the man page. Man pages must be installed in the directory beneath /usr/share/man that matches the section number of the page.");
+                } else if (id == REMEDY_MODULARITY_LABEL) {
+                    r = _("This package is part of a module but is missing the %{modularitylabel} header tag.  Add this as a %define in the spec file and rebuild.");
+                } else if (id == REMEDY_MODULARITY_RELEASE) {
+                    r = _("This package is part of a module but lacks a conformant Release tag value.  A Release tag in a modular RPM needs to carry a substring that is more specific than a major release dist tag (e.g., el8.9.0 rather than el8) and must carry '+module' as a substring before that specific dist tag.");
+                } else if (id == REMEDY_MODULARITY_STATIC_CONTEXT) {
+                    r = _("This build either contains a valid or invalid /data/static_context setting.  Refer to the module rules for the product you are building to determine what the setting should be.  The rpminspect configuration settings also set the rules determining if the /data/static_context setting is required, forbidden, or recommend.");
+                } else if (id == REMEDY_MOVEDFILES) {
+                    r = _("Unexpected file moves were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file moves between builds.");
+                } else if (id == REMEDY_OWNERSHIP_BIN_GROUP) {
+                    r = _("Bin path files must be owned by the bin_group set in the rpminspect configuration, which is usually root. If this ownership is expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
+                } else if (id == REMEDY_OWNERSHIP_BIN_OWNER) {
+                    r = _("Bin path files must be owned by the bin_owner set in the rpminspect configuration, which is usually root. If this ownership is expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
+                } else if (id == REMEDY_OWNERSHIP_CHANGED) {
+                    r = _("Verify the ownership changes are expected. If not, adjust the package build process to set correct owner and group information. If expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
+                } else if (id == REMEDY_OWNERSHIP_DEFATTR) {
+                    r = _("Make sure the %files section includes the %defattr macro. If these permissions are expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
+                } else if (id == REMEDY_OWNERSHIP_IWGRP) {
+                    r = _("Either chgrp the file to the bin_group set in the rpminspect configuration or remove the group write bit on the file (chmod g-w). If this ownership is expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
+                } else if (id == REMEDY_OWNERSHIP_IXOTH) {
+                    r = _("Either chgrp the file to the bin_group set in the rpminspect configuration or remove the world execute bit on the file (chmod o-x). If this ownership is expected, update the fileinfo exception list for this product release and send a patch to the project that owns the rpminspect data files.");
+                } else if (id == REMEDY_PATCHES_CORRUPT) {
+                    r = _("An invalid patch file was found.  This is usually the result of generating a collection of patches by comparing two trees.  When files disappear that can lead to zero length patches in the resulting collection.  Check to see if the source package has any zero length or otherwise invalid patches and correct the problem.");
+                } else if (id == REMEDY_PATCHES_MISMATCHED_MACRO) {
+                    r = _("The named patch is defined but is mismatched by number with the %patch macro.  Make sure all numbered patches have corresponding %patch macros.  For example, Patch47 needs to have either a '%patch 47', '%patch -P 47', '%patch -P47', or '%patch47' macro.");
+                } else if (id == REMEDY_PATCHES_MISSING_MACRO) {
+                    r = _("The named patch is defined in the source RPM header (this means it has a PatchN: definition in the spec file) but is not applied anywhere in the spec file.  It is missing a corresponding %patch macro and the spec file lacks the %autosetup or %autopatch macros.  You can fix this by adding the appropriate %patch macro in the spec file (usually in the %prep section).  The number specified with the %patch macro corresponds to the number used to define the patch at the top of the spec file.  So Patch47 is applied with either a '%patch 47', '%patch -P 47', '%patch -P47', or '%patch47' macro.");
+                } else if (id == REMEDY_PATCHES_UNHANDLED_PATCH) {
+                    r = _("The defined patch file is not something rpminspect can handle.  This is likely a bug and should be reported to the upstream rpminspect project.");
+                } else if (id == REMEDY_PATHMIGRATION) {
+                    r = _("Files should not be installed in old directory names.  Modify the package to install the affected file to the preferred directory.");
+                } else if (id == REMEDY_POLITICS) {
+                    r = _("A file with potential politically sensitive content was found in the package.  If this file is permitted, it should be added to the rpminspect vendor data package for the product.  Modify the politics allow/deny list file for this product release and send a patch to the project that owns the rpminspect data files.");
+                } else if (id == REMEDY_REMOVEDFILES) {
+                    r = _("Unexpected file removals were found.  Verify these changes are correct.  If they are not, adjust the build to prevent the file removals between builds.");
+                } else if (id == REMEDY_RPMDEPS_CHANGED) {
+                    r = _("A dependency listed in the before build changed to the indicated dependency in the after build.  If this is a VERIFY result, it means rpminspect noticed the change in what it considers a maintenance update in a package.  An INFO result means it noticed this change, but deems it ok because it is comparing a rebased build.");
+                } else if (id == REMEDY_RPMDEPS_EPOCH) {
+                    r = _("The package has an Epoch value greater than zero, but the explicit subpackage dependencies are not consistently using it.  For the dependency reported, the '= %{version}-%{release}' needs to change to '= %{epoch}:%{version}-%{release}' to capture the package Epoch in the dependency.");
+                } else if (id == REMEDY_RPMDEPS_EXPLICIT) {
+                    r = _("Add the indicated explicit Requires to the spec file for the named subpackage.  Subpackages depending on shared libraries in another subpackage must carry an explicit 'Requires: SUBPACKAGE_NAME = %{version}-%{release}' in the spec file.");
+                } else if (id == REMEDY_RPMDEPS_EXPLICIT_EPOCH) {
+                    r = _("Add the indicated explicit Requires to the spec file for the named subpackage.  Subpackages depending on shared libraries in another subpackage must carry an explicit 'Requires: SUBPACKAGE_NAME = %{epoch}:%{version}-%{release}' in the spec file.");
+                } else if (id == REMEDY_RPMDEPS_GAINED) {
+                    r = _("A new dependency is seen in the after build that was not present in the before build.  If this is a VERIFY result, it means rpminspect noticed the change in what it considers a maintenance update in a package.  An INFO result means it noticed this change, but deems it ok because it is comparing a rebased build.");
+                } else if (id == REMEDY_RPMDEPS_LOST) {
+                    r = _("A dependency seen in the before build is not seen in the after build meaning it was removed or lost.  If this is a VERIFY result, it means rpminspect noticed the change in what it considers a maintenance update in a package.  An INFO result means it noticed this change, but deems it ok because it is comparing a rebased build.");
+                } else if (id == REMEDY_RPMDEPS_MACROS) {
+                    r = _("Unexpanded RPM spec file macros were found in the noted dependency rule.  Check the spec file for this dependency and ensure you have not misspelled a macro or used a macro name that does not exist.");
+                } else if (id == REMEDY_RPMDEPS_MULTIPLE) {
+                    r = _("Check subpackage %files sections and explicit Provides statements.  Only one subpackage should provide a given shared library.  Shared library names are automatically added as Provides, so there is no need to specify them in the spec file but you do need to make sure only one subpackage is packaging up the shared library in question.");
+                } else if (id == REMEDY_RUNPATH_BOTH) {
+                    r = _("Both DT_RPATH and DT_RUNPATH properties were found in an ELF shared object.  This indicates a linker error and should not happen.  ELF objects should only carry DT_RPATH or DT_RUNPATH, never both.");
+                } else if (id == REMEDY_RUNPATH) {
+                    r = _("Either DT_RPATH or DT_RUNPATH properties were found on ELF shared objects in this package.  The use of DT_RPATH and DT_RUNPATH is discouraged except in certain situations.  Check to see that you are disabling rpath during the %build stage of the spec file.  If you are unable to do this easily, you can try using a program such as patchelf to remove these properties from the ELF files.");
+                } else if (id == REMEDY_SHELLSYNTAX_BAD) {
+                    r = _("The referenced shell script is invalid. Consider debugging it with the '-n' option on the shell to find and fix the problem.");
+                } else if (id == REMEDY_SHELLSYNTAX) {
+                    r = _("Consult the shell documentation for proper syntax.");
+                } else if (id == REMEDY_SHELLSYNTAX_GAINED_SHELL) {
+                    r = _("The file referenced was not a known shell script in the before build but is now a shell script in the after build.");
+                } else if (id == REMEDY_SPECNAME) {
+                    r = _("The spec file name does not match the expected NAME.spec format.  Rename the spec file to conform to this policy.");
+                } else if (id == REMEDY_SUBPACKAGES_GAIN) {
+                    r = _("A new subpackage has appeared in the after build.  This may indicate progress in the world of computing.");
+                } else if (id == REMEDY_SUBPACKAGES_LOST) {
+                    r = _("A subpackage present in the before build is now missing in the after build.  This may be deliberate, but check to make sure you have correct syntax defining the subpackage in the spec file.");
+                } else if (id == REMEDY_SYMLINKS_DIRECTORY) {
+                    r = _("Make sure symlinks point to a valid destination in one of the subpackages of the build; dangling symlinks are not allowed.  If you are comparing builds and have a non-symlink turn in to a symlink, ensure this is deliberate.  NOTE:  You cannot turn a directory in to a symlink due to RPM limitations.  If you absolutely must do that, make sure you include the %pretrans scriptlet for replacing a directory.  See the packaging guidelines for 'Scriptlet to replace a directory' for more information.");
+                } else if (id == REMEDY_SYMLINKS) {
+                    r = _("Make sure symlinks point to a valid destination in one of the subpackages of the build; dangling symlinks are not allowed.  If you are comparing builds and have a non-symlink turn in to a symlink, ensure this is deliberate.  NOTE:  You cannot turn a directory in to a symlink due to RPM limitations.");
+                } else if (id == REMEDY_TYPES) {
+                    r = _("In many cases the changing MIME type is deliberate.  Verify that the change is intended and if necessary fix the spec file so the correct file is included in the built package.");
+                } else if (id == REMEDY_UDEVRULES) {
+                    r = _("Refer to the udev documentation at https://www.freedesktop.org/software/systemd/man/udev.html for help correcting the errors and warnings.");
+                } else if (id == REMEDY_UNAPPROVED_LICENSE) {
+                    r = _("The specified license abbreviation is not listed as approved in the license database.  The license database is specified in the rpminspect configuration file.  Check this file and send a pull request to the appropriate upstream project to update the database.  If the license is listed in the database but marked unapproved, you may need to work with the legal team regarding options for this software.");
+                } else if (id == REMEDY_UNICODE_PREP_FAILED) {
+                    r = _("The %prep section of the spec file could not be executed for some reason.  This usually results from a failure in librpmbuild, which is usually tied to archive extraction problems or the filesystem changing while rpminspect is running.  A common cause is removal of the working directory while the program is executing.");
+                } else if (id == REMEDY_UNICODE) {
+                    r = _("The rpminspect configuration file contains a list of forbidden Unicode code points.  One was found in the extracted and patched source tree or in one of the text source files in the source RPM.  Either remove this code point or discuss the situation with the Product Security Team to determine the correct course of action.");
+                } else if (id == REMEDY_UPSTREAM) {
+                    r = _("Unexpected changed source archive content. The version of the package did not change between builds, but the source archive content did. This may be deliberate, but needs inspection. If this change is expected, update the rebaseable exception list for this product release and send a patch to the project that owns the rpminspect data files.");
+                } else if (id == REMEDY_VENDOR) {
+                    r = _("Change the string specified on the 'Vendor:' line in the spec file.");
+                } else if (id == REMEDY_VIRUS) {
+                    r = _("ClamAV has found a virus in the named file.  This may be a false positive, but you should manually inspect the file in question to ensure it is clean.  This may be a problem with the ClamAV database or detection.  If you are sure the file in question is clean, please file a bug with rpminspect for further help.");
+                } else if (id == REMEDY_XML) {
+                    r = _("Correct the reported errors in the XML document.");
+                } else if (id == REMEDY_MIXED_LICENSE_TAGS) {
+                    r = _("The License tag contains mixed used of SPDX and legacy license identifiers.  You must use either all SPDX license identifiers or all legacy license identifiers; you cannot mix the two systems.");
+                }
+            }
+        }
+
+        if (r) {
+            break;
         }
     }
 
-    return NULL;
+    return r;
 }
 
 /*
  * Set a remedy override string from the config file.  Returns true if
  * the remedy identifier was valid, false otherwise.
  */
-bool set_remedy(const char *name, const char *remedy)
+bool set_remedy(const char *name, char *remedy)
 {
     unsigned int i = 0;
 
@@ -232,10 +319,25 @@ bool set_remedy(const char *name, const char *remedy)
 
     for (i = 0; remedies[i].name != NULL; i++) {
         if (!strcmp(remedies[i].name, name)) {
+            free(remedies[i].remedy);
             remedies[i].remedy = remedy;
             return true;
         }
     }
 
     return false;
+}
+
+/*
+ * Any remedy strings that were read in from config files need to be
+ * freed before exit.
+ */
+void free_remedy_strings(void) {
+    unsigned int i = 0;
+
+    for (i = 0; remedies[i].name != NULL; i++) {
+        free(remedies[i].remedy);
+    }
+
+    return;
 }

--- a/lib/results.c
+++ b/lib/results.c
@@ -19,7 +19,7 @@ void init_result_params(struct result_params *params)
     params->header = NULL;
     params->msg = NULL;
     params->details = NULL;
-    params->remedy = NULL;
+    params->remedy = 0;
     params->verb = VERB_NIL;
     params->noun = NULL;
     params->arch = NULL;
@@ -84,7 +84,7 @@ void debug_print_result(const results_entry_t *result)
     DEBUG_PRINT("      header=|%s|\n", result->header ? result->header : "(null)");
     DEBUG_PRINT("         msg=|%s|\n", result->msg ? result->msg : "(null)");
     DEBUG_PRINT("     details=|%s|\n", result->details ? result->details : "(null)");
-    DEBUG_PRINT("      remedy=|%s|\n", result->remedy ? result->remedy : "(null)");
+    DEBUG_PRINT("      remedy=|%s|\n", result->remedy ? get_remedy(result->remedy) : "");
     DEBUG_PRINT("        verb=|%s|\n", strverb(result->verb));
     DEBUG_PRINT("        noun=|%s|\n", result->noun ? result->noun : "(noun)");
     DEBUG_PRINT("        arch=|%s|\n", result->arch ? result->arch : "(arch)");
@@ -130,10 +130,7 @@ void add_result_entry(results_t **results, struct result_params *params)
         entry->details = strdup(params->details);
     }
 
-    if (params->remedy != NULL) {
-        entry->remedy = strdup(params->remedy);
-    }
-
+    entry->remedy = params->remedy;
     entry->verb = params->verb;
 
     if (params->noun != NULL) {


### PR DESCRIPTION
1) Make sure unapproved licenses are reported as such

Ran in to a problem where unapproved licenses were showing up as approved.  Not good.

2) Refactor how remedy strings are handled in librpminspect

If a config file provided remedy string overrides, these were getting lost and we hit a NULL pointer dereference in the reporting.  Refactored how remedy strings are handled with the defaults and then the user overrides.  We now get the expected remedy string in the results.