### PR TITLE
[lib] Support SPDX 3.0 expression specification

### DIFF
--- a/include/internal/callbacks.h
+++ b/include/internal/callbacks.h
@@ -33,6 +33,7 @@ typedef struct {
 
 /* Context structure for lic_cb() in lib/inspect_license.c. */
 typedef struct {
+    struct rpminspect *ri;
     parser_plugin *p;
     parser_context *db;
     const char *lic;

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -193,6 +193,8 @@ string_list_t *strsplit(const char *, const char *);
 const char *strtype(const mode_t mode);
 char *strshorten(const char *s, size_t width);
 char *strtrim(char *s);
+bool isupperstr(const char *s);
+bool islowerstr(const char *s);
 
 /**
  * @brief Return descriptive string for the given exit code.

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -697,3 +697,37 @@ char *strtrim(char *s)
 
     return r;
 }
+
+/*
+ * Returns true if the given string is all uppercase, false otherwise.
+ * Non-alpha characters are ignored.
+ */
+bool isupperstr(const char *s)
+{
+    while (*s != '\0') {
+        if (isalpha(*s) && (isupper(*s) == 0)) {
+            return false;
+        }
+
+        s++;
+    }
+
+    return true;
+}
+
+/*
+ * Returns true if the given string is all lowercase, false otherwise.
+ * Non-alpha characters are ignored.
+ */
+bool islowerstr(const char *s)
+{
+    while (*s != '\0') {
+        if (isalpha(*s) && (islower(*s) == 0)) {
+            return false;
+        }
+
+        s++;
+    }
+
+    return true;
+}

--- a/test/data/licenses/test.json
+++ b/test/data/licenses/test.json
@@ -3,31 +3,31 @@
     "approved": "yes",
     "fedora_abbrev": "GPLv2",
     "fedora_name": "GNU General Public License v2.0 only",
-    "spdx_abbrev": "GPL-2.0",
+    "spdx_abbrev": "GPL-2.0-only",
   },
   "1": {
     "approved": "yes",
     "fedora_abbrev": "GPLv2+",
     "fedora_name": "GNU General Public License v2.0 or later",
-    "spdx_abbrev": "GPL-2.0+",
+    "spdx_abbrev": "GPL-2.0-or-later",
   },
   "2": {
     "approved": "yes",
     "fedora_abbrev": "GPLv2+ with exceptions",
     "fedora_name": "GNU General Public License v2.0 or later, with font embedding exception",
-    "spdx_abbrev": "",
+    "spdx_abbrev": "GPL-2.0-or-later WITH Exceptions",
   },
   "3": {
     "approved": "yes",
     "fedora_abbrev": "GPLv3",
     "fedora_name": "GNU General Public License v3.0 only",
-    "spdx_abbrev": "GPL-3.0",
+    "spdx_abbrev": "GPL-3.0-only",
   },
   "4": {
     "approved": "yes",
     "fedora_abbrev": "GPLv3+",
     "fedora_name": "GNU General Public License v3.0 or later",
-    "spdx_abbrev": "GPL-3.0+",
+    "spdx_abbrev": "GPL-3.0-or-later",
   },
   "5": {
     "approved": "yes",
@@ -40,12 +40,6 @@
     "fedora_abbrev": "ASL 2.0",
     "fedora_name": "Apache Software License 2.0",
     "spdx_abbrev": "Apache-2.0",
-  },
-  "7": {
-    "approved": "no",
-    "fedora_abbrev": "",
-    "fedora_name": "Apple Public Source License 1.2",
-    "spdx_abbrev": "APSL-1.2",
   },
   "8": {
     "approved": "yes",
@@ -196,5 +190,14 @@
     "fedora_abbrev": "Python",
     "fedora_name": "Python License",
     "spdx_abbrev": "Python-2.0.1"
-  }
+  },
+  "27": {
+    "license": {
+      "expression": "GPL-3.0-or-later WITH Exceptions",
+      "status": [
+        "allowed"
+      ],
+    },
+    "fedora": {}
+  },
 }

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -540,3 +540,115 @@ class ValidCompoundSPDXLicenseExpressionDualKoji(TestKoji):
         self.inspection = "license"
         self.result = "INFO"
         self.waiver_auth = "Not Waivable"
+
+
+# Valid license using 'WITH'
+class ValidLicenseTagWITHKeywordSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("GPL-3.0-or-later WITH Exceptions")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidLicenseTagWITHKeywordRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("GPL-3.0-or-later WITH Exceptions")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidLicenseTagWITHKeywordKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("GPL-3.0-or-later WITH Exceptions")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# Valid license using 'with'
+class ValidLicenseTagwithKeywordSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("GPL-3.0-or-later with Exceptions")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidLicenseTagwithKeywordRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("GPL-3.0-or-later with Exceptions")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidLicenseTagwithKeywordKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("GPL-3.0-or-later with Exceptions")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# Valid license using 'WITH' and combined with another license
+class ValidMultiLicenseTagWITHKeywordSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT AND GPL-3.0-or-later WITH Exceptions")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidMultiLicenseTagWITHKeywordRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT AND GPL-2.0-or-later WITH Exceptions")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+class ValidMultiLicenseTagWITHKeywordKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT AND GPL-2.0-or-later WITH Exceptions")
+        self.inspection = "license"
+        self.result = "INFO"
+        self.waiver_auth = "Not Waivable"
+
+
+# Invalid SPDX capitalization for and, or, with
+class InvalidSPDXCapitalizationSRPM(TestSRPM):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT aNd GPL-2.0-or-later With Exceptions")
+        self.inspection = "license"
+        self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
+
+
+class InvalidSPDXCapitalizationRPMs(TestRPMs):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT aNd GPL-2.0-or-later With Exceptions")
+        self.inspection = "license"
+        self.result = "BAD"
+        self.waiver_auth = "Not Waivable"
+
+
+class InvalidSPDXCapitalizationKoji(TestKoji):
+    def setUp(self):
+        super().setUp()
+        self.rpm.addLicense("MIT aNd GPL-2.0-or-later With Exceptions")
+        self.inspection = "license"
+        self.result = "BAD"
+        self.waiver_auth = "Not Waivable"


### PR DESCRIPTION
The main thing is the special keywords: AND, OR, WITH must be written in all uppercase or all lowercase while the actual license tokens can be in any case.  This patch takes care to deal with our license database where we have compound expressions that are approved and not just individual SPDX tokens.  Use of incorrect case for special keywords is reported as well as the license expression being reported as unapproved.

Fixes: #1447