### PR TITLE
[lib] Drop FNM_PATHNAME for path matching from rule files

### DIFF
--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -279,7 +279,7 @@ bool match_fileinfo_group(struct rpminspect *ri, const rpmfile_entry_t *file, co
 caps_filelist_entry_t *get_caps_entry(struct rpminspect *ri, const char *pkg, const char *filepath)
 {
     bool found = false;
-    int flags = FNM_NOESCAPE | FNM_PATHNAME;
+    int flags = FNM_NOESCAPE;
     caps_entry_t *entry = NULL;
     caps_filelist_entry_t *flentry = NULL;
 

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -199,7 +199,7 @@ bool match_path(const char *pattern, const char *root, const char *path)
 {
     bool match = false;
     int r = 0;
-    int flags = FNM_NOESCAPE | FNM_PATHNAME;
+    int flags = FNM_NOESCAPE;
     int gflags = GLOB_NOSORT;
     char globpath[PATH_MAX + 1];
     char *globsub = NULL;

--- a/lib/secrule.c
+++ b/lib/secrule.c
@@ -20,7 +20,7 @@ security_entry_t *get_secrule_by_path(struct rpminspect *ri, const rpmfile_entry
     const char *version = NULL;
     const char *release = NULL;
     security_entry_t *sentry = NULL;
-    int flags = FNM_NOESCAPE | FNM_PATHNAME;
+    int flags = FNM_NOESCAPE;
     int w = 0;
     int x = 0;
     int y = 0;


### PR DESCRIPTION
rpminspect has a series of rule files with per-file rules.  Files can be specified with shell-style globbing syntax.  Internally rpminspect uses both fnmatch(3) and glob(3) to match paths to these rule definitions.  When using fnmatch(), rpminspect set the FNM_PATHNAME flag.  When this flag is set, slashes are only matched with explicit slashes in the pattern.  They are not matched by as asterisk or question mark.  Unsetting this flag causes the matching to be more greedy and an asterisk now can consume many levels of subdirectories.

Note this is opposite of typical shell behavior, but may work fine for the purposes of rpminspect per-file rule pattern matching.  If this becomes too much of a problem and we cannot get around it with more explicit rule definitions then I may need to implement something like rsync's '**' matching for directories.  I would like to avoid doing that if at all possible.

Fixes: #1451