### PR TITLE
[ci] Uninstall openssl-fips-provider-so in the RHEL UBI9 test environ…

### DIFF
--- a/.github/workflows/ubi.yml
+++ b/.github/workflows/ubi.yml
@@ -62,7 +62,7 @@ jobs:
                           done
 
                           # Avoid package conflicts
-                          rpm -e --nodeps openssl-fips-provider
+                          rpm -e --nodeps openssl-fips-provider openssl-fips-provider-so
 
                           # Upgrade things
                           dnf upgrade -y


### PR DESCRIPTION
…ment

We do not need this package installed to build and test rpminspect. Previously it was just openssl-fips-provider, but now there are two packages that we have to remove.