### PR TITLE
[fix] Match 32-bit x86 RPMs when performing inspections

### DIFF
--- a/lib/arches.c
+++ b/lib/arches.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <fnmatch.h>
 
 #include "rpminspect.h"
 
@@ -56,6 +57,8 @@ void init_arches(struct rpminspect *ri)
  */
 bool allowed_arch(const struct rpminspect *ri, const char *rpmarch)
 {
+    string_entry_t *arch = NULL;
+
     assert(ri != NULL);
     assert(rpmarch != NULL);
 
@@ -63,5 +66,15 @@ bool allowed_arch(const struct rpminspect *ri, const char *rpmarch)
         return true;
     }
 
-    return list_contains(ri->arches, rpmarch);
+    if (list_contains(ri->arches, rpmarch)) {
+        return true;
+    }
+
+    TAILQ_FOREACH(arch, ri->arches, items) {
+        if (!fnmatch(arch->data, rpmarch, 0)) {
+            return true;
+        }
+    }
+
+    return false;
 }


### PR DESCRIPTION
Sometimes a build may place i686 RPMs in an i386 subdirectory. rpminspect handles that using fnmatch().  In some cases the RPMs would be downloaded, but then skipped in inspections because fnmatch() was not used.  This patch fixes that so the i686 packages are included in inspections even if they appear in an i386 subdirectory.

Fixes: #1464