### PR TITLE
[fix] Add extra guards for hardlink handling in extract_rpm()

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -341,7 +341,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         archive_entry_set_perm(entry, archive_perm);
 
         /* If this is a hard link, update the hardlink destination path */
-        if (file_entry->st_nlink > 1) {
+        if (file_entry->st_nlink > 1 && archive_entry_hardlink(entry) != NULL) {
             xasprintf(&hardlinkpath, "%s/%s", *output_dir, archive_entry_hardlink(entry));
             archive_entry_set_link(entry, hardlinkpath);
             free(hardlinkpath);


### PR DESCRIPTION
We were solely relying on st_nlink, but we should also check the link destination to make sure it is not NULL.