### PR TITLE
[fix] Prevent duplicate SRPMs in file lists when comparing tasks

### DIFF
--- a/osdeps/fedora-rawhide/pre.sh
+++ b/osdeps/fedora-rawhide/pre.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+
+# Needed in our build scripts
+dnf5 install -y gawk

--- a/osdeps/fedora-rawhide/reqs.txt
+++ b/osdeps/fedora-rawhide/reqs.txt
@@ -9,6 +9,7 @@ dash
 desktop-file-utils
 elfutils-devel
 file-devel
+gawk
 gcc
 gcc-c++
 gcc-plugin-devel

--- a/osdeps/fedora/reqs.txt
+++ b/osdeps/fedora/reqs.txt
@@ -10,6 +10,7 @@ dash
 desktop-file-utils
 elfutils-devel
 file-devel
+gawk
 gcc
 gcovr
 gettext


### PR DESCRIPTION
If you compare one or more Koji tasks that you have not previously downloaded, rpminspect will download the SRPM at least twice.  It is only written to disk once because the path is the same, but you do end up with multiple file entries.  So the upstream inspection fails because there could be 3 SRPMs.  One before and two after, so one of the after build SRPMs fails to peer and that causes the upstream inspection to fail.

This patch cleans up how Koji tasks are downloaded so we only download the SRPM once which then fixes up the upstream inspection.