### PR TITLE
[fix] Check if archive exists before closing it

### DIFF
--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -487,8 +487,12 @@ cleanup:
     free(buf);
     Fclose(gzdi);
     archive_entry_free(entry);
-    archive_write_close(archive);
-    archive_write_free(archive);
+
+    if (archive != NULL) {
+        archive_write_close(archive);
+        archive_write_free(archive);
+    }
+
     rpmfilesFree(files);
     rpmfiFree(fi);
     headerFree(hdr);


### PR DESCRIPTION
archive_write_close does not check whether archive is NULL before dereferencing it. archive may be NULL if extract_rpm_payload fails to open the package or the payload.