### PR TITLE
Add an AI-policy to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,8 @@ The force push is required to your copy since you are rewriting the
 project history to match upstream.  You need to do this on a clean
 repo, so stash anything you are working on and ensure your copy is
 clean.
+
+### AI Policy
+
+As a policy, the rpminspect project does not accept use of generative
+AI in contributions.


### PR DESCRIPTION
(Lifted from rpm's commit:
 https://github.com/rpm-software-management/rpm/commit/2e4b7d7d135c4e5706863e10dffdb1422742de52)

The license of anything AI generated is questionable at best, as is the content itself. Poisoning this well with AI slop is just not acceptable.

The last straw driving us to add this is GitHub now advertising Copilot Agent in each and every ticket in "click here to fix this" style. The last thing we want is "helpful" folken submitting AI generated "fixes".

The times. Sigh.