### PR TITLE
[tst] Adjust test_kmod to account for EXTRA_CFLAGS removal in 6.15

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -76,7 +76,7 @@ jobs:
             # and run the test suite
             - name: Build and run the test suite
               run: |
-                  dnf install -y make
+                  dnf install -y /usr/bin/make /usr/bin/awk
                   make instreqs
                   make debug MESON_OPTIONS="-D with_system_libtoml=true"
                   make check

--- a/test/data/derp-kmod-aliases/Makefile
+++ b/test/data/derp-kmod-aliases/Makefile
@@ -1,0 +1,17 @@
+# KERNEL_BUILD_DIR is a path like /usr/lib/modules/5.6.0/build and is
+# passed in by the test_kmod.py script.
+
+# If you want to build this module manually, run:
+#
+#     make KERNEL_BUILD_DIR=/usr/lib/modules/$(uname -r)/build
+#
+# This assumes you have the kernel development files installed on your
+# system.
+
+obj-m += derp.o
+
+all:
+	$(MAKE) -C $(KERNEL_BUILD_DIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KERNEL_BUILD_DIR) M=$(PWD) clean

--- a/test/data/derp-kmod-aliases/derp.c
+++ b/test/data/derp-kmod-aliases/derp.c
@@ -1,0 +1,93 @@
+/*
+ * derp kernel module
+ * Copyright 2020 David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include <linux/module.h>
+#include <linux/fs.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/proc_fs.h>
+#include <linux/seq_file.h>
+#include <linux/version.h>
+
+MODULE_AUTHOR("David Cantrell <dcantrell@redhat.com>");
+MODULE_DESCRIPTION("derp testing module");
+MODULE_LICENSE("GPL");
+MODULE_VERSION("0.1");
+MODULE_INFO(derp, "derp");
+
+/* For the aliases check, leave this here to match alias wildcards */
+MODULE_ALIAS("pci:v00001425d00000020sv*sd*bc*sc*i*");
+
+static int derp_count = 1;
+static char *derp_text = "derp";
+
+static int derp_proc_show(struct seq_file *m, void *v)
+{
+    int i;
+
+    for (i = 0; i < derp_count; i++) {
+        seq_printf(m, "%s\n", derp_text);
+    }
+
+    return 0;
+}
+
+static int derp_proc_open(struct inode *inode, struct file *file)
+{
+    return single_open(file, derp_proc_show, NULL);
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
+static const struct file_operations derp_proc_fops = {
+    .owner   = THIS_MODULE,
+    .open    = derp_proc_open,
+    .read    = seq_read,
+    .llseek  = seq_lseek,
+    .release = single_release,
+#else
+static const struct proc_ops derp_proc_fops = {
+    .proc_open    = derp_proc_open,
+    .proc_read    = seq_read,
+    .proc_lseek   = seq_lseek,
+    .proc_release = single_release,
+#endif
+};
+
+static int __init derp_init(void)
+{
+    proc_create("derp", 0, NULL, &derp_proc_fops);
+    printk(KERN_INFO "derp activated\n");
+    return 0;
+}
+
+static void __exit derp_exit(void)
+{
+    remove_proc_entry("derp", NULL);
+    printk(KERN_INFO "derp deactivated\n");
+}
+
+module_init(derp_init);
+module_exit(derp_exit);
+
+/* Just some text */
+MODULE_ALIAS("pci:lorem*ipsum");
+
+/* PCI ID wildcard stuff */
+MODULE_ALIAS("pci:v00001425d00000020sv*sd00000001bc*sc*i*");

--- a/test/data/derp-kmod-depends/Makefile
+++ b/test/data/derp-kmod-depends/Makefile
@@ -1,0 +1,17 @@
+# KERNEL_BUILD_DIR is a path like /usr/lib/modules/5.6.0/build and is
+# passed in by the test_kmod.py script.
+
+# If you want to build this module manually, run:
+#
+#     make KERNEL_BUILD_DIR=/usr/lib/modules/$(uname -r)/build
+#
+# This assumes you have the kernel development files installed on your
+# system.
+
+obj-m += derp.o
+
+all:
+	$(MAKE) -C $(KERNEL_BUILD_DIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KERNEL_BUILD_DIR) M=$(PWD) clean

--- a/test/data/derp-kmod-depends/derp.c
+++ b/test/data/derp-kmod-depends/derp.c
@@ -1,0 +1,89 @@
+/*
+ * derp kernel module
+ * Copyright 2020 David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include <linux/module.h>
+#include <linux/fs.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/proc_fs.h>
+#include <linux/seq_file.h>
+#include <linux/version.h>
+
+MODULE_AUTHOR("David Cantrell <dcantrell@redhat.com>");
+MODULE_DESCRIPTION("derp testing module");
+MODULE_LICENSE("GPL");
+MODULE_VERSION("0.1");
+MODULE_INFO(derp, "derp");
+
+/* For the aliases check, leave this here to match alias wildcards */
+MODULE_ALIAS("pci:v00001425d00000020sv*sd*bc*sc*i*");
+
+static int derp_count = 1;
+static char *derp_text = "derp";
+
+static int derp_proc_show(struct seq_file *m, void *v)
+{
+    int i;
+
+    for (i = 0; i < derp_count; i++) {
+        seq_printf(m, "%s\n", derp_text);
+    }
+
+    return 0;
+}
+
+static int derp_proc_open(struct inode *inode, struct file *file)
+{
+    return single_open(file, derp_proc_show, NULL);
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
+static const struct file_operations derp_proc_fops = {
+    .owner   = THIS_MODULE,
+    .open    = derp_proc_open,
+    .read    = seq_read,
+    .llseek  = seq_lseek,
+    .release = single_release,
+#else
+static const struct proc_ops derp_proc_fops = {
+    .proc_open    = derp_proc_open,
+    .proc_read    = seq_read,
+    .proc_lseek   = seq_lseek,
+    .proc_release = single_release,
+#endif
+};
+
+static int __init derp_init(void)
+{
+    proc_create("derp", 0, NULL, &derp_proc_fops);
+    printk(KERN_INFO "derp activated\n");
+    return 0;
+}
+
+static void __exit derp_exit(void)
+{
+    remove_proc_entry("derp", NULL);
+    printk(KERN_INFO "derp deactivated\n");
+}
+
+module_init(derp_init);
+module_exit(derp_exit);
+
+MODULE_SOFTDEP("pre: video");

--- a/test/data/derp-kmod-params/Makefile
+++ b/test/data/derp-kmod-params/Makefile
@@ -1,0 +1,17 @@
+# KERNEL_BUILD_DIR is a path like /usr/lib/modules/5.6.0/build and is
+# passed in by the test_kmod.py script.
+
+# If you want to build this module manually, run:
+#
+#     make KERNEL_BUILD_DIR=/usr/lib/modules/$(uname -r)/build
+#
+# This assumes you have the kernel development files installed on your
+# system.
+
+obj-m += derp.o
+
+all:
+	$(MAKE) -C $(KERNEL_BUILD_DIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KERNEL_BUILD_DIR) M=$(PWD) clean

--- a/test/data/derp-kmod-params/derp.c
+++ b/test/data/derp-kmod-params/derp.c
@@ -1,0 +1,90 @@
+/*
+ * derp kernel module
+ * Copyright 2020 David Cantrell <dcantrell@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include <linux/module.h>
+#include <linux/fs.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/proc_fs.h>
+#include <linux/seq_file.h>
+#include <linux/version.h>
+
+MODULE_AUTHOR("David Cantrell <dcantrell@redhat.com>");
+MODULE_DESCRIPTION("derp testing module");
+MODULE_LICENSE("GPL");
+MODULE_VERSION("0.1");
+MODULE_INFO(derp, "derp");
+
+/* For the aliases check, leave this here to match alias wildcards */
+MODULE_ALIAS("pci:v00001425d00000020sv*sd*bc*sc*i*");
+
+static int derp_count = 1;
+static char *derp_text = "derp";
+
+module_param(derp_count, int, 0660);
+module_param(derp_text, charp, 0660);
+
+static int derp_proc_show(struct seq_file *m, void *v)
+{
+    int i;
+
+    for (i = 0; i < derp_count; i++) {
+        seq_printf(m, "%s\n", derp_text);
+    }
+
+    return 0;
+}
+
+static int derp_proc_open(struct inode *inode, struct file *file)
+{
+    return single_open(file, derp_proc_show, NULL);
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
+static const struct file_operations derp_proc_fops = {
+    .owner   = THIS_MODULE,
+    .open    = derp_proc_open,
+    .read    = seq_read,
+    .llseek  = seq_lseek,
+    .release = single_release,
+#else
+static const struct proc_ops derp_proc_fops = {
+    .proc_open    = derp_proc_open,
+    .proc_read    = seq_read,
+    .proc_lseek   = seq_lseek,
+    .proc_release = single_release,
+#endif
+};
+
+static int __init derp_init(void)
+{
+    proc_create("derp", 0, NULL, &derp_proc_fops);
+    printk(KERN_INFO "derp activated\n");
+    return 0;
+}
+
+static void __exit derp_exit(void)
+{
+    remove_proc_entry("derp", NULL);
+    printk(KERN_INFO "derp deactivated\n");
+}
+
+module_init(derp_init);
+module_exit(derp_exit);

--- a/test/test_kmod.py
+++ b/test/test_kmod.py
@@ -52,15 +52,23 @@ if not have_kernel_devel:
 
 
 # Support functions to build the kernel modules we need
-def build_module(rpminspect, build_ext=None, extra_cflags=None):
+def build_module(rpminspect, build_ext=None):
     build = os.path.dirname(rpminspect)
     srcdir = os.path.realpath(
         os.path.join(os.environ["RPMINSPECT_TEST_DATA_PATH"], "derp-kmod")
     )
 
     if build_ext is None:
+        srcdir = os.path.realpath(
+            os.path.join(os.environ["RPMINSPECT_TEST_DATA_PATH"], "derp-kmod")
+        )
         moddir = os.path.join(build, "derp-kmod")
     else:
+        srcdir = os.path.realpath(
+            os.path.join(
+                os.environ["RPMINSPECT_TEST_DATA_PATH"], "derp-kmod" + build_ext
+            )
+        )
         moddir = os.path.join(build, "derp-kmod" + build_ext)
 
     kmod = os.path.join(moddir, "derp.ko")
@@ -76,17 +84,7 @@ def build_module(rpminspect, build_ext=None, extra_cflags=None):
 
     cwd = os.getcwd()
     os.chdir(moddir)
-
-    if extra_cflags is None:
-        cmd = "make -s KERNEL_BUILD_DIR=" + kernel_build_dir
-    else:
-        cmd = (
-            "make -s KERNEL_BUILD_DIR="
-            + kernel_build_dir
-            + " EXTRA_CFLAGS="
-            + extra_cflags
-        )
-
+    cmd = "make -C " + kernel_build_dir + " M=$(pwd) V=1"
     os.system(cmd)
     os.chdir(cwd)
 
@@ -102,21 +100,15 @@ def get_derp_kmod(rpminspect):
 
 
 def get_derp_kmod_params(rpminspect):
-    return build_module(
-        rpminspect, build_ext="-params", extra_cflags="-D_USE_MODULE_PARAMETERS"
-    )
+    return build_module(rpminspect, build_ext="-params")
 
 
 def get_derp_kmod_depends(rpminspect):
-    return build_module(
-        rpminspect, build_ext="-depends", extra_cflags="-D_USE_MODULE_DEPENDS"
-    )
+    return build_module(rpminspect, build_ext="-depends")
 
 
 def get_derp_kmod_aliases(rpminspect):
-    return build_module(
-        rpminspect, build_ext="-aliases", extra_cflags="-D_USE_MODULE_ALIASES"
-    )
+    return build_module(rpminspect, build_ext="-aliases")
 
 
 ############################


### PR DESCRIPTION
The 6.15 kernel removed the long deprecated EXTRA_CFLAGS (and other) variables so you now need to use other Kbuild syntax.  I just split up the derp testing module in to all the different ones I needed to test so hopefully this is less complicated and just remains simple source for the purposes of test cases.