### PR TITLE
[fix] Properly handle hard links on RPM payload extraction

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -349,7 +349,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         /* If this is a hard link, update the hardlink destination path */
         if (file_entry->st_nlink > 1 && archive_entry_hardlink(entry) != NULL) {
             xasprintf(&hardlinkpath, "%s/%s", *output_dir, archive_entry_hardlink(entry));
-            archive_entry_set_link(entry, hardlinkpath);
+            archive_entry_set_hardlink(entry, hardlinkpath);
             free(hardlinkpath);
         }
 


### PR DESCRIPTION
For some reason this one did not always show up, but I think that may have had something to do with the underlying filesystem (or any layer of emulation).  At any rate, this was a bug and should have been found earlier.  Better late than never!

Fixes: #1475