### PR TITLE
[ci] Set /var/lib/clamav ownership on CentOS 10 CI job

### DIFF
--- a/osdeps/centos10/post.sh
+++ b/osdeps/centos10/post.sh
@@ -2,4 +2,5 @@
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 
 # Update clamav database
+chown clamupdate:clamupdate /var/lib/clamav
 freshclam


### PR DESCRIPTION
For some reason this directory is not owned by clamupdate:clamupdate so freshclam fails.  Run chown before running freshclam.