### PR TITLE
[lib] Make free_string_hash() part of the public API

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -107,6 +107,7 @@ struct rpminspect *xalloc_rpminspect(struct rpminspect *);
 struct rpminspect *init_rpminspect(struct rpminspect *, const char *, const char *);
 
 /* free.c */
+void free_string_hash(string_hash_t *hash);
 void free_string_map(string_map_t *table);
 void free_regex(regex_t *regex);
 void free_rpminspect(struct rpminspect *);

--- a/lib/free.c
+++ b/lib/free.c
@@ -9,24 +9,6 @@
 #include "queue.h"
 #include "rpminspect.h"
 
-static void free_string_hash(string_hash_t *hash)
-{
-    string_hash_t *entry = NULL;
-    string_hash_t *tmp_entry = NULL;
-
-    if (hash == NULL) {
-        return;
-    }
-
-    HASH_ITER(hh, hash, entry, tmp_entry) {
-        HASH_DEL(hash, entry);
-        free(entry->data);
-        free(entry);
-    }
-
-    return;
-}
-
 static void free_string_list_map(string_list_map_t *table)
 {
     string_list_map_t *entry = NULL;
@@ -59,6 +41,24 @@ static void free_deprule_ignore_map(deprule_ignore_map_t *table)
         HASH_DEL(table, entry);
         free_regex(entry->ignore);
         free(entry->pattern);
+        free(entry);
+    }
+
+    return;
+}
+
+void free_string_hash(string_hash_t *hash)
+{
+    string_hash_t *entry = NULL;
+    string_hash_t *tmp_entry = NULL;
+
+    if (hash == NULL) {
+        return;
+    }
+
+    HASH_ITER(hh, hash, entry, tmp_entry) {
+        HASH_DEL(hash, entry);
+        free(entry->data);
         free(entry);
     }
 


### PR DESCRIPTION
free_string_hash() can be used elsewhere and by callers of librpminspect.  I at least need it for an upcoming inspection.