### PR TITLE
[lib] Define PATH_SEP and rename joinpath() to joindelim()

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -36,6 +36,15 @@ extern "C"
  */
 
 /**
+ * @def PATH_SEP
+ *
+ * Path seperator for the filesystem.  This is usually "/" but I have
+ * no idea what the future holds.  Windows spells "/" as "\" and HFS
+ * on Macs spelled it ":".
+ */
+#define PATH_SEP '/'
+
+/**
  * @def DEFAULT_MESSAGE_DIGEST
  *
  * Default message digest to use internally.  The definition comes

--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -511,25 +511,8 @@ bool is_remote_rpm(const char *url);
  */
 char *human_size(const unsigned long int bytes);
 
-/* joinpath.c */
-/**
- * @brief Join path substrings in to a single allocated and normalized
- * path string.  Caller must free this string.
- *
- * Given a list of path components as separate strings, join them in to a
- * correct (but unverified) Unix path.  Extra slashes are removed.  Spaces
- * and other special characters are not escaped.  This function allocates
- * memory for the returned value.  The caller must free this memory when
- * done.
- *
- * Usage: path = joinpath(a, b, c, ..., NULL);
- * (where a, b, and c are char *)
- *
- * @param path One or more strings that form path components.  These
- *             will be joined together and delimited with slashes.
- * @return Allocated path string that the caller must free.
- */
-char *joinpath(const char *path, ...);
+/* joindelim.c */
+char *joindelim(const char delim, const char *s, ...);
 
 /* array.c */
 void array(parser_plugin *p, parser_context *ctx, const char *key1, const char *key2, string_list_t **list);

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -817,8 +817,8 @@ static struct koji_build *get_koji_task_as_build(const struct koji_task *task)
     srpm = strdup(entry->data);
     assert(srpm != NULL);
 
-    if (strrchr(srpm, '/')) {
-        nvr = strrchr(srpm, '/');
+    if (strrchr(srpm, PATH_SEP)) {
+        nvr = strrchr(srpm, PATH_SEP);
         nvr++;
     } else {
         nvr = srpm;

--- a/lib/curl.c
+++ b/lib/curl.c
@@ -47,7 +47,7 @@ static void setup_progress_bar(const char *src)
     /* generate the verbose message string */
     if (src != NULL) {
         /* the basename of the source URL, which is the file name */
-        archive = rindex(src, '/') + 1;
+        archive = rindex(src, PATH_SEP) + 1;
         assert(archive != NULL);
 
         /* we need to shorten the package basename if too wide */
@@ -192,7 +192,7 @@ void curl_get_file(const bool verbose, const char *src, const char *dst)
             curl_easy_setopt(c, CURLOPT_NOPROGRESS, 0L);
             setup_progress_bar(src);
         } else {
-            archive = rindex(src, '/') + 1;
+            archive = rindex(src, PATH_SEP) + 1;
             assert(archive != NULL);
             printf(">>> %s", archive);
         }

--- a/lib/files.c
+++ b/lib/files.c
@@ -186,7 +186,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
     assert(subdir != NULL);
 
     /* Create an output directory for the rpm payload. */
-    *output_dir = joinpath(ri->worksubdir, ROOT_SUBDIR, subdir, get_rpm_header_arch(hdr), NULL);
+    *output_dir = joindelim(PATH_SEP, ri->worksubdir, ROOT_SUBDIR, subdir, get_rpm_header_arch(hdr), NULL);
     assert(*output_dir != NULL);
 
     if (mkdirp(*output_dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == -1) {
@@ -285,8 +285,8 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
         file_entry->rpm_header = hdr;
         file_entry->idx = path_entry->index;
 
-        if (headerIsSource(hdr) && strrchr(archive_path, '/') != NULL) {
-            file_entry->localpath = strdup(strrchr(archive_path, '/'));
+        if (headerIsSource(hdr) && strrchr(archive_path, PATH_SEP) != NULL) {
+            file_entry->localpath = strdup(strrchr(archive_path, PATH_SEP));
         } else {
             file_entry->localpath = strdup(archive_path);
         }
@@ -318,7 +318,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
             if (strprefix(archive_path, "/")) {
                 div = "";
 
-                while (*tmp == '/' && *tmp != '\0') {
+                while (*tmp == PATH_SEP && *tmp != '\0') {
                     tmp++;
                 }
             } else {

--- a/lib/init.c
+++ b/lib/init.c
@@ -1059,7 +1059,7 @@ bool init_fileinfo(struct rpminspect *ri)
                 fnpart = token;
 
                 /* trim leading slashes since we compare to localpath later */
-                while (*token != '/' && *token != '\0') {
+                while (*token != PATH_SEP && *token != '\0') {
                     token++;
                 }
 

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -37,7 +37,7 @@ static void add_header_path(const char *root, const char *arch, pair_list_t **he
     assert(root != NULL);
     assert(arch != NULL);
 
-    incpath = joinpath(root, INCLUDE_DIR, NULL);
+    incpath = joindelim(PATH_SEP, root, INCLUDE_DIR, NULL);
     assert(incpath != NULL);
     memset(&sb, 0, sizeof(sb));
 
@@ -120,7 +120,7 @@ static severity_t check_abi(const severity_t sev, const long int threshold, cons
         } else {
             /* do specific matching on the DSO name */
             TAILQ_FOREACH(dsoentry, entry->dsos, items) {
-                if ((dsoentry->data[0] == '/') && strprefix(path, dsoentry->data)) {
+                if ((dsoentry->data[0] == PATH_SEP) && strprefix(path, dsoentry->data)) {
                     return RESULT_INFO;
                 } else {
                     /* do a soft match against the file basename */
@@ -205,7 +205,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* debug dir1 args */
-    tmp = joinpath(ri->worksubdir, ROOT_SUBDIR, BEFORE_SUBDIR, arch, DEBUG_PATH, NULL);
+    tmp = joindelim(PATH_SEP, ri->worksubdir, ROOT_SUBDIR, BEFORE_SUBDIR, arch, DEBUG_PATH, NULL);
     assert(tmp != NULL);
     cmd = strappend(cmd, " ", ABI_DEBUG_INFO_DIR1, " ", tmp, NULL);
     assert(cmd != NULL);
@@ -222,7 +222,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* debug dir2 args */
-    tmp = joinpath(ri->worksubdir, ROOT_SUBDIR, AFTER_SUBDIR, arch, DEBUG_PATH, NULL);
+    tmp = joindelim(PATH_SEP, ri->worksubdir, ROOT_SUBDIR, AFTER_SUBDIR, arch, DEBUG_PATH, NULL);
     assert(tmp != NULL);
     cmd = strappend(cmd, " ", ABI_DEBUG_INFO_DIR2, " ", tmp, NULL);
     assert(cmd != NULL);

--- a/lib/inspect_addedfiles.c
+++ b/lib/inspect_addedfiles.c
@@ -51,13 +51,13 @@ static bool have_forbidden_directory(const rpmfile_entry_t *file, const char *fo
         }
 
         /* back up the path */
-        tmp = strrchr(local, '/');
+        tmp = strrchr(local, PATH_SEP);
 
         if (tmp == local) {
             break;
         } else {
             *tmp = '\0';
-            tmp = strrchr(full, '/');
+            tmp = strrchr(full, PATH_SEP);
             *tmp = '\0';
         }
     }
@@ -139,15 +139,15 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 subpath = entry->data;
                 localpath = file->localpath;
 
-                /* ensure the paths do not start with '/' */
-                if (*subpath == '/') {
-                    while (*subpath == '/') {
+                /* ensure the paths do not start with PATH_SEP */
+                if (*subpath == PATH_SEP) {
+                    while (*subpath == PATH_SEP) {
                         subpath++;
                     }
                 }
 
-                if (*localpath == '/') {
-                    while (*localpath == '/') {
+                if (*localpath == PATH_SEP) {
+                    while (*localpath == PATH_SEP) {
                         localpath++;
                     }
                 }
@@ -204,7 +204,7 @@ static bool addedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         TAILQ_FOREACH(entry, ri->security_path_prefix, items) {
             subpath = entry->data;
 
-            while (*subpath != '/') {
+            while (*subpath != PATH_SEP) {
                 subpath++;
             }
 

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -77,7 +77,7 @@ static char *build_annocheck_cmd(const char *cmd, const char *opts, const char *
     }
 
     if (debugpath) {
-        tmp = joinpath(debugpath, DEBUG_PATH, NULL);
+        tmp = joindelim(PATH_SEP, debugpath, DEBUG_PATH, NULL);
         r = strappend(r, " --debug-dir=", tmp, NULL);
         free(tmp);
     }

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -145,7 +145,7 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Set the waiver type if this is a file of security concern */
     if (ri->security_path_prefix) {
         TAILQ_FOREACH(entry, ri->security_path_prefix, items) {
-            while (*entry->data != '/') {
+            while (*entry->data != PATH_SEP) {
                 entry->data++;
             }
 
@@ -278,8 +278,8 @@ static bool changedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (exitcode || params.details) {
             if (type) {
                 /* get a reporting type for the message */
-                if (rindex(type, '/')) {
-                    comptype = rindex(type, '/') + 1;
+                if (rindex(type, PATH_SEP)) {
+                    comptype = rindex(type, PATH_SEP) + 1;
                     assert(comptype != NULL);
                 } else {
                     comptype = type;

--- a/lib/inspect_desktop.c
+++ b/lib/inspect_desktop.c
@@ -71,7 +71,7 @@ static int find_file(const char *fpath, __attribute__((unused)) const struct sta
                     continue;
                 }
 
-                if (*entry->data == '/') {
+                if (*entry->data == PATH_SEP) {
                     tmp = strdup(entry->data);
                 } else {
                     /* everything else would be in /usr/bin */

--- a/lib/inspect_kmidiff.c
+++ b/lib/inspect_kmidiff.c
@@ -207,13 +207,13 @@ static bool kmidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     }
 
     /* debug dir args */
-    tmp = joinpath(ri->worksubdir, ROOT_SUBDIR, BEFORE_SUBDIR, arch, DEBUG_PATH, NULL);
+    tmp = joindelim(PATH_SEP, ri->worksubdir, ROOT_SUBDIR, BEFORE_SUBDIR, arch, DEBUG_PATH, NULL);
     assert(tmp != NULL);
     cmd = strappend(cmd, " ", ABI_DEBUG_INFO_DIR1, " ", tmp, NULL);
     assert(cmd != NULL);
     free(tmp);
 
-    tmp = joinpath(ri->worksubdir, ROOT_SUBDIR, AFTER_SUBDIR, arch, DEBUG_PATH, NULL);
+    tmp = joindelim(PATH_SEP, ri->worksubdir, ROOT_SUBDIR, AFTER_SUBDIR, arch, DEBUG_PATH, NULL);
     assert(tmp != NULL);
     cmd = strappend(cmd, " ", ABI_DEBUG_INFO_DIR2, " ", tmp, NULL);
     assert(cmd != NULL);

--- a/lib/inspect_license.c
+++ b/lib/inspect_license.c
@@ -56,7 +56,7 @@ static parser_plugin *read_licensedb(struct rpminspect *ri, const char *db, pars
     assert(db != NULL);
 
     /* build path to license db if necessary */
-    if (db && db[0] == '/') {
+    if (db && db[0] == PATH_SEP) {
         actualdb = strdup(db);
         assert(actualdb != NULL);
     } else {

--- a/lib/inspect_modularity.c
+++ b/lib/inspect_modularity.c
@@ -74,7 +74,7 @@ static bool get_static_context(const char *subdir, const char *build)
     assert(build != NULL);
 
     /* create the build path */
-    path = joinpath(subdir, build, NULL);
+    path = joindelim(PATH_SEP, subdir, build, NULL);
     assert(path != NULL);
 
     /* find the modulemd.txt file and read /data/static_context */

--- a/lib/inspect_pathmigration.c
+++ b/lib/inspect_pathmigration.c
@@ -33,7 +33,7 @@ static bool pathmigration_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         }
 
         TAILQ_FOREACH(entry, ri->pathmigration_excluded_paths, items) {
-            /* ensure the path prefixes end with '/' */
+            /* ensure the path prefixes end with PATH_SEP */
             if (strsuffix(entry->data, "/")) {
                 old = strdup(entry->data);
             } else {

--- a/lib/inspect_removedfiles.c
+++ b/lib/inspect_removedfiles.c
@@ -75,7 +75,7 @@ static bool removedfiles_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     /* Set the waiver type if this is a file of security concern */
     if (ri->security_path_prefix && !rebase) {
         TAILQ_FOREACH(entry, ri->security_path_prefix, items) {
-            while (*entry->data != '/') {
+            while (*entry->data != PATH_SEP) {
                 entry->data++;
             }
 

--- a/lib/inspect_rpmdeps.c
+++ b/lib/inspect_rpmdeps.c
@@ -423,7 +423,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                      * contains the potential_prov's package name.
                      */
                     TAILQ_FOREACH(verify, after_deps, items) {
-                        if (verify->type == TYPE_REQUIRES && *verify->requirement != '/'
+                        if (verify->type == TYPE_REQUIRES && *verify->requirement != PATH_SEP
                             && !strprefix(verify->requirement, SHARED_LIB_PREFIX) && !strstr(verify->requirement, SHARED_LIB_SUFFIX)) {
                             isareq = remove_isa_substring(verify->requirement);
                             assert(isareq != NULL);
@@ -452,7 +452,7 @@ static bool check_explicit_lib_deps(struct rpminspect *ri, Header h, deprule_lis
                                     if (!strcmp(tn, entry->data)) {
                                         TAILQ_FOREACH(verify, peer->after_deprules, items) {
                                             if (verify->type == TYPE_REQUIRES
-                                                && *verify->requirement != '/'
+                                                && *verify->requirement != PATH_SEP
                                                 && !strprefix(verify->requirement, SHARED_LIB_PREFIX) && !strstr(verify->requirement, SHARED_LIB_SUFFIX)) {
                                                 isareq = remove_isa_substring(verify->requirement);
                                                 assert(isareq != NULL);

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -53,7 +53,7 @@ static char *get_shell(const struct rpminspect *ri, const char *fullpath)
         buf[strcspn(buf, "\n")] = '\0';
 
         /* shift over to start to the shell (skip #! and spaces) */
-        while (*buf != '/' && *buf != ' ' && *buf != '\0') {
+        while (*buf != PATH_SEP && *buf != ' ' && *buf != '\0') {
             buf++;
         }
 

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -53,7 +53,7 @@ static bool is_linkdest_reachable(const rpmpeer_t *peers, const char *target, co
         }
 
         /* create the full path to the link destination */
-        tmp = joinpath(peer->after_root, target, NULL);
+        tmp = joindelim(PATH_SEP, peer->after_root, target, NULL);
         assert(tmp != NULL);
 
         if (linkerr != NULL) {
@@ -171,13 +171,13 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
      * Handle absolute symlinks differently so we can check each subpackage.
      * Relative symlinks will be canonicalized in each subpackage.
      */
-    if (*target == '/') {
+    if (*target == PATH_SEP) {
         /* link is absolute */
         /*
          * Trim leading slashes so readlink() can work from the subpackage
          * root directory.
          */
-        while (*target == '/' && *target != '\0') {
+        while (*target == PATH_SEP && *target != '\0') {
             target++;
         }
 
@@ -194,7 +194,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         assert(reltarget != NULL);
 
         while (target && *target != '\0') {
-            if (*target == '/') {
+            if (*target == PATH_SEP) {
                 /* ignore the leading slash */
                 target++;
             } else if (strprefix(target, "./")) {
@@ -218,7 +218,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 return false;
             } else if (strprefix(target, "../")) {
                 /* back up a directory level */
-                tmp = rindex(reltarget, '/');
+                tmp = rindex(reltarget, PATH_SEP);
                 assert(tmp != NULL);
                 *tmp = '\0';
                 tail = tmp;
@@ -235,9 +235,9 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                  * Find the directory separator and make it end-of-string.
                  * Now 'target' points to the first directory element.
                  * Take care to account for the final path element
-                 * where there is no '/' so index() will give us NULL.
+                 * where there is no PATH_SEP so index() will give us NULL.
                  */
-                tmp = index(target, '/');
+                tmp = index(target, PATH_SEP);
 
                 if (tmp != NULL) {
                     *tmp = '\0';
@@ -253,7 +253,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
                 tail = stpcpy(tail, target);
                 assert(tail != NULL);
 
-                /* advance target past the first directory element and '/' */
+                /* advance target past the first directory element and PATH_SEP */
                 target += strlen(target);
 
                 if (tmp != NULL) {
@@ -270,7 +270,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     target = reltarget;
 
     /* drop the leading slashes */
-    while (*target == '/' && *target != '\0') {
+    while (*target == PATH_SEP && *target != '\0') {
         target++;
     }
 

--- a/lib/inspect_unicode.c
+++ b/lib/inspect_unicode.c
@@ -464,7 +464,7 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
         localpath += strlen(build);
 
         /* trim the leading slash */
-        while (*localpath == '/' && *localpath != '\0') {
+        while (*localpath == PATH_SEP && *localpath != '\0') {
             localpath++;
         }
 
@@ -482,7 +482,7 @@ static int validate_file(const char *fpath, __attribute__((unused)) const struct
     }
 
     if (localpath) {
-        while (*localpath == '/' && *localpath != '\0') {
+        while (*localpath == PATH_SEP && *localpath != '\0') {
             localpath++;
         }
     }

--- a/lib/inspect_upstream.c
+++ b/lib/inspect_upstream.c
@@ -29,7 +29,7 @@ static bool is_source(const rpmfile_entry_t *file)
     }
 
     /* The RPM header stores basenames */
-    shortname = rindex(file->fullpath, '/') + 1;
+    shortname = rindex(file->fullpath, PATH_SEP) + 1;
 
     /* See if this file is a Source file */
     if (list_contains(source, shortname)) {

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -78,7 +78,7 @@ librpminspect_sources = [
     'inspect_virus.c',
     'inspect_xml.c',
     'io.c',
-    'joinpath.c',
+    'joindelim.c',
     'koji.c',
     'listfuncs.c',
     'local.c',

--- a/lib/mkdirp.c
+++ b/lib/mkdirp.c
@@ -47,7 +47,7 @@ int mkdirp(const char *path, mode_t mode)
     }
 
     /* handle relative vs. explicit paths, we want explicit */
-    if (*path == '/') {
+    if (*path == PATH_SEP) {
         start = p = strdup(path);
     } else {
         if ((cwd = getcwd(NULL, 0)) == NULL) {
@@ -64,12 +64,12 @@ int mkdirp(const char *path, mode_t mode)
 
     /* handle all the parent directories */
     while (*p != '\0') {
-        if (*p == '/') {
+        if (*p == PATH_SEP) {
             *p = '\0';
             r = stat(start, &sb);
 
             if (r == 0 && S_ISDIR(sb.st_mode)) {
-                *p = '/';
+                *p = PATH_SEP;
                 p++;
                 continue;
             } else if (mkdir(start, mode) == -1) {
@@ -78,7 +78,7 @@ int mkdirp(const char *path, mode_t mode)
                 return -1;
             }
 
-            *p = '/';
+            *p = PATH_SEP;
         }
 
         p++;

--- a/lib/paths.c
+++ b/lib/paths.c
@@ -112,7 +112,7 @@ const char *get_debuginfo_path(struct rpminspect *ri, const rpmfile_entry_t *fil
             tmp = pattern;
 
             if (strsuffix(DEBUG_PATH, "/")) {
-                while (*tmp == '/' && *tmp != '\0') {
+                while (*tmp == PATH_SEP && *tmp != '\0') {
                     tmp++;
                 }
             }
@@ -222,13 +222,13 @@ bool match_path(const char *pattern, const char *root, const char *path)
         return true;
     }
 
-    /* A pattern ending with '/' will match a path prefix */
+    /* A pattern ending with PATH_SEP will match a path prefix */
     if (strsuffix(pattern, "/") && strprefix(path, pattern)) {
         return true;
     }
 
     /*
-     * Also handle the incredibly common case of the trailing '/'
+     * Also handle the incredibly common case of the trailing PATH_SEP
      * where users specify an asterisk after the slash to mean
      * everything below this directory.
      */
@@ -313,7 +313,7 @@ bool match_path(const char *pattern, const char *root, const char *path)
  * @param ri The struct rpminspect for the program.
  * @param inspection The name of the inspection currently running.
  * @param path The relative path to check (i.e., localpath).
- * @param root The root directory, optional (pass NULL to use '/').
+ * @param root The root directory, optional (pass NULL to use PATH_SEP).
  * @return True if path should be ignored, false otherwise.
  */
 bool ignore_path(const struct rpminspect *ri, const char *inspection, const char *path, const char *root)

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -51,8 +51,8 @@ char *find_cmd(const char *cmd)
         return NULL;
     }
 
-    /* if cmd contains a '/', use as-is */
-    if (strchr(cmd, '/')) {
+    /* if cmd contains a PATH_SEP, use as-is */
+    if (strchr(cmd, PATH_SEP)) {
         r = strdup(cmd);
         assert(r != NULL);
         return r;
@@ -95,7 +95,7 @@ char *find_cmd(const char *cmd)
     /* iterate over PATH elements looking for the command */
     TAILQ_FOREACH(entry, path, items) {
         /* try the first directory */
-        candidate = joinpath(entry->data, cmd, NULL);
+        candidate = joindelim(PATH_SEP, entry->data, cmd, NULL);
         assert(candidate != NULL);
 
         /* where is it really? */

--- a/lib/uncompress.c
+++ b/lib/uncompress.c
@@ -73,7 +73,7 @@ char *uncompress_file(struct rpminspect *ri, const char *infile, const char *sub
     free(outfile);
 
     /* create the output file that will be uncompressed */
-    base = rindex(infile, '/') + 1;
+    base = rindex(infile, PATH_SEP) + 1;
     assert(base != NULL);
 
     if (subdir == NULL) {

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -141,7 +141,7 @@ static char *match_product(string_map_t *products, const char *candidate)
 /*
  * Get the product release string by grabbing a possible dist tag from
  * the Release value.  Dist tags begin with '.' and go to the end of the
- * Release value.  Trim any trailing '/' characters in case the user is
+ * Release value.  Trim any trailing PATH_SEP characters in case the user is
  * specifying a build from a local path.
  */
 static char *get_product_release(string_map_t *products, const favor_release_t favor_release, const char *before, const char *after)


### PR DESCRIPTION
Make the joinpath() function a little more generic and make the first parameter be the delimiter.  Define our path separator as PATH_SEP based on the weird idea that maybe in the future we will see a different path separator (or rpminspect will need to run on Windows or something).