### PR TITLE
[lib] Introduce the 'filesmatch' inspection

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -676,25 +676,11 @@ extern "C"
  */
 
 /**
- * @def SPEC_MACRO_DEFINE
- *
- * How macros are defined in spec files.
- */
-#define SPEC_MACRO_DEFINE      "%define"
-
-/**
- * @def SPEC_MACRO_GLOBAL
- *
- * How global macros are defined in spec files.
- */
-#define SPEC_MACRO_GLOBAL      "%global"
-
-/**
  * @def SPEC_MACRO_PATCH
  *
  * The %patch macro used to apply patches.
  */
-#define SPEC_MACRO_PATCH       "%patch"
+#define SPEC_MACRO_PATCH "%patch"
 
 /**
  * @def SPEC_MACRO_PATCH_P_ARG
@@ -705,13 +691,27 @@ extern "C"
 #define SPEC_MACRO_PATCH_P_ARG "-P"
 
 /**
+ * @def SPEC_SECTION_DESCRIPTION
+ *
+ * The package description block.
+ */
+#define SPEC_SECTION_DESCRIPTION "%description"
+
+/**
+ * @def SPEC_SECTION_PACKAGE
+ *
+ * The package block.
+ */
+#define SPEC_SECTION_PACKAGE "%package"
+
+/**
  * @def SPEC_SECTION_PREP
  *
  * Command or series of commands to prepare the software to be built,
  * for example, unpacking the archive in Source0. This directive can
  * contain a shell script.
  */
-#define SPEC_SECTION_PREP      "%prep"
+#define SPEC_SECTION_PREP "%prep"
 
 /**
  * @def SPEC_SECTION_BUILD
@@ -720,7 +720,7 @@ extern "C"
  * into machine code (for compiled languages) or byte code (for some
  * interpreted languages).
  */
-#define SPEC_SECTION_BUILD     "%build"
+#define SPEC_SECTION_BUILD "%build"
 
 /**
  * @def SPEC_SECTION_INSTALL
@@ -734,7 +734,7 @@ extern "C"
  * a package, not when the end-user installs the package. See Working
  * with SPEC files for details.
  */
-#define SPEC_SECTION_INSTALL   "%install"
+#define SPEC_SECTION_INSTALL "%install"
 
 /**
  * @def SPEC_SECTION_CHECK
@@ -742,14 +742,49 @@ extern "C"
  * Command or series of commands to test the software. This normally
  * includes things such as unit tests.
  */
-#define SPEC_SECTION_CHECK     "%check"
+#define SPEC_SECTION_CHECK "%check"
+
+/**
+ * @def SPEC_SECTION_PRE
+ *
+ * The %pre scriptlet block.
+ */
+#define SPEC_SECTION_PRE "%pre"
+
+/**
+ * @def SPEC_SECTION_PREUN
+ *
+ * The %preun scriptlet block.
+ */
+#define SPEC_SECTION_PREUN "%preun"
+
+/**
+ * @def SPEC_SECTION_POST
+ *
+ * The %post scriptlet block.
+ */
+#define SPEC_SECTION_POST "%post"
+
+/**
+ * @def SPEC_SECTION_POSTUN
+ *
+ * The %postun scriptlet block.
+ */
+#define SPEC_SECTION_POSTUN "%postun"
+
+/**
+ * @def SPEC_SECTION_TRIGGERUN
+ *
+ * The %triggerun scriptlet block.
+ */
+#define SPEC_SECTION_TRIGGERUN "%triggerun"
 
 /**
  * @def SPEC_SECTION_FILES
  *
  * How file listings are specified in the spec file.
  */
-#define SPEC_SECTION_FILES     "%files"
+#define SPEC_SECTION_FILES "%files"
 
 /**
  * @def SPEC_SECTION_CHANGELOG
@@ -763,14 +798,14 @@ extern "C"
  *
  * The name of RPMTAG_RELEASE in a spec file.
  */
-#define SPEC_TAG_RELEASE       "Release:"
+#define SPEC_TAG_RELEASE "Release:"
 
 /**
  * @def SPEC_TAG_PATCH
  *
  * The leading text of the RPMTAG_PATCH identifier in a spec file.
  */
-#define SPEC_TAG_PATCH         "Patch"
+#define SPEC_TAG_PATCH "Patch"
 
 /**
  * @def SPEC_DISTTAG
@@ -779,7 +814,7 @@ extern "C"
  * strings.  Common in Fedora Linux and related distributions, but may
  * not be consistently defined in other RPM-based distributions.
  */
-#define SPEC_DISTTAG           "%{?dist}"
+#define SPEC_DISTTAG "%{?dist}"
 
 /**
  * @def SPEC_AUTORELEASE
@@ -787,7 +822,89 @@ extern "C"
  * The Release tag in a spec file may contain this token in place of
  * an explicit release value and SPEC_DISTTAG.
  */
-#define SPEC_AUTORELEASE       "%autorelease"
+#define SPEC_AUTORELEASE "%autorelease"
+
+/**
+ * @def SPEC_FILES_DOC
+ *
+ * The documentation file macro for %files entries.
+ */
+#define SPEC_FILES_DOC "%doc"
+
+/**
+ * @def SPEC_FILES_DOCDIR
+ *
+ * The documentation directory spec file macro.
+ */
+#define SPEC_FILES_DOCDIR "_docdir"
+
+/**
+ * @def SPEC_FILES_LICENSE
+ *
+ * The license file macro for %files entries.
+ */
+#define SPEC_FILES_LICENSE "%license"
+
+/**
+ * @def SPEC_FILES_LICENSEDIR
+ *
+ * The license directory spec file macro.
+ */
+#define SPEC_FILES_LICENSEDIR "_licensedir"
+
+/**
+ * @def SPEC_FILES_ATTR
+ *
+ * The %attr macro for %files list entries.  Used to specify ownership
+ * and permissions for the packaged file specification.
+ */
+#define SPEC_FILES_ATTR "%attr"
+
+/**
+ * @def SPEC_FILES_CONFIG
+ *
+ * The %config macro for %files list entries.  Used to specify actions
+ * for configuration files.
+ */
+#define SPEC_FILES_CONFIG "%config"
+
+/**
+ * @def SPEC_FILES_VERIFY
+ *
+ * A %files macro that instructs RPM specifically how to verify the named
+ * file at install time, removal time, and check time.
+ */
+#define SPEC_FILES_VERIFY "%verify"
+
+/**
+ * @def SPEC_FILES_LANG
+ *
+ * The %lang macro for %files section entries.
+ */
+#define SPEC_FILES_LANG "%lang"
+
+/**
+ * @def SPEC_FILES_CAPS
+ *
+ * The %caps macro for %files section entries.
+ */
+#define SPEC_FILES_CAPS "%caps"
+
+/**
+ * @def SPEC_FILES_DIR
+ *
+ * A %files macro used to specify a directory and everything in it should
+ * be packaged.
+ */
+#define SPEC_FILES_DIR "%dir"
+
+/**
+ * @def SPEC_FILES_EXCLUDE
+ *
+ * A %files macro used to specify a path glob of known build artifacts
+ * that should not be packaged in the built RPM.
+ */
+#define SPEC_FILES_EXCLUDE "%exclude"
 
 /** @} */
 
@@ -811,49 +928,49 @@ extern "C"
  * The rpmbuild(1) top directory.  The directory where all other
  * rpmbuild(1) subdirectories live.
  */
-#define RPMBUILD_TOPDIR        "rpmbuild"
+#define RPMBUILD_TOPDIR "rpmbuild"
 
 /**
  * @def RPMBUILD_BUILDDIR
  *
  * The BUILD subdirectory name under RPMBUILD_TOPDIR.
  */
-#define RPMBUILD_BUILDDIR      "BUILD"
+#define RPMBUILD_BUILDDIR "BUILD"
 
 /**
  * @def RPMBUILD_BUILDROOTDIR
  *
  * The BUILDROOT subdirectory name under RPMBUILD_TOPDIR.
  */
-#define RPMBUILD_BUILDROOTDIR  "BUILDROOT"
+#define RPMBUILD_BUILDROOTDIR "BUILDROOT"
 
 /**
  * @def RPMBUILD_RPMDIR
  *
  * The RPMS subdirectory name under RPMBUILD_TOPDIR.
  */
-#define RPMBUILD_RPMDIR        "RPMS"
+#define RPMBUILD_RPMDIR "RPMS"
 
 /**
  * @def RPMBUILD_SOURCEDIR
  *
  * The SOURCES subdirectory name under RPMBUILD_TOPDIR.
  */
-#define RPMBUILD_SOURCEDIR     "SOURCES"
+#define RPMBUILD_SOURCEDIR "SOURCES"
 
 /**
  * @def RPMBUILD_SPECDIR
  *
  * The SPECS subdirectory name under RPMBUILD_TOPDIR.
  */
-#define RPMBUILD_SPECDIR       "SPECS"
+#define RPMBUILD_SPECDIR "SPECS"
 
 /**
  * @def RPMBUILD_SRPMSDIR
  *
  * The SRPMS subdirectory name under RPMBUILD_TOPDIR.
  */
-#define RPMBUILD_SRPMDIR       "SRPMS"
+#define RPMBUILD_SRPMDIR "SRPMS"
 
 /** @} */
 

--- a/include/inspect.h
+++ b/include/inspect.h
@@ -727,6 +727,17 @@ bool inspect_debuginfo(struct rpminspect *ri);
  */
 bool inspect_udevrules(struct rpminspect *ri);
 
+/**
+ * @brief Perform the 'filesmatch' inspection.
+ *
+ * Perform path glob matching for every file in binary RPMs with the
+ * glob patterns specified in the %files section(s) of the spec file.
+ *
+ * @param ri Pointer to the struct rpminspect for the program.
+ * @return True if the inspection passed, false otherwise.
+ */
+bool inspect_filesmatch(struct rpminspect *ri);
+
 /** @} */
 
 /**
@@ -1031,6 +1042,12 @@ bool inspect_udevrules(struct rpminspect *ri);
  */
 #define INSPECT_UDEVRULES                   (((uint64_t) 1) << 46)
 
+/**
+ * @def INSPECT_FILESMATCH
+ * 'filesmatch' inspection ID.
+ */
+#define INSPECT_FILESMATCH                  (((uint64_t) 1) << 47)
+
 /** @} */
 
 /**
@@ -1331,6 +1348,12 @@ bool inspect_udevrules(struct rpminspect *ri);
  */
 #define NAME_UDEVRULES                      "udevrules"
 
+/**
+ * @def NAME_FILESMATCH
+ * The string "filesmatch"
+ */
+#define NAME_FILESMATCH                     "filesmatch"
+
 /** @} */
 
 /**
@@ -1624,6 +1647,12 @@ bool inspect_udevrules(struct rpminspect *ri);
  * The description for the 'udevrules' inspection.
  */
 #define DESC_UDEVRULES _("Perform syntax check on udev rules files using udevadm verify.")
+
+/**
+ * @def DESC_FILESMATCH
+ * The description for the 'filesmatch' inspection.
+ */
+#define DESC_FILESMATCH _("Match every file path glob(7) specified in the %%files section(s) of the spec file against every file found in the binary RPMs.  Report any discrepancies as a failure.")
 
 /** @} */
 

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -83,7 +83,8 @@ struct inspect inspections[] = {
     { INSPECT_UPSTREAM,      "upstream",      false, false, &inspect_upstream },
     { INSPECT_VIRUS,         "virus",         true,  true,  &inspect_virus },
     { INSPECT_XML,           "xml",           false, true,  &inspect_xml },
-    { 0, NULL, false, false, NULL }
+    { INSPECT_FILESMATCH,    "filesmatch",    false, true,  &inspect_filesmatch },
+    { 0,                     NULL,            false, false, NULL }
 };
 
 /*
@@ -255,6 +256,8 @@ uint64_t inspection_id(const char *name)
         return INSPECT_DEBUGINFO;
     } else if (!strcmp(name, NAME_UDEVRULES)) {
         return INSPECT_UDEVRULES;
+    } else if (!strcmp(name, NAME_FILESMATCH)) {
+        return INSPECT_FILESMATCH;
     } else {
         return INSPECT_NULL;
     }
@@ -366,6 +369,8 @@ const char *inspection_desc(const uint64_t inspection)
             return DESC_DEBUGINFO;
         case INSPECT_UDEVRULES:
             return DESC_UDEVRULES;
+        case INSPECT_FILESMATCH:
+            return DESC_FILESMATCH;
         default:
             return NULL;
     }
@@ -478,6 +483,8 @@ const char *inspection_header_to_desc(const char *header)
         i = INSPECT_DEBUGINFO;
     } else if (!strcmp(header, NAME_UDEVRULES)) {
         i = INSPECT_UDEVRULES;
+    } else if (!strcmp(header, NAME_FILESMATCH)) {
+        i = INSPECT_FILESMATCH;
     }
 
     return inspection_desc(i);

--- a/lib/inspect_filesmatch.c
+++ b/lib/inspect_filesmatch.c
@@ -1,0 +1,371 @@
+/*
+ * Copyright The rpminspect Project Authors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <err.h>
+#include <errno.h>
+#include <assert.h>
+#include <rpm/rpmmacro.h>
+
+#include "rpminspect.h"
+
+/* Globals */
+static bool result = true;
+static string_hash_t *files_globs = NULL;
+static string_hash_t *files_dirs = NULL;
+static string_hash_t *files_excludes = NULL;
+
+enum {
+    FILES_GLOBS = 0,
+    FILES_DIRS = 1,
+    FILES_EXCLUDES = 2
+};
+
+/* Helper function to save strings in a specified hash table */
+static void save_pathspec(const char *s, const int type)
+{
+    string_hash_t *hash = NULL;
+    string_hash_t *entry = NULL;
+    char *expanded = NULL;
+
+    if (s == NULL) {
+        return;
+    }
+
+    /* sometimes we end up with empty strings, ignore */
+    if (strlen(s) == 0) {
+        return;
+    }
+
+    /* alright, we need at least some path separator in a pathspec */
+    if (!strchr(s, PATH_SEP)) {
+        return;
+    }
+
+    /* determine which hash table to use */
+    if (type == FILES_GLOBS) {
+        hash = files_globs;
+    } else if (type == FILES_DIRS) {
+        hash = files_dirs;
+    } else if (type == FILES_EXCLUDES) {
+        hash = files_excludes;
+    }
+
+    /* expand any macros in the string */
+    expanded = calloc(1, BUFSIZ);
+    assert(expanded != NULL);
+
+    if (rpmExpandMacros(NULL, s, &expanded, 0) < 0) {
+        warn("rpmExpandMacros");
+    }
+
+    /* look for the string first */
+    HASH_FIND_STR(hash, s, entry);
+
+    /* if we don't have the string yet, add it to the hash table */
+    if (entry == NULL) {
+        entry = xalloc(sizeof(*entry));
+        assert(entry != NULL);
+        entry->data = strdup(expanded);
+DEBUG_PRINT("type:pathspec: %d:|%s|\n", type, entry->data);
+        HASH_ADD_KEYPTR(hh, hash, entry->data, strlen(entry->data), entry);
+    }
+
+    /* cleanup */
+    free(expanded);
+
+    return;
+}
+
+/*
+ * Trim any leading modifiers on %files entry lines that are not
+ * delimited by spaces from the actual pathspec.  For instance, a line
+ * like this:
+ *
+ *     %config(noreplace)/etc/passwd
+ *
+ * Would have the %config() part trimmed.  In cases where there is a
+ * space between "%config(noreplace)" and "/etc/passwd, the main block
+ * below would handle skipping the modifier.
+ */
+static char *trim_files_modifiers(char *s)
+{
+    char *r = s;
+
+    if (r == NULL) {
+        return NULL;
+    }
+
+    if (strprefix(r, SPEC_FILES_ATTR) ||
+        strprefix(r, SPEC_FILES_CONFIG) ||
+        strprefix(r, SPEC_FILES_VERIFY) ||
+        strprefix(r, SPEC_FILES_LANG) ||
+        strprefix(r, SPEC_FILES_CAPS)) {
+        if (strchr(r, '(') && strchr(r, ')')) {
+            r = strchr(r, ')');
+        }
+
+        while (*r != PATH_SEP && *r != '\0') {
+            *r = ' ';
+            r++;
+        }
+    }
+
+    return r;
+}
+
+/*
+ * Read all of the %files section in spec files and gather the
+ * macro-expanded entries.
+ */
+static void gather_files_entries(struct rpminspect *ri)
+{
+    rpmpeer_entry_t *peer = NULL;
+    rpmfile_entry_t *file = NULL;
+    string_list_t *speclines = NULL;
+    string_entry_t *line = NULL;
+    string_list_t *tokens = NULL;
+    string_entry_t *token = NULL;
+    bool found = false;
+    const char *name = NULL;
+    char *pathspec = NULL;
+    char *entry = NULL;
+    char *prefix = NULL;
+    char *macrofunc = NULL;
+    char *macro = NULL;
+    int type = FILES_GLOBS;
+
+    assert(ri != NULL);
+
+    /* Build the file glob list first */
+    TAILQ_FOREACH(peer, ri->peers, items) {
+        if (!headerIsSource(peer->after_hdr)) {
+            continue;
+        }
+
+        if (peer->after_files == NULL || TAILQ_EMPTY(peer->after_files)) {
+            continue;
+        }
+
+        name = headerGetString(peer->after_hdr, RPMTAG_NAME);
+DEBUG_PRINT("package: %s-%s-%s\n", name, headerGetString(peer->after_hdr, RPMTAG_VERSION), headerGetString(peer->after_hdr, RPMTAG_RELEASE));
+
+        /*
+         * Iterate over the file list of the SRPM and read the spec file.
+         * There should only be one spec file, but if there is a future
+         * with multiple spec files in a single SRPM then I sure hope to
+         * be a USCG licensed captain by then.
+         */
+        TAILQ_FOREACH(file, peer->after_files, items) {
+            /* find the spec file and read the lines */
+            if (strsuffix(file->localpath, SPEC_FILENAME_EXTENSION)) {
+                speclines = read_spec(file->fullpath);
+
+                if (speclines == NULL || TAILQ_EMPTY(speclines)) {
+                    warn("read_spec");
+                    continue;
+                }
+
+                break;
+            }
+        }
+
+        if (speclines == NULL || TAILQ_EMPTY(speclines)) {
+            continue;
+        }
+
+        /* read in all of the glob(7) lines from %files sections */
+        TAILQ_FOREACH(line, speclines, items) {
+            line->data = strtrim(line->data);
+            assert(line->data != NULL);
+            type = FILES_GLOBS;
+
+            /* skip empty lines */
+            if (!strcmp(line->data, "")) {
+                continue;
+            }
+
+            /* when found is true, we are reading %files entries */
+            if (found) {
+                /* we have a glob(7) specification */
+                pathspec = line->data;
+
+                /* look for %files sections and skip other sections */
+                if (strprefix(pathspec, SPEC_SECTION_FILES)) {
+                    /* a subpackage %files section, keep reading */
+                    continue;
+                } else if (strprefix(pathspec, SPEC_SECTION_DESCRIPTION) ||
+                           strprefix(pathspec, SPEC_SECTION_PACKAGE) ||
+                           strprefix(pathspec, SPEC_SECTION_PREP) ||
+                           strprefix(pathspec, SPEC_SECTION_BUILD) ||
+                           strprefix(pathspec, SPEC_SECTION_INSTALL) ||
+                           strprefix(pathspec, SPEC_SECTION_CHECK) ||
+                           strprefix(pathspec, SPEC_SECTION_PRE) ||
+                           strprefix(pathspec, SPEC_SECTION_PREUN) ||
+                           strprefix(pathspec, SPEC_SECTION_POST) ||
+                           strprefix(pathspec, SPEC_SECTION_POSTUN) ||
+                           strprefix(pathspec, SPEC_SECTION_TRIGGERUN) ||
+                           strprefix(pathspec, SPEC_SECTION_CHANGELOG)) {
+                    /* we reached the end of the %files section(s) */
+                    found = false;
+                    break;
+                }
+
+                /* check for %doc and %license and set a prefix accordingly */
+                tokens = strsplit(pathspec, " \t");
+
+                if (list_len(tokens) >= 2) {
+                    token = TAILQ_FIRST(tokens);
+                } else {
+                    token = NULL;
+                }
+
+                if (token && !strcmp(token->data, SPEC_FILES_DOC)) {
+                    /* handle %doc */
+                    macrofunc = SPEC_FILES_DOC;
+                    macro = SPEC_FILES_DOCDIR;
+                } else if (token && !strcmp(token->data, SPEC_FILES_LICENSE)) {
+                    /* handle %licensedir */
+                    macrofunc = SPEC_FILES_LICENSE;
+                    macro = SPEC_FILES_LICENSEDIR;
+                }
+
+                list_free(tokens, free);
+
+                if (macrofunc && macro) {
+                    pathspec += strlen(macrofunc) + 1;
+
+                    while (*pathspec != '\0' && isspace(*pathspec)) {
+                        pathspec++;
+                    }
+
+                    xasprintf(&prefix, "%%{%s}/%s", macro, name);
+                    assert(prefix != NULL);
+
+                    tokens = strsplit(pathspec, " \t");
+                    macrofunc = NULL;
+                    macro = NULL;
+
+                    /* save docs and licenses if we are on one of those lines */
+                    TAILQ_FOREACH(token, tokens, items) {
+                        /* build this entry's path spec */
+                        entry = joindelim(PATH_SEP, prefix, token->data, NULL);
+                        assert(entry != NULL);
+
+                        /* save this glob in the right hash table */
+                        save_pathspec(entry, type);
+
+                        /* cleanup */
+                        free(entry);
+                    }
+
+                    free(prefix);
+                    prefix = NULL;
+                    list_free(tokens, free);
+                    continue;
+                }
+
+                /* now scan horizontally through the line */
+                tokens = strsplit(pathspec, " \t");
+
+                if (tokens != NULL) {
+                    type = FILES_GLOBS;
+
+                    TAILQ_FOREACH(token, tokens, items) {
+                        if (strprefix(token->data, SPEC_FILES_ATTR) ||
+                            strprefix(token->data, SPEC_FILES_CONFIG) ||
+                            strprefix(token->data, SPEC_FILES_VERIFY) ||
+                            strprefix(token->data, SPEC_FILES_LANG) ||
+                            strprefix(token->data, SPEC_FILES_CAPS)) {
+                            /* skip %attr, %config, %verify, %lang, and %caps */
+                            continue;
+                        } else if (strprefix(token->data, SPEC_FILES_DIR)) {
+                            /*
+                             * this is a %dir specification so we
+                             * record it in a different hash table
+                             * because checking actual files in the
+                             * binary RPMs will be checking path
+                             * prefixes against these vs glob matching
+                             */
+                            type = FILES_DIRS;
+                        } else if (strprefix(token->data, SPEC_FILES_EXCLUDE)) {
+                            /*
+                             * this is an %exclude specification which
+                             * is a known glob that *SHOULD NOT* be
+                             * present in built RPMs
+                             */
+                            type = FILES_EXCLUDES;
+                        } else {
+                            /* at this point we should have the pathspec portion */
+                            pathspec = token->data;
+                            break;
+                        }
+                    }
+
+                    /*
+                     * there is a possibility of %files modifiers
+                     * existing without using space delimiters, so
+                     * trim those
+                     */
+                    pathspec = trim_files_modifiers(pathspec);
+
+                    /* trim and leading or trailing whitespace */
+                    pathspec = strtrim(pathspec);
+
+                    if (pathspec == NULL) {
+                        /* no reason to continue if there's nothing here */
+                        continue;
+                    }
+
+                    save_pathspec(pathspec, type);
+
+                    /* cleanup */
+                    list_free(tokens, free);
+                }
+            } else if (!found && strprefix(line->data, SPEC_SECTION_FILES)) {
+                /* we found %files, start reading lines */
+                found = true;
+                continue;
+            }
+        }
+
+        list_free(speclines, free);
+    }
+
+    return;
+}
+
+/*
+ * Main driver for the 'filesmatch' inspection.
+ */
+bool inspect_filesmatch(struct rpminspect *ri)
+{
+    struct result_params params;
+
+    assert(ri != NULL);
+
+    /* Read in all of the %files entries */
+    gather_files_entries(ri);
+
+    /* Set up result parameters */
+    init_result_params(&params);
+    params.header = NAME_FILESMATCH;
+    params.verb = VERB_OK;
+
+    /* Report a single OK message if everything was fine */
+    if (result) {
+        params.severity = RESULT_OK;
+        add_result(ri, &params);
+    }
+
+    /* cleanup */
+    free_string_hash(files_dirs);
+    free_string_hash(files_globs);
+    free_string_hash(files_excludes);
+
+    return result;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -51,6 +51,7 @@ librpminspect_sources = [
     'inspect_emptyrpm.c',
     'inspect_files.c',
     'inspect_filesize.c',
+    'inspect_filesmatch.c',
     'inspect_javabytecode.c',
     'inspect_kmidiff.c',
     'inspect_license.c',


### PR DESCRIPTION
The filesmatch inspection reads a parsed spec file and collects all of the entry specifications from %files sections.  It then looks at what was actually in the package payload and compares it to list from the spec file and reports any problems.

NOTE: Right now the filesmatch inspection is just parsing the spec file and gathering entries.  The actual inspection is not hooked up yet, but will be soon.  You can see what it gathers from the spec file when running in debug mode.