### PR TITLE
[fix] Retain empty lines when using strsplit()

### DIFF
--- a/lib/listfuncs.c
+++ b/lib/listfuncs.c
@@ -423,7 +423,7 @@ string_list_t *list_add(string_list_t *list, const char *s)
 {
     string_entry_t *entry = NULL;
 
-    if (s == NULL || (s && !strcmp(s, ""))) {
+    if (s == NULL) {
         return list;
     }
 

--- a/lib/readfile.c
+++ b/lib/readfile.c
@@ -68,7 +68,7 @@ void *read_file_bytes(const char *path, off_t *len)
         warn(_("*** unable to close %s"), path);
     }
 
-    /* break up the file in to lines */
+    /* copy the data in to a buffer for the caller */
     data = xalloc(*len + 1);
     data = memcpy(data, buf, *len);
     assert(data != NULL);

--- a/lib/strfuncs.c
+++ b/lib/strfuncs.c
@@ -530,7 +530,7 @@ string_list_t *strsplit(const char *s, const char *delim)
     }
 
     /* given a string but no delim, just make a single entry list */
-    if (s && (delim == NULL || !strcmp(delim, "") || !strcmp(s, delim))) {
+    if (s && (delim == NULL || !strcmp(s, delim))) {
         list = list_add(list, s);
         return list;
     }
@@ -541,10 +541,6 @@ string_list_t *strsplit(const char *s, const char *delim)
 
     /* split the string and build the list */
     while ((token = strsep(&walk, delim)) != NULL) {
-        if (!strcmp(token, "")) {
-            continue;
-        }
-
         list = list_add(list, token);
     }
 


### PR DESCRIPTION
Do not filter out blank lines when using strsplit() to split the lines of a text file read in.