### PR TITLE
[fix] Ignore .build-id subdirectories in the filesmatch inspection

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -526,6 +526,13 @@ extern "C"
 #define INCLUDE_DIR "/usr/include"
 
 /**
+ * @def LIB_DIR_PREFIX
+ *
+ * Library directory prefix (note the system could use /usr/lib64).
+ */
+#define LIB_DIR_PREFIX "/usr/lib"
+
+/**
  * @def KERNEL_FILENAMES
  *
  * Default array of kernel executable filename possibilities.

--- a/lib/inspect_filesmatch.c
+++ b/lib/inspect_filesmatch.c
@@ -426,6 +426,11 @@ static bool filesmatch_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         return true;
     }
 
+    /* skip build-id stuff */
+    if (strprefix(file->localpath, LIB_DIR_PREFIX) && strstr(file->localpath, BUILD_ID_DIR)) {
+        return true;
+    }
+
     /* used in message reporting below */
     name = headerGetString(file->rpm_header, RPMTAG_NAME);
     arch = get_rpm_header_arch(file->rpm_header);


### PR DESCRIPTION
These are generated at build time to link files in packages with debuginfo data.