### PR TITLE
[cmd] Disable the 'filesmatch' inspection for now

### DIFF
--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -594,6 +594,11 @@ int main(int argc, char **argv)
         printf(_("\nAvailable inspections:\n"));
 
         for (i = 0; inspections[i].name != NULL; i++) {
+            /* XXX: temporarily disable the filesmatch inspection */
+            if (inspections[i].flag == INSPECT_FILESMATCH) {
+                continue;
+            }
+
             if (i > 0 && verbose) {
                 printf("\n");
             }
@@ -984,6 +989,11 @@ int main(int argc, char **argv)
         }
 
         for (i = 0; inspections[i].name != NULL; i++) {
+            /* XXX: temporarily disable the filesmatch inspection */
+            if (inspections[i].flag == INSPECT_FILESMATCH) {
+                continue;
+            }
+
             /* test not selected by user */
             if (!(ri->tests & inspections[i].flag)) {
                 /*


### PR DESCRIPTION
Temporarily disable the filesmatch inspection.  It is likely this inspection will be removed in a week or so (but moved off to a branch) but just disable it for now.