### PR TITLE
[lib] Ignore expected empty RPM payloads in 'lostpayload' (#1518)

### DIFF
--- a/lib/inspect_lostpayload.c
+++ b/lib/inspect_lostpayload.c
@@ -51,6 +51,11 @@ bool inspect_lostpayload(struct rpminspect *ri)
 
     /* Check the binary peers */
     TAILQ_FOREACH(peer, ri->peers, items) {
+        /* Expected empty RPM packages are ignored here */
+        if (peer->after_hdr && list_contains(ri->expected_empty_rpms, headerGetString(peer->after_hdr, RPMTAG_NAME))) {
+            continue;
+        }
+
         /*
          * Subpackages may disappear in subsequent builds.  Sometimes this
          * is intentional, sometimes not.


### PR DESCRIPTION
The lostpayload inspection is supposed to catch unexpected build accidents where you do an update and one of the subpackages ends up with an empty payload.  However, some builds have subpackages with empty payloads.  The emptyrpm inspection knows how to deal with those, so expand lostpayload so it ignores those packages that are expected to have empty payloads.

Resolves: #1518