### PR TITLE
[bld] Change the Release value used for Copr builds to 1.1....

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -60,7 +60,7 @@ srpm:
 	sed -e 's|%%VERSION%%|$(VER)|g' < "$(SPEC_TEMPLATE)" > "$(SPEC)"
 	sed -i -e 's|%%GPGKEYRING%%|gpgkey-$(GPGKEY).gpg|g' "$(SPEC)"
 ifeq ($(BUILDTYPE),copr)
-	sed -i -e '/^Release:/ s/%autorelease$$/0.1.$(GITDATE)git$(GITHASH)/' "$(SPEC)"
+	sed -i -e '/^Release:/ s/%autorelease$$/1.1.$(GITDATE)git$(GITHASH)/' "$(SPEC)"
 	sed -i -e 's|^Source0:.*$$|Source0: $(TARBALL_BASENAME).tar.gz|g' "$(SPEC)"
 	sed -i -e 's|^%autosetup.*$$|%autosetup -n $(TARBALL_BASENAME)|g' "$(SPEC)"
 	sed -i -e '/^Source1:.*$$/d' "$(SPEC)"


### PR DESCRIPTION
Rather than 0.1 like I had been using, go with 1.1 as the prefix followed by the date stamp and git hash.