### PR TITLE
[fix] Invoke annocheck correctly so we do not get incorrect reporting

### DIFF
--- a/include/rpminspect.h
+++ b/include/rpminspect.h
@@ -526,6 +526,9 @@ void *xreallocarray(void *p, size_t n, size_t s);
 /* spec.c */
 string_list_t *read_spec(struct rpminspect *ri, const char *specfile);
 
+/* inspect.c */
+bool has_security_checks(const char *inspection);
+
 #endif
 
 #ifdef __cplusplus

--- a/lib/inspect.c
+++ b/lib/inspect.c
@@ -89,7 +89,7 @@ struct inspect inspections[] = {
 /*
  * Returns true if the named inspection has security checks.
  */
-static bool has_security_checks(const char *inspection)
+bool has_security_checks(const char *inspection)
 {
     int i = 0;
 

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -163,11 +163,6 @@ char *run_cmd_vp(int *exitcode, const char *workdir, char **argv)
         if (getcwd(cwd, PATH_MAX) == NULL) {
             err(RI_PROGRAM_ERROR, "*** getcwd");
         }
-
-        /* power through if it fails */
-        if (chdir(workdir) == -1) {
-            warn("*** chdir");
-        }
     }
 
     /* create pipes to interact with the child */
@@ -201,6 +196,11 @@ char *run_cmd_vp(int *exitcode, const char *workdir, char **argv)
 
         /* find the command */
         cmd = find_cmd(argv[0]);
+
+        /* change to the working directory */
+        if (chdir(workdir) == -1) {
+            warn("*** chdir");
+        }
 
         /* run the command */
         if (execvp(cmd, argv) == -1) {


### PR DESCRIPTION
Annocheck has code to detect some packages that need special handling, like glibc, where some parts of glibc must "break the rules" because they're part of the rules' infrastructure. This code assumes that, when checking uninstalled files, a dot-relative path is used, like ./usr/lib64/libc.so.6 instead of /full/path/to/usr/lib64/libc.so.6

Fixes: #1515