### PR TITLE
[bld] Add 'Recommends: system-rpm-config' to the spec file template

### DIFF
--- a/rpminspect.spec.in
+++ b/rpminspect.spec.in
@@ -88,9 +88,16 @@ Recommends:     xhtml1-dtds
 Recommends:     html401-dtds
 %endif
 
-# Required to support things like %%autorelease in spec files
-%if 0%{?fedora} >= 33
-Recommends:     rpm_macro(autorelease)
+# Necessary to support preprocessing spec files for parsing.  The
+# package providing this dependency in turn pulls in other packages
+# that define macros.  This is similar to the rpm-build package
+# carrying a Requires on the same package.  It ensures the build
+# environment has all of the necessary macro definitions that the
+# package spec file may use.
+%if 0%{?rhel} >= 8 || 0%{?epel} >= 8 || 0%{?fedora}
+Recommends:     system-rpm-config
+%else
+Requires:       system-rpm-config
 %endif
 
 # These programs are only required for the 'shellsyntax' functionality.


### PR DESCRIPTION
librpminspect uses librpm to preprocess and parse spec files, but to do that correctly requires the host system have spec file macro definitions in use.  That's going to vary by RPM environment, but in the Fedora/CentOS/RHEL sphere, we can put a weak dependency on system-rpm-config and pull in macro definitions.  This is similar to what the rpm-build package does.

Fixes: #1526