### PR TITLE
[ci] Build cc with CFLAGS=-std=gnu99 on Alpine Linux

### DIFF
--- a/osdeps/alpine/post.sh
+++ b/osdeps/alpine/post.sh
@@ -43,7 +43,7 @@ cd rc || exit 1
 TAG="$(git tag -l | sort -V | tail -n 1)"
 git checkout -b ${TAG} ${TAG}
 autoreconf --force --install
-./configure --prefix=/usr
+CFLAGS=-std=gnu99 ./configure --prefix=/usr
 make
 make install
 cd "${CWD}" || exit 1


### PR DESCRIPTION
Without this the bool type and values do not work.