### PR TITLE
[lib] Account for RPM payloads carrying paths not in the RPM metadata

### DIFF
--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -227,7 +227,10 @@ static int _get_rpm_header_array_value_helper(rpmtd *td, const rpmfile_entry_t *
 
     assert(td != NULL);
     assert(file != NULL);
-    assert(file->idx >= 0);
+
+    if (file->idx == -1) {
+        return -1;
+    }
 
     /* new header transaction */
     *td = rpmtdNew();


### PR DESCRIPTION
This was somewhat difficult to track down, but I think it was a combination of varying versions of support libraries and my test suite that uncovered it.

rpminspect unpacks the RPM payload using libarchive.  Before it does that it builds up a list of what it expects from the payload by reading RPMTAG_FILENAMES from the header.  The idea being that the list we get from the header should match the payload.  That's mostly true on most systems, but I have now seen multiple systems carry an empty directory in the payload that is not in the RPM header metadata (or at least not in RPMTAG_FILENAMES).  I'm not really sure what is going on but my initial thinking is that RPM does not see the empty directory as needing to carry additional metadata so it can just fall through to the libarchive extraction and call it a day.

I have test cases that use empty directories and this is showing up on some non-Fedora/non-CentOS systems, so I know it's possible.  To account for these cases I expanded the extraction and file peering code in rpminspect to do the following additional things:

* When extracting the payload if we do not see a path in the payload in the RPMTAG_FILENAMES metadata, then capture it anyway but note the record index is -1 since we don't know if or where it lives in the RPM header.

* Continue with extraction.  When capturing the st_mode for a payload entry, try RPMTAG_FILEMODES first but if the record index is -1 then ask libarchive what it thinks and go with the value from archive_entry_mode().

* In the case of a payload entry path ending with '/', then trim that. This appears to be some versions of libarchive, so just account for it and trim as necessary.  We don't use trailing slashes on our path values.  Even for directories.

This fixes some failing symlink tests on things like Arch Linux and Alpine Linux, which is definitely a stretch but I want to make sure rpminspect is consistent across Linux systems since you can really do development anywhere.