### PR TITLE
[ci] Fix up the Gentoo CI jobs so they don't fail

### DIFF
--- a/osdeps/gentoo/post.sh
+++ b/osdeps/gentoo/post.sh
@@ -45,7 +45,7 @@ cd rc || exit 1
 TAG="$(git tag -l | sort -V | tail -n 1)"
 git checkout -b ${TAG} ${TAG}
 autoreconf --force --install
-./configure --prefix=/usr
+CFLAGS="-std=gnu99" ./configure --prefix=/usr
 make
 make install
 cd "${CWD}" || exit 1

--- a/osdeps/gentoo/pre.sh
+++ b/osdeps/gentoo/pre.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
+PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
 # Enable Python support in things like rpm
 echo 'USE="${USE} caps python lzma"' >> /etc/portage/make.conf
+[ -d /etc/portage/package.use ] || mkdir -p /etc/portage/package.use
+echo 'app-antivirus/clamav clamapp' > /etc/portage/package.use/clamav
 
 # Disable things
 echo 'USE="${USE} -milter -experimental -clamapp -bashlogger -mem-scramble -pgo -plugins -abyss -debug -gnome -qt5 -qt6"' >> /etc/portage/make.conf


### PR DESCRIPTION
The rc shell needs to build with -std=gnu99 on gcc.  And we need to tell Gentoo to install the clamav commands when the clamav package is "emerged".  Yes, I would like to USE the commands that come with the command line program, thank you.