### PR TITLE
[tst] When writing to test rpminspect.yaml file, do not wrap lines

### DIFF
--- a/test/baseclass.py
+++ b/test/baseclass.py
@@ -294,7 +294,7 @@ class RequiresRpminspect(unittest.TestCase):
 
         # write the temporary config file for the test suite
         outstream = open(self.conffile, "w")
-        outstream.write(yaml.dump(cfg).replace("- ", "  - "))
+        outstream.write(yaml.dump(cfg, width=float("inf")).replace("- ", "  - "))
         outstream.close()
 
     def tearDown(self):


### PR DESCRIPTION
The PyYAML module has yaml.dump() which we use to write out the config file created for test cases.  Be sure it does not wrap what it considers long lines because that just leads to parse errors and tests failing before anything runs.