### PR TITLE
[lib] General hardening of the code base

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -406,7 +406,6 @@ typedef enum _politics_field_t {
 
 /* Commands used by rpminspect at runtime. */
 struct command_paths {
-    char *diff;
     char *msgunfmt;
     char *desktop_file_validate;
     char *abidiff;

--- a/lib/builds.c
+++ b/lib/builds.c
@@ -138,12 +138,12 @@ static void prune_local(const int whichbuild)
         free(apath);
     }
 
+    free(lpath);
+
     if (closedir(d) == -1) {
         warn("*** closedir");
         return;
     }
-
-    free(lpath);
 
     return;
 }

--- a/lib/curl.c
+++ b/lib/curl.c
@@ -265,7 +265,7 @@ curl_off_t curl_get_size(const char *src)
 
     if (cc != CURLE_OK) {
         warnx(_("*** unable to read %s"), src);
-        return 0;
+        goto curl_done;
     }
 
 #ifdef _HAVE_NEWER_CURLINFO
@@ -275,6 +275,7 @@ curl_off_t curl_get_size(const char *src)
     r = (curl_off_t) len;
 #endif
 
+curl_done:
     curl_easy_cleanup(c);
     return r;
 }

--- a/lib/diags.c
+++ b/lib/diags.c
@@ -180,7 +180,6 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     if (exitcode == 0) {
         details = strsplit(tmp, "\n");
-        free(tmp);
 
         if (details) {
             entry = TAILQ_FIRST(details);
@@ -206,13 +205,14 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
         free(ver);
     }
 
+    free(tmp);
+
 #ifdef _WITH_ANNOCHECK
     /* annocheck */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.annocheck, "--version", NULL);
 
     if (exitcode == 0) {
         details = strsplit(tmp, "\n");
-        free(tmp);
 
         if (details) {
             entry = TAILQ_FIRST(details);
@@ -237,6 +237,8 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
         free(ver);
     }
+
+    free(tmp);
 #endif
 
     /* abidiff */
@@ -244,7 +246,6 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
     if (exitcode == 0) {
         details = strsplit(tmp, "\n");
-        free(tmp);
 
         if (details) {
             entry = TAILQ_FIRST(details);
@@ -270,12 +271,13 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
         free(ver);
     }
 
+    free(tmp);
+
     /* kmidiff */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.kmidiff, "--version", NULL);
 
     if (exitcode == 0) {
         details = strsplit(tmp, "\n");
-        free(tmp);
 
         if (details) {
             entry = TAILQ_FIRST(details);
@@ -301,12 +303,13 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
         free(ver);
     }
 
+    free(tmp);
+
     /* udevadm */
     tmp = run_cmd(&exitcode, ri->worksubdir, ri->commands.udevadm, "--version", NULL);
 
     if (exitcode == 0) {
         details = strsplit(tmp, "\n");
-        free(tmp);
 
         if (details) {
             entry = TAILQ_FIRST(details);
@@ -331,6 +334,8 @@ string_list_t *gather_diags(struct rpminspect *ri, const char *progname, const c
 
         free(ver);
     }
+
+    free(tmp);
 
     return list;
 }

--- a/lib/files.c
+++ b/lib/files.c
@@ -201,6 +201,7 @@ rpmfile_t *extract_rpm(struct rpminspect *ri, const char *pkg, Header hdr, const
     assert(*output_dir != NULL);
 
     if (mkdirp(*output_dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == -1) {
+        free(*output_dir);
         return NULL;
     }
 

--- a/lib/free.c
+++ b/lib/free.c
@@ -332,6 +332,8 @@ void free_rpminspect(struct rpminspect *ri)
 
     free_remedy_strings();
 
+    free(ri);
+
     return;
 }
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -597,6 +597,8 @@ static inline void _remedy_walker(struct toml_node *node, void *data)
                 free(entry->data);
                 free(entry);
             }
+
+            free(r);
         }
     }
 

--- a/lib/inspect_abidiff.c
+++ b/lib/inspect_abidiff.c
@@ -186,6 +186,7 @@ static bool abidiff_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     /* ET_DYN with no DT_SONAME is _probably_ an executable */
     if (is_elf_executable(file) || (is_elf_shared_library(file) && soname == NULL)) {
+        free(soname);
         return true;
     }
 

--- a/lib/inspect_annocheck.c
+++ b/lib/inspect_annocheck.c
@@ -513,8 +513,10 @@ static bool annocheck_driver(struct rpminspect *ri, rpmfile_entry_t *file, rpmpe
             reported = true;
             free(params.details);
             free(params.msg);
-            list_free(details, free);
         }
+
+        list_free(details, free);
+        details = NULL;
     }
 
     /* set result based on worst result encountered */

--- a/lib/inspect_changedfiles.c
+++ b/lib/inspect_changedfiles.c
@@ -41,11 +41,15 @@ static char *run_and_capture(const char *where, char **output, char *cmd, const 
 
     if (fd == -1) {
         warn("*** mkstemp");
+        free(*output);
+        *output = NULL;
         return NULL;
     }
 
     if (close(fd) == -1) {
         warn("*** close");
+        free(*output);
+        *output = NULL;
         return NULL;
     }
 

--- a/lib/inspect_dsodeps.c
+++ b/lib/inspect_dsodeps.c
@@ -185,8 +185,8 @@ done:
         close(before_fd);
     }
 
-    free(removed);
-    free(added);
+    list_free(removed, free);
+    list_free(added, free);
     list_free(before_needed, free);
     list_free(after_needed, free);
 

--- a/lib/inspect_elf.c
+++ b/lib/inspect_elf.c
@@ -702,6 +702,8 @@ static bool elf_archive_tests(struct rpminspect *ri, Elf *after_elf, int after_e
     elf_archive_iterate(before_elf_fd, before_elf, find_pic, &before_pic);
 
     if (after_no_pic == NULL || before_pic == NULL) {
+        list_free(after_no_pic, free);
+        list_free(before_pic, free);
         return true;
     }
 

--- a/lib/inspect_javabytecode.c
+++ b/lib/inspect_javabytecode.c
@@ -206,6 +206,7 @@ static bool javabytecode_driver(struct rpminspect *ri, rpmfile_entry_t *file)
         if (unpack_archive(file->fullpath, tmppath, true)) {
             /* not an archive, just clean up and skip */
             rmtree(tmppath, true, false);
+            free(tmppath);
             return true;
         }
 

--- a/lib/inspect_kmod.c
+++ b/lib/inspect_kmod.c
@@ -143,6 +143,8 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     if (kctx == NULL) {
         warn("*** kmod_new");
+        kmod_module_unref(beforekmod);
+        kmod_unref(kctx);
         return true;
     }
 
@@ -151,6 +153,7 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
     if (err < 0) {
         /* not a kernel module */
         kmod_module_unref(beforekmod);
+        kmod_module_unref(afterkmod);
         kmod_unref(kctx);
         return true;
     } else {
@@ -195,9 +198,6 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             free(params.msg);
             reported = true;
         }
-
-        list_free(lost, free);
-        lost = NULL;
     }
 
     if (gain != NULL && !TAILQ_EMPTY(gain)) {
@@ -212,9 +212,6 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             free(params.msg);
             reported = true;
         }
-
-        list_free(gain, free);
-        gain = NULL;
     }
 
     /* Compute lost and gained module dependencies */
@@ -233,9 +230,6 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             free(params.msg);
             reported = true;
         }
-
-        list_free(lost, free);
-        lost = NULL;
     }
 
     if (gain != NULL && !TAILQ_EMPTY(gain)) {
@@ -249,10 +243,10 @@ static bool kmod_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             free(params.msg);
             reported = true;
         }
-
-        list_free(gain, free);
-        gain = NULL;
     }
+
+    list_free(gain, free);
+    list_free(lost, free);
 
     /* Compute lost PCI device IDs in kernel modules */
     beforealiases = gather_module_aliases(before_kmod_name, beforeinfo);

--- a/lib/inspect_lto.c
+++ b/lib/inspect_lto.c
@@ -73,11 +73,7 @@ static bool find_lto_symbols(Elf *elf, __attribute__((unused)) string_list_t **u
         }
     }
 
-    if (TAILQ_EMPTY(specifics)) {
-        list_free(specifics, free);
-        specifics = NULL;
-    }
-
+    list_free(specifics, free);
     list_free(names, free);
 
     return true;

--- a/lib/inspect_patches.c
+++ b/lib/inspect_patches.c
@@ -763,13 +763,13 @@ bool inspect_patches(struct rpminspect *ri)
                             buf[strcspn(buf, " \t")] = '\0';
                         } else {
                             warnx(_("*** unrecognized %%patch line: %s"), specentry->data);
-                            continue;
+                            goto clean_continue;
                         }
 
                         /* add a new patch entry to the hash table */
                         if (buf == NULL) {
                             warnx(_("*** unable to read spec file line: %s"), specentry->data);
-                            continue;
+                            goto clean_continue;
                         }
 
                         aentry = xalloc(sizeof(*aentry));
@@ -794,6 +794,7 @@ bool inspect_patches(struct rpminspect *ri)
 
                         HASH_ADD_INT(applied, num, aentry);
 
+clean_continue:
                         /* clean up */
                         list_free(fields, free);
                     }

--- a/lib/inspect_shellsyntax.c
+++ b/lib/inspect_shellsyntax.c
@@ -298,6 +298,8 @@ static bool shellsyntax_driver(struct rpminspect *ri, rpmfile_entry_t *file)
 
     free(shell);
     free(before_shell);
+    free(errors);
+    free(before_errors);
     return result;
 }
 

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -140,6 +140,8 @@ bool inspect_virus(struct rpminspect *ri)
 
         if (cvd == NULL) {
             free(cvdpath);
+            free(params.msg);
+            free(params.details);
 
             if (closedir(d) == -1) {
                 warn("*** closedir");

--- a/lib/kmods.c
+++ b/lib/kmods.c
@@ -161,8 +161,8 @@ bool compare_module_parameters(const struct kmod_list *before, const struct kmod
         *gain = list_copy(added);
     }
 
-    list_free(added, NULL);
-    list_free(difference, NULL);
+    list_free(added, free);
+    list_free(difference, free);
     list_free(before_parm_list, free);
     list_free(after_parm_list, free);
     list_free(combined, free);
@@ -397,6 +397,8 @@ bool compare_module_aliases(kernel_alias_data_t *before, kernel_alias_data_t *af
         if (wildcard_search) {
             list_free(after_modules, NULL);
         }
+
+        list_free(difference, NULL);
     }
 
     return result;

--- a/lib/output_json.c
+++ b/lib/output_json.c
@@ -97,6 +97,7 @@ void output_json(const results_t *results, const char *dest, __attribute__((unus
 
             if (fp == NULL) {
                 warn(_("*** error opening %s for writing"), dest);
+                json_object_put(j);
                 return;
             }
         }

--- a/lib/parse_json.c
+++ b/lib/parse_json.c
@@ -183,6 +183,8 @@ static bool json_strdict_foreach(parser_context *context, const char *key1, cons
             free(valstr);
             return true;
         }
+
+        free(valstr);
     }
 
     return false;

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -413,6 +413,8 @@ char *extract_rpm_payload(const char *rpm)
 
     if (archive_write_open_filename(archive, payload) != ARCHIVE_OK) {
         warnx("*** archive_write_open_filename: %s", archive_error_string(archive));
+        free(payload);
+        payload = NULL;
         goto cleanup;
     }
 

--- a/lib/spec.c
+++ b/lib/spec.c
@@ -219,5 +219,8 @@ string_list_t *read_spec(struct rpminspect *ri, const char *specfile)
     /* split in to lines */
     r = strsplit(s, "\n\r");
 
+    /* cleanup */
+    rpmSpecFree(spec);
+
     return r;
 }

--- a/lib/unpack.c
+++ b/lib/unpack.c
@@ -133,6 +133,8 @@ int unpack_archive(const char *archive, const char *dest, const bool force)
         }
     }
 
+    free(rfilename);
+
     /* archive reader */
     input = archive_read_new();
 #if ARCHIVE_VERSION_NUMBER < 3000000
@@ -196,6 +198,5 @@ int unpack_archive(const char *archive, const char *dest, const bool force)
         return -1;
     }
 
-    free(rfilename);
     return ret;
 }

--- a/src/rpminspect.c
+++ b/src/rpminspect.c
@@ -308,6 +308,25 @@ static void check_found(const bool found, const char *inspection)
     return;
 }
 
+/*
+ * Copy the option argument, but error out if we have already done
+ * that.  Enforces single use of options on the command line.
+ */
+static char *gather_arg(char *val, char *arg, const char *opt)
+{
+    char *r = NULL;
+
+    if (arg) {
+        warnx(_("*** multiple instances of command line option: `%s`"), opt);
+        errx(RI_PROGRAM_ERROR, _("*** See `%s --help` for more information."), COMMAND_NAME);
+    }
+
+    r = strdup(val);
+    assert(r != NULL);
+
+    return r;
+}
+
 int main(int argc, char **argv)
 {
     struct sigaction abrt;
@@ -428,31 +447,31 @@ int main(int argc, char **argv)
         switch (c) {
             case 'c':
                 /* Capture user specified config file */
-                cfgfile = strdup(optarg);
+                cfgfile = gather_arg(optarg, cfgfile, "-c");
                 break;
             case 'p':
                 /* Configuration profile to use */
-                profile = strdup(optarg);
+                profile = gather_arg(optarg, profile, "-p");
                 break;
             case 'T':
                 /* Inspections to enable */
                 check_inspection_options(inspection_opt);
-                insoptarg = strdup(optarg);
+                insoptarg = gather_arg(optarg, insoptarg, "-T");
                 exclude = false;
                 inspection_opt = true;
                 break;
             case 'E':
                 /* Inspections to disable */
                 check_inspection_options(inspection_opt);
-                insoptarg = strdup(optarg);
+                insoptarg = gather_arg(optarg, insoptarg, "-E");
                 exclude = true;
                 inspection_opt = true;
                 break;
             case 'a':
-                archopt = strdup(optarg);
+                archopt = gather_arg(optarg, archopt, "-a");
                 break;
             case 'r':
-                release = strdup(optarg);
+                release = gather_arg(optarg, release, "-r");
                 break;
             case 'n':
                 rebase_detection = false;
@@ -476,7 +495,7 @@ int main(int argc, char **argv)
 
                 break;
             case 'o':
-                output = strdup(optarg);
+                output = gather_arg(optarg, output, "-o");
                 break;
             case 'F':
                 /* validate the specified output format */
@@ -519,10 +538,10 @@ int main(int argc, char **argv)
                 wordfree(&expand);
                 break;
             case 't':
-                threshold = strdup(optarg);
+                threshold = gather_arg(optarg, threshold, "-t");
                 break;
             case 's':
-                suppress = strdup(optarg);
+                suppress = gather_arg(optarg, suppress, "-s");
                 break;
             case 'f':
                 fetch_only = true;        /* -f implies -k */


### PR DESCRIPTION
Go through and fix up things that could leak memory or are otherwise just bad form.  Probably the biggest visible change is the addition of command line option enforcement where the program will halt if you specify certain options more than once.  This was always expected, but if you specified an option more than once the program would just take the last one (and leak the previous one).  It is not only expected that options be specified once, it is now enforced (for most options).