### PR TITLE
Fix possible NULL pointer dereference in badfuncs_driver()

### DIFF
--- a/lib/inspect_badfuncs.c
+++ b/lib/inspect_badfuncs.c
@@ -146,7 +146,7 @@ static bool badfuncs_driver(struct rpminspect *ri, rpmfile_entry_t *after)
         list_free(allowed_symbols, free);
     }
 
-    if (TAILQ_EMPTY(used_symbols)) {
+    if (used_symbols == NULL || TAILQ_EMPTY(used_symbols)) {
         goto cleanup;
     }
 

--- a/lib/inspect_symlinks.c
+++ b/lib/inspect_symlinks.c
@@ -220,6 +220,7 @@ static bool symlinks_driver(struct rpminspect *ri, rpmfile_entry_t *file)
             } else if (strprefix(target, "../")) {
                 /* back up a directory level */
                 tmp = strrchr(reltarget, PATH_SEP);
+                assert(tmp != NULL);
                 *tmp = '\0';
                 tail = tmp;
                 target += 3;


### PR DESCRIPTION
used_symbols may be NULL, so don't assume you can run TAILQ_EMPTY on it.
    
Fixes: #1568
    
Signed-off-by: Dave Cantrell <dcantrell@redhat.com>
