### PR TITLE
Packit tweaks

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,12 +3,6 @@ specfile_path: rpminspect.spec
 upstream_package_name: rpminspect
 downstream_package_name: rpminspect
 
-targets:
-  - fedora-all
-  - epel-10
-  - epel-9
-  - epel-8
-
 actions:
   post-upstream-clone:
     - cp rpminspect.spec.in rpminspect.spec
@@ -26,6 +20,11 @@ jobs:
   # Upstream jobs
   - job: copr_build
     trigger: pull_request
+    targets:
+      - fedora-all
+      - epel-10
+      - epel-9
+      - epel-8
 
   - job: copr_build
     trigger: commit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,6 +4,8 @@ upstream_package_name: rpminspect
 downstream_package_name: rpminspect
 
 actions:
+  get-current-version:
+    - "sed -nr \"s/\\s*version : '(.*)',/\\1/p\" meson.build"
   post-upstream-clone:
     - cp rpminspect.spec.in rpminspect.spec
     # Arbitrary version, will be replaced at the `fix-spec-file` action
@@ -12,7 +14,6 @@ actions:
     - sed -i -e '/^Source2:.*$/d' rpminspect.spec
     - sed -i -e '/^%{gpgverify}.*$/d' rpminspect.spec
 
-upstream_tag_template: v{version}
 version_suffix: ~{PACKIT_PROJECT_SNAPSHOTID}
 update_release: false
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,7 +13,7 @@ actions:
     - sed -i -e '/^%{gpgverify}.*$/d' rpminspect.spec
 
 upstream_tag_template: v{version}
-version_suffix: ^{PACKIT_PROJECT_SNAPSHOTID}
+version_suffix: ~{PACKIT_PROJECT_SNAPSHOTID}
 update_release: false
 
 jobs:


### PR DESCRIPTION
Two minor tweaks here:
- Make sure all arches that are enabled on the project `@rpminspect/latest` are being built, for PR still only x86_64
- Use the pre-release suffix for the version

Noticed that here you have a PR to bump the version after each release, so the post-release would create some issues when a new release is cut.