### PR TITLE
[lib] Expand virus scan reporting to note infected file in archives

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -1173,6 +1173,17 @@ typedef struct _patchstat_t {
     long int lines;
 } patchstat_t;
 
+/*
+ * Used for tracking file paths within scanned archive files in the
+ * virus inspection.
+ */
+typedef struct {
+    char *current;
+    char **pathnames;
+    uint32_t level;
+    char *virus_path;
+} virus_scan_context_t;
+
 #endif
 
 #ifdef __cplusplus

--- a/lib/inspect_virus.c
+++ b/lib/inspect_virus.c
@@ -26,10 +26,104 @@ static unsigned file_no = (unsigned)-1;
 static int virus_countdown = 4000;
 static int write_fd;
 
+/* File inspection callback to track files being scanned */
+static cl_error_t file_inspection_callback(int fd __attribute__((unused)),
+                                           const char *type __attribute__((unused)),
+                                           const char **pathnames,
+                                           size_t parent_file_size __attribute__((unused)),
+                                           const char *file_name,
+                                           size_t file_size __attribute__((unused)),
+                                           const char *file_buffer __attribute__((unused)),
+                                           uint32_t level,
+                                           uint32_t layer_attributes __attribute__((unused)),
+                                           void *context)
+{
+    virus_scan_context_t *ctx = (virus_scan_context_t *) context;
+    unsigned int i = 0;
+
+    /* free previous file name */
+    if (ctx->current) {
+        free(ctx->current);
+        ctx->current = NULL;
+    }
+
+    /* free previous pathnames */
+    if (ctx->pathnames) {
+        for (i = 0; i < ctx->level; i++) {
+            free(ctx->pathnames[i]);
+            ctx->pathnames[i] = NULL;
+        }
+
+        free(ctx->pathnames);
+        ctx->pathnames = NULL;
+    }
+
+    ctx->level = level;
+
+    /* copy current file name */
+    if (file_name) {
+        ctx->current = strdup(file_name);
+        assert(ctx->current != NULL);
+    }
+
+    /* copy pathnames */
+    if (pathnames && level > 0) {
+        ctx->pathnames = calloc(level, sizeof(*(ctx->pathnames)));
+
+        for (i = 0; i < level; i++) {
+            if (pathnames[i]) {
+                ctx->pathnames[i] = strdup(pathnames[i]);
+                assert(ctx->pathnames[i] != NULL);
+            }
+        }
+    }
+
+    return CL_CLEAN;
+}
+
+/* Virus found callback to record the file path when a virus is detected */
+static void virus_found_callback(int fd __attribute__((unused)),
+                                 const char *virname __attribute__((unused)),
+                                 void *context)
+{
+    virus_scan_context_t *ctx = (virus_scan_context_t *) context;
+    unsigned int i = 0;
+
+    /* build the full path including pathnames */
+    if (ctx->virus_path) {
+        free(ctx->virus_path);
+        ctx->virus_path = NULL;
+    }
+
+    /* construct path: pathname1/pathname2/.../current */
+    if (ctx->pathnames && ctx->level > 0) {
+        ctx->virus_path = strdup(ctx->pathnames[0]);
+        assert(ctx->virus_path != NULL);
+
+        for (i = 1; i < ctx->level; i++) {
+            if (ctx->pathnames[i]) {
+                ctx->virus_path = joindelim('/', ctx->virus_path, ctx->pathnames[i], NULL);
+            }
+        }
+
+        if (ctx->current) {
+            ctx->virus_path = joindelim('/', ctx->virus_path, ctx->current, NULL);
+        }
+    } else if (ctx->current) {
+        ctx->virus_path = strdup(ctx->current);
+        assert(ctx->virus_path != NULL);
+    }
+
+    return;
+}
+
 static bool virus_driver(struct rpminspect *ri __attribute__((unused)), rpmfile_entry_t *file)
 {
     int r = 0;
+    unsigned int i = 0;
     const char *virus = NULL;
+    const char *infected_file = "";
+    virus_scan_context_t ctx;
 
     /* cyclically count from 0 to NCHILDREN-1 */
     file_no++;
@@ -48,11 +142,14 @@ static bool virus_driver(struct rpminspect *ri __attribute__((unused)), rpmfile_
         return true;
     }
 
+    /* Initialize scan context */
+    memset(&ctx, 0, sizeof(ctx));
+
     /* scan the file */
 #ifndef CL_SCAN_STDOPT
-    r = cl_scanfile(file->fullpath, &virus, NULL, engine, &clamav_opts);
+    r = cl_scanfile_callback(file->fullpath, &virus, NULL, engine, &clamav_opts, &ctx);
 #else
-    r = cl_scanfile(file->fullpath, &virus, NULL, engine, CL_SCAN_STDOPT);
+    r = cl_scanfile_callback(file->fullpath, &virus, NULL, engine, CL_SCAN_STDOPT, &ctx);
 #endif
 #if 0 /* debug: uncomment for error injection - test that virus detection indeed works */
     if (child_no == 0 && file_no == 0 && virus_countdown == 4000) {
@@ -79,9 +176,33 @@ static bool virus_driver(struct rpminspect *ri __attribute__((unused)), rpmfile_
          */
         if (virus_countdown != 0) {
             virus_countdown--;
+
+            /* Get the infected file path from context */
+            if (ctx.virus_path && ctx.virus_path[0]) {
+                infected_file = ctx.virus_path;
+            }
+
             full_write(write_fd, virus, strlen(virus) + 1);
             full_write(write_fd, &file, sizeof(file));
+            full_write(write_fd, infected_file, strlen(infected_file) + 1);
         }
+    }
+
+    /* Clean up context */
+    if (ctx.current) {
+        free(ctx.current);
+    }
+
+    if (ctx.pathnames) {
+        for (i = 0; i < ctx.level; i++) {
+            free(ctx.pathnames[i]);
+        }
+
+        free(ctx.pathnames);
+    }
+
+    if (ctx.virus_path) {
+        free(ctx.virus_path);
     }
 
     return true;
@@ -198,6 +319,10 @@ bool inspect_virus(struct rpminspect *ri)
         errx(RI_PROGRAM_ERROR, "*** cl_load: %s", cl_strerror(r));
     }
 
+    /* set up callbacks for tracking infected files within archives */
+    cl_engine_set_clcb_file_inspection(engine, file_inspection_callback);
+    cl_engine_set_clcb_virus_found(engine, virus_found_callback);
+
     /* compile engine */
     r = cl_engine_compile(engine);
 
@@ -307,18 +432,25 @@ bool inspect_virus(struct rpminspect *ri)
         char *output = slot->output;
 
         if (output) {
-            /* consume all pairs of ("virusname",rpmfile_entry_t pointer) in output */
+            /* consume all triples of ("virusname",rpmfile_entry_t pointer,"infected_file") in output */
             while (output[0]) {
                 rpmfile_entry_t *file;
                 const char *virus = output;
+                const char *infected_file = NULL;
+                char *nevra = NULL;
 
                 output += strlen(virus) + 1;
                 memcpy(&file, output, sizeof(file)); /* copy unaligned bytes */
                 output += sizeof(file);
+                infected_file = output;
+                output += strlen(infected_file) + 1;
 
                 params.severity = get_secrule_result_severity(ri, file, SECRULE_VIRUS);
 
                 if (params.severity != RESULT_NULL && params.severity != RESULT_SKIP) {
+                    nevra = get_nevra(file->rpm_header);
+                    assert(nevra != NULL);
+
                     if (params.severity == RESULT_INFO) {
                         params.waiverauth = NOT_WAIVABLE;
                         params.verb = VERB_OK;
@@ -331,9 +463,24 @@ bool inspect_virus(struct rpminspect *ri)
                     params.arch = get_rpm_header_arch(file->rpm_header);
                     params.file = file->localpath;
                     params.remedy = REMEDY_VIRUS;
-                    xasprintf(&params.msg, _("Virus detected in %s in the %s package on %s: %s"), file->localpath, headerGetString(file->rpm_header, RPMTAG_NAME), params.arch, virus);
+
+                    if (headerIsSource(file->rpm_header)) {
+                        if (infected_file && infected_file[0]) {
+                            xasprintf(&params.msg, _("Virus detected in %s in the %s source package: %s (infected file: %s)"), file->localpath, nevra, virus, infected_file);
+                        } else {
+                            xasprintf(&params.msg, _("Virus detected in %s in the %s source package: %s"), file->localpath, nevra, virus);
+                        }
+                    } else {
+                        if (infected_file && infected_file[0]) {
+                            xasprintf(&params.msg, _("Virus detected in %s in the %s package: %s (infected file: %s)"), file->localpath, nevra, virus, infected_file);
+                        } else {
+                            xasprintf(&params.msg, _("Virus detected in %s in the %s package: %s"), file->localpath, nevra, virus);
+                        }
+                    }
+
                     add_result(ri, &params);
                     free(params.msg);
+                    free(nevra);
                 }
             } /* while (there is unprocessed output from this child) */
 

--- a/po/rpminspect.pot
+++ b/po/rpminspect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rpminspect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-28 15:15-0500\n"
+"POT-Creation-Date: 2026-05-27 12:24-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -424,12 +424,12 @@ msgstr ""
 msgid "There is not enough available space to download the requested %s.\n"
 msgstr ""
 
-#: lib/builds.c:235 lib/peers.c:171
+#: lib/builds.c:235 lib/peers.c:177
 #, c-format
 msgid "    Need %s in %s, have %s.\n"
 msgstr ""
 
-#: lib/builds.c:236 lib/peers.c:172
+#: lib/builds.c:236 lib/peers.c:178
 #, c-format
 msgid "See the `-w' option for specifying an alternate working directory.\n"
 msgstr ""
@@ -456,50 +456,50 @@ msgstr ""
 msgid "Downloading RPM build"
 msgstr ""
 
-#: lib/builds.c:373 lib/inspect_modularity.c:47
+#: lib/builds.c:374 lib/inspect_modularity.c:47
 #, c-format
 msgid "*** ignoring malformed module metadata file: %s"
 msgstr ""
 
-#: lib/builds.c:382
+#: lib/builds.c:384
 #, c-format
 msgid "*** malformed rpm filters in file: %s"
 msgstr ""
 
-#: lib/builds.c:556 lib/builds.c:560
+#: lib/builds.c:560 lib/builds.c:564
 msgid "task"
 msgstr ""
 
-#: lib/builds.c:574
+#: lib/builds.c:578
 #, c-format
 msgid "Downloading task %d"
 msgstr ""
 
-#: lib/builds.c:715 lib/builds.c:718
+#: lib/builds.c:719 lib/builds.c:722
 msgid "RPM"
 msgstr ""
 
-#: lib/builds.c:854
+#: lib/builds.c:858
 #, c-format
 msgid "*** `%s' already exists in %s"
 msgstr ""
 
-#: lib/builds.c:908
+#: lib/builds.c:912
 #, c-format
 msgid "*** unable to find local build: %s"
 msgstr ""
 
-#: lib/builds.c:920
+#: lib/builds.c:924
 #, c-format
 msgid "*** unable to download RPM: %s"
 msgstr ""
 
-#: lib/builds.c:939 lib/builds.c:970 lib/builds.c:980
+#: lib/builds.c:943 lib/builds.c:974 lib/builds.c:984
 #, c-format
 msgid "*** unable to find build %s in Koji hub %s"
 msgstr ""
 
-#: lib/builds.c:949
+#: lib/builds.c:953
 #, c-format
 msgid "*** unable to find task %s in Koji hub %s"
 msgstr ""
@@ -598,7 +598,7 @@ msgstr ""
 msgid "*** ignoring malformed section %s->%s"
 msgstr ""
 
-#: lib/init.c:472 lib/init.c:485
+#: lib/init.c:471 lib/init.c:484
 #, c-format
 msgid "*** error reading %s ignore pattern"
 msgstr ""
@@ -617,132 +617,132 @@ msgstr ""
 msgid "*** malformed/unknown inspections section"
 msgstr ""
 
-#: lib/init.c:666
+#: lib/init.c:669
 #, c-format
 msgid "*** ignoring malformed %s configuration file: %s"
 msgstr ""
 
-#: lib/init.c:738
+#: lib/init.c:741
 #, c-format
 msgid "*** unknown modularity static context settiongs '%s'"
 msgstr ""
 
-#: lib/init.c:818
+#: lib/init.c:821
 #, c-format
 msgid "*** unknown specname match setting '%s', defaulting to 'full'"
 msgstr ""
 
-#: lib/init.c:833
+#: lib/init.c:836
 #, c-format
 msgid "*** unknown specname primary setting '%s', defaulting to 'name'"
 msgstr ""
 
-#: lib/init.c:848
+#: lib/init.c:851
 #, c-format
 msgid "*** invalid annocheck failure_reporting_level: %s, defaulting to %s"
 msgstr ""
 
-#: lib/init.c:906
+#: lib/init.c:909
 msgid "*** malformed badfuncs->allowed section"
 msgstr ""
 
-#: lib/init.c:924
+#: lib/init.c:927
 #, c-format
 msgid "*** error reading unicode exclude regular expression: %s"
 msgstr ""
 
-#: lib/init.c:934
+#: lib/init.c:937
 msgid "*** malformed rpmdeps->ignore section; skipping"
 msgstr ""
 
-#: lib/init.c:1068
+#: lib/init.c:1073
 #, c-format
 msgid "*** Invalid filename in the fileinfo list: %s"
 msgstr ""
 
-#: lib/init.c:1069
+#: lib/init.c:1074
 msgid "*** From this invalid line:"
 msgstr ""
 
-#: lib/init.c:1070
+#: lib/init.c:1075
 #, c-format
 msgid "***     %s"
 msgstr ""
 
-#: lib/init.c:1217
+#: lib/init.c:1222
 #, c-format
 msgid "*** unexpected token `%s' seen in %s, cannot continue"
 msgstr ""
 
-#: lib/init.c:1508
+#: lib/init.c:1513
 #, c-format
 msgid "*** invalid security rule: %s"
 msgstr ""
 
-#: lib/init.c:1520
+#: lib/init.c:1525
 #, c-format
 msgid "*** unknown security rule: %s"
 msgstr ""
 
-#: lib/init.c:1529
+#: lib/init.c:1534
 #, c-format
 msgid "*** unknown security action: %s"
 msgstr ""
 
-#: lib/init.c:1554
+#: lib/init.c:1559
 #, c-format
 msgid "*** malformed security line: %s"
 msgstr ""
 
-#: lib/init.c:1711
+#: lib/init.c:1718
 #, c-format
 msgid "*** missing configuration file `%s'"
 msgstr ""
 
-#: lib/init.c:1747
+#: lib/init.c:1754
 #, c-format
 msgid "*** unable to find profile '%s'"
 msgstr ""
 
-#: lib/inspect_abidiff.c:265
-msgid "abidiff usage error"
-msgstr ""
-
-#: lib/inspect_abidiff.c:274
-msgid "ABI change in ${FILE} on ${ARCH}"
-msgstr ""
-
-#: lib/inspect_abidiff.c:283
+#: lib/inspect_abidiff.c:270
 msgid "ABI incompatible change in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_abidiff.c:295
+#: lib/inspect_abidiff.c:279
+msgid "ABI change in ${FILE} on ${ARCH}"
+msgstr ""
+
+#: lib/inspect_abidiff.c:285
+msgid "abidiff usage error"
+msgstr ""
+
+#: lib/inspect_abidiff.c:297
 #, c-format
 msgid ""
 "Comparing old vs. new version of %s in package %s with ABI compatibility "
 "level %ld on %s revealed ABI differences."
 msgstr ""
 
-#: lib/inspect_abidiff.c:297
+#: lib/inspect_abidiff.c:299
 #, c-format
 msgid ""
 "Comparing old vs. new version of %s in package %s on %s revealed ABI "
 "differences."
 msgstr ""
 
-#: lib/inspect_abidiff.c:301
+#: lib/inspect_abidiff.c:303
 #, c-format
 msgid ""
 "Comparing from %s to %s in package %s with ABI compatibility level %ld on %s "
 "revealed ABI differences."
 msgstr ""
 
-#: lib/inspect_abidiff.c:303
+#: lib/inspect_abidiff.c:305
 #, c-format
 msgid "Comparing from %s to %s in package %s on %s revealed ABI differences."
 msgstr ""
 
-#: lib/inspect_abidiff.c:308
+#: lib/inspect_abidiff.c:310
 #, c-format
 msgid ""
 "Command: %s\n"
@@ -841,91 +841,86 @@ msgstr ""
 msgid "*** libannocheck_%s_test: %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:267
+#: lib/inspect_annocheck.c:268
 #, c-format
 msgid "*** libannocheck_enable_all_tests: %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:280
+#: lib/inspect_annocheck.c:281
 #, c-format
 msgid "*** libannocheck_reinit: %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:374
+#: lib/inspect_annocheck.c:375
 #, c-format
 msgid "*** before libannocheck_run_tests: %s (%d)"
 msgstr ""
 
-#: lib/inspect_annocheck.c:383 lib/inspect_annocheck.c:427
+#: lib/inspect_annocheck.c:384 lib/inspect_annocheck.c:428
 #, c-format
 msgid "*** libannocheck_get_known_tests: %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:401 lib/inspect_annocheck.c:531
-#, c-format
-msgid "*** libannocheck_finish: %s"
-msgstr ""
-
-#: lib/inspect_annocheck.c:418
+#: lib/inspect_annocheck.c:419
 #, c-format
 msgid "*** after libannocheck_run_tests: %s (%d)"
 msgstr ""
 
-#: lib/inspect_annocheck.c:462 lib/inspect_annocheck.c:614
+#: lib/inspect_annocheck.c:463 lib/inspect_annocheck.c:617
 msgid "lost -D_FORTIFY_SOURCE in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_annocheck.c:465
+#: lib/inspect_annocheck.c:466
 #, c-format
 msgid "%s may have lost -O2 -D_FORTIFY_SOURCE on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:490
+#: lib/inspect_annocheck.c:491
 #, c-format
 msgid "libannocheck '%s' continues passing for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:493
+#: lib/inspect_annocheck.c:494
 #, c-format
 msgid "libannocheck '%s' test now passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:496
+#: lib/inspect_annocheck.c:497
 #, c-format
 msgid "libannocheck '%s' test now fails for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:499 lib/inspect_annocheck.c:506
+#: lib/inspect_annocheck.c:500 lib/inspect_annocheck.c:507
 #, c-format
 msgid "libannocheck '%s' test fails for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:504
+#: lib/inspect_annocheck.c:505
 #, c-format
 msgid "libannocheck '%s' test passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:552 lib/inspect_annocheck.c:570
+#: lib/inspect_annocheck.c:555 lib/inspect_annocheck.c:573
 #, c-format
 msgid "annocheck '%s' test passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:554
+#: lib/inspect_annocheck.c:557
 #, c-format
 msgid "annocheck '%s' test now passes for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:556
+#: lib/inspect_annocheck.c:559
 #, c-format
 msgid "annocheck '%s' test now fails for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:562 lib/inspect_annocheck.c:572
+#: lib/inspect_annocheck.c:565 lib/inspect_annocheck.c:575
 #, c-format
 msgid "annocheck '%s' test fails for %s on %s"
 msgstr ""
 
-#: lib/inspect_annocheck.c:617
+#: lib/inspect_annocheck.c:620
 #, c-format
 msgid "%s may have lost -D_FORTIFY_SOURCE on %s"
 msgstr ""
@@ -948,17 +943,17 @@ msgstr ""
 msgid "Architecture '%s' has appeared"
 msgstr ""
 
-#: lib/inspect_badfuncs.c:152
+#: lib/inspect_badfuncs.c:159
 #, c-format
 msgid "Forbidden function symbols found:\n"
 msgstr ""
 
-#: lib/inspect_badfuncs.c:168
+#: lib/inspect_badfuncs.c:175
 #, c-format
 msgid "%s may use forbidden functions on %s"
 msgstr ""
 
-#: lib/inspect_badfuncs.c:175
+#: lib/inspect_badfuncs.c:182
 msgid "forbidden functions in ${FILE} on ${ARCH}"
 msgstr ""
 
@@ -1012,50 +1007,55 @@ msgstr ""
 msgid "Compressed %s file %s changed content in %s on %s."
 msgstr ""
 
-#: lib/inspect_changedfiles.c:332 lib/inspect_changedfiles.c:346
+#: lib/inspect_changedfiles.c:332 lib/inspect_changedfiles.c:347
 #, c-format
 msgid "Error running msgunfmt on %s in %s on %s; malformed mo file?"
 msgstr ""
 
-#: lib/inspect_changedfiles.c:336 lib/inspect_changedfiles.c:350
+#: lib/inspect_changedfiles.c:336 lib/inspect_changedfiles.c:351
 msgid "msgunfmt on ${FILE}"
 msgstr ""
 
-#: lib/inspect_changedfiles.c:361
+#: lib/inspect_changedfiles.c:363
 #, c-format
 msgid "Message catalog %s changed content in %s on %s"
 msgstr ""
 
-#: lib/inspect_changedfiles.c:365 lib/inspect_changedfiles.c:422
-#: lib/inspect_changedfiles.c:443
+#: lib/inspect_changedfiles.c:367 lib/inspect_changedfiles.c:424
+#: lib/inspect_changedfiles.c:445
 msgid "${FILE}"
 msgstr ""
 
-#: lib/inspect_changedfiles.c:418
+#: lib/inspect_changedfiles.c:420
 #, c-format
 msgid ""
 "Public header file %s changed content in %s on %s.  A unified diff of the "
 "changes follows."
 msgstr ""
 
-#: lib/inspect_changedfiles.c:446
+#: lib/inspect_changedfiles.c:448
 #, c-format
 msgid ""
 "File %s changed content in %s on %s.  Changes to security policy related "
 "files require inspection by the Security Response Team."
 msgstr ""
 
-#: lib/inspect_changedfiles.c:448
+#: lib/inspect_changedfiles.c:450
 #, c-format
 msgid "File %s changed content in %s on %s."
 msgstr ""
 
-#: lib/inspect_changelog.c:233 lib/inspect_changelog.c:358
+#: lib/inspect_changelog.c:45
+#, c-format
+msgid "*** error processing forbidden changelog regular expression: %s"
+msgstr ""
+
+#: lib/inspect_changelog.c:325 lib/inspect_changelog.c:483
 #, c-format
 msgid "%%changelog"
 msgstr ""
 
-#: lib/inspect_changelog.c:427
+#: lib/inspect_changelog.c:567
 msgid "Inspection skipped because this build's type is not `rpm'."
 msgstr ""
 
@@ -1064,105 +1064,105 @@ msgstr ""
 msgid "%config ${FILE}"
 msgstr ""
 
-#: lib/inspect_config.c:114
+#: lib/inspect_config.c:118
 #, c-format
 msgid ""
 "%%config file %s went from actual file to symlink (pointing to %s) in %s on "
 "%s"
 msgstr ""
 
-#: lib/inspect_config.c:123
+#: lib/inspect_config.c:127
 #, c-format
 msgid ""
 "%%config file %s was a symlink (pointing to %s), became an actual file in %s "
 "on %s"
 msgstr ""
 
-#: lib/inspect_config.c:132
+#: lib/inspect_config.c:136
 #, c-format
 msgid "Symlink value for %%config file %s changed in %s on %s."
 msgstr ""
 
-#: lib/inspect_config.c:153
+#: lib/inspect_config.c:157
 #, c-format
 msgid "%%config file content change for %s in %s on %s"
 msgstr ""
 
-#: lib/inspect_config.c:168
+#: lib/inspect_config.c:172
 #, c-format
 msgid ""
 "%%config file change for %s in %s on %s (%smarked as %%config -> %smarked as "
 "%%config)\n"
 msgstr ""
 
-#: lib/inspect_config.c:169 lib/inspect_doc.c:114
+#: lib/inspect_config.c:173 lib/inspect_doc.c:114
 msgid "not "
 msgstr ""
 
-#: lib/inspect_debuginfo.c:213
+#: lib/inspect_debuginfo.c:212
 #, c-format
 msgid "%s in %s on %s is missing debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:217
+#: lib/inspect_debuginfo.c:216
 msgid "missing debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:220
+#: lib/inspect_debuginfo.c:219
 #, c-format
 msgid "Missing: %s"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:231
+#: lib/inspect_debuginfo.c:230
 #, c-format
 msgid "%s in %s on %s contains debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:235
+#: lib/inspect_debuginfo.c:234
 msgid "contains debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:237
+#: lib/inspect_debuginfo.c:236
 #, c-format
 msgid "Contains: %s"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:256
+#: lib/inspect_debuginfo.c:255
 #, c-format
 msgid "%s in %s on %s gained debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:257
+#: lib/inspect_debuginfo.c:256
 msgid "gained debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:262
+#: lib/inspect_debuginfo.c:261
 #, c-format
 msgid "Gained: %s"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:282
+#: lib/inspect_debuginfo.c:281
 #, c-format
 msgid "%s in %s on %s lost debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:283
+#: lib/inspect_debuginfo.c:282
 msgid "lost debugging symbols"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:288
+#: lib/inspect_debuginfo.c:287
 #, c-format
 msgid "Lost: %s"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:314
+#: lib/inspect_debuginfo.c:313
 #, c-format
 msgid ""
 "%s in %s on %s carries .gosymtab but should not have the .gnu_debugdata "
 "symbol"
 msgstr ""
 
-#: lib/inspect_debuginfo.c:316
+#: lib/inspect_debuginfo.c:315
 msgid ".gnu_debugdata with .gosymtab"
 msgstr ""
 
@@ -1375,35 +1375,35 @@ msgstr ""
 msgid "lost GNU_RELRO in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_elf.c:725
+#: lib/inspect_elf.c:727
 #, c-format
 msgid "The following objects lost -fPIC:\n"
 msgstr ""
 
-#: lib/inspect_elf.c:742
+#: lib/inspect_elf.c:744
 #, c-format
 msgid "The following new objects were built without -fPIC:\n"
 msgstr ""
 
-#: lib/inspect_elf.c:755
+#: lib/inspect_elf.c:757
 #, c-format
 msgid "%s in %s has objects built without -fPIC on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:763
+#: lib/inspect_elf.c:765
 msgid "missing -fPIC in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_elf.c:799
+#: lib/inspect_elf.c:801
 msgid "TEXTREL relocations in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_elf.c:814
+#: lib/inspect_elf.c:816
 #, c-format
 msgid "%s in %s acquired TEXTREL relocations on %s"
 msgstr ""
 
-#: lib/inspect_elf.c:817
+#: lib/inspect_elf.c:819
 #, c-format
 msgid "%s in %s has TEXTREL relocations on %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Java byte code version changed in ${FILE}"
 msgstr ""
 
-#: lib/inspect_javabytecode.c:255 lib/inspect_javabytecode.c:267
+#: lib/inspect_javabytecode.c:256 lib/inspect_javabytecode.c:268
 msgid "*** missing JVM version to product release mapping"
 msgstr ""
 
@@ -1579,35 +1579,35 @@ msgstr ""
 msgid "Kernel module '%s' gained alias '%s'"
 msgstr ""
 
-#: lib/inspect_kmod.c:188
+#: lib/inspect_kmod.c:190
 #, c-format
 msgid "Kernel module %s removes parameter '%s' (was present in %s)."
 msgstr ""
 
-#: lib/inspect_kmod.c:191 lib/inspect_kmod.c:208
+#: lib/inspect_kmod.c:193 lib/inspect_kmod.c:207
 msgid "${FILE} kernel module parameter on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_kmod.c:205
+#: lib/inspect_kmod.c:204
 #, c-format
 msgid "Kernel module %s adds parameter '%s' (was not present in %s)."
 msgstr ""
 
-#: lib/inspect_kmod.c:226
+#: lib/inspect_kmod.c:227
 #, c-format
 msgid "Kernel module %s removes dependency '%s' (was present in %s)."
 msgstr ""
 
-#: lib/inspect_kmod.c:229
+#: lib/inspect_kmod.c:230
 msgid "${FILE} kernel module dependency on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_kmod.c:243
+#: lib/inspect_kmod.c:241
 #, c-format
 msgid "Kernel module %s adds dependency '%s' (was not present in %s)."
 msgstr ""
 
-#: lib/inspect_kmod.c:246
+#: lib/inspect_kmod.c:244
 msgid "${FILE} kernel module parameter"
 msgstr ""
 
@@ -1635,12 +1635,12 @@ msgstr ""
 msgid "*** problem checking license database"
 msgstr ""
 
-#: lib/inspect_license.c:742
+#: lib/inspect_license.c:747
 #, c-format
 msgid "Unapproved license in %s: %s"
 msgstr ""
 
-#: lib/inspect_license.c:771
+#: lib/inspect_license.c:776
 #, c-format
 msgid ""
 "SPDX license expressions in use in %s, but an invalid SPDX special keyword "
@@ -1648,44 +1648,44 @@ msgid ""
 "all lowercase or all uppercase (not mixed case)."
 msgstr ""
 
-#: lib/inspect_license.c:772 lib/inspect_license.c:787
+#: lib/inspect_license.c:777 lib/inspect_license.c:792
 #, c-format
 msgid "License: %s"
 msgstr ""
 
-#: lib/inspect_license.c:786
+#: lib/inspect_license.c:791
 #, c-format
 msgid "Mixed SPDX and legacy license identifiers found in %s."
 msgstr ""
 
-#: lib/inspect_license.c:818
+#: lib/inspect_license.c:823
 #, c-format
 msgid "Empty License Tag in %s"
 msgstr ""
 
-#: lib/inspect_license.c:822
+#: lib/inspect_license.c:827
 msgid "missing License tag in ${FILE}"
 msgstr ""
 
-#: lib/inspect_license.c:832
+#: lib/inspect_license.c:837
 #, c-format
 msgid "Valid License Tag in %s: %s"
 msgstr ""
 
-#: lib/inspect_license.c:847
+#: lib/inspect_license.c:852
 #, c-format
 msgid "License Tag contains unprofessional language in %s: %s"
 msgstr ""
 
-#: lib/inspect_license.c:851
+#: lib/inspect_license.c:856
 msgid "unprofessional language in License tag in ${FILE}"
 msgstr ""
 
-#: lib/inspect_license.c:899
+#: lib/inspect_license.c:904
 msgid "Missing license database(s)."
 msgstr ""
 
-#: lib/inspect_license.c:903
+#: lib/inspect_license.c:908
 msgid "missing license database"
 msgstr ""
 
@@ -1698,173 +1698,173 @@ msgstr ""
 msgid "missing subpackage ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_lostpayload.c:94 lib/inspect_lostpayload.c:126
+#: lib/inspect_lostpayload.c:94
 #, c-format
 msgid "Package %s on %s continues to be empty (no payloads)"
 msgstr ""
 
-#: lib/inspect_lostpayload.c:95 lib/inspect_lostpayload.c:127
+#: lib/inspect_lostpayload.c:95
 msgid "existing empty subpackage ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_lostpayload.c:98 lib/inspect_lostpayload.c:130
+#: lib/inspect_lostpayload.c:98
 #, c-format
 msgid "Package %s on %s became empty (no payloads)"
 msgstr ""
 
-#: lib/inspect_lostpayload.c:99 lib/inspect_lostpayload.c:131
+#: lib/inspect_lostpayload.c:99
 msgid "subpackage ${FILE} on ${ARCH} now has empty payload"
 msgstr ""
 
-#: lib/inspect_lto.c:144
+#: lib/inspect_lto.c:140
 msgid "${FILE} not portable on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_lto.c:152
+#: lib/inspect_lto.c:148
 #, c-format
 msgid ""
 "%s contains symbols [%s] on %s; this is not portable across compiler versions"
 msgstr ""
 
-#: lib/inspect_lto.c:168
+#: lib/inspect_lto.c:164
 #, c-format
 msgid ""
 "%s contains symbol [%s] on %s; this is not portable across compiler versions"
 msgstr ""
 
-#: lib/inspect_manpage.c:52
+#: lib/inspect_manpage.c:53
 #, c-format
 msgid "Error parsing %s:%d:%d: %s: %s: %s\n"
 msgstr ""
 
-#: lib/inspect_manpage.c:81
+#: lib/inspect_manpage.c:88
 #, c-format
 msgid "*** unable to compile man page path regular expression: %s"
 msgstr ""
 
-#: lib/inspect_manpage.c:179
+#: lib/inspect_manpage.c:186
 #, c-format
 msgid "Unable to open man page %s\n"
 msgstr ""
 
-#: lib/inspect_manpage.c:187
+#: lib/inspect_manpage.c:194
 #, c-format
 msgid "Man page %s does not end in %s\n"
 msgstr ""
 
-#: lib/inspect_manpage.c:195
+#: lib/inspect_manpage.c:202
 #, c-format
 msgid "man page with %s suffix is not really compressed with gzip\n"
 msgstr ""
 
-#: lib/inspect_manpage.c:236
+#: lib/inspect_manpage.c:243
 #, c-format
 msgid "Errors found validating %s\n"
 msgstr ""
 
-#: lib/inspect_manpage.c:299
+#: lib/inspect_manpage.c:306
 #, c-format
 msgid "Man page %s is possibly empty on %s in %s"
 msgstr ""
 
-#: lib/inspect_manpage.c:302
+#: lib/inspect_manpage.c:309
 msgid "empty man page ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_manpage.c:315
+#: lib/inspect_manpage.c:322
 #, c-format
 msgid "Man page checker reported problems with %s on %s in %s"
 msgstr ""
 
-#: lib/inspect_manpage.c:318
+#: lib/inspect_manpage.c:325
 msgid "man page ${FILE} on ${ARCH} has errors"
 msgstr ""
 
-#: lib/inspect_manpage.c:327
+#: lib/inspect_manpage.c:334
 #, c-format
 msgid "Man page %s has incorrect path on %s in %s"
 msgstr ""
 
-#: lib/inspect_manpage.c:330
+#: lib/inspect_manpage.c:337
 msgid "man page ${FILE} on ${ARCH} has incorrect path"
 msgstr ""
 
-#: lib/inspect_metadata.c:40
+#: lib/inspect_metadata.c:41
 #, c-format
 msgid ""
 "Vendor not set in the rpminspect configuration, ignoring Package Vendor "
 "\"%s\" in %s"
 msgstr ""
 
-#: lib/inspect_metadata.c:51
+#: lib/inspect_metadata.c:52
 #, c-format
 msgid "Package Vendor \"%s\" is not \"%s\" in %s"
 msgstr ""
 
-#: lib/inspect_metadata.c:55
+#: lib/inspect_metadata.c:56
 msgid "invalid vendor ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_metadata.c:76
+#: lib/inspect_metadata.c:78
 #, c-format
 msgid ""
 "Package Build Host \"%s\" is not within an expected build host subdomain in "
 "%s"
 msgstr ""
 
-#: lib/inspect_metadata.c:80
+#: lib/inspect_metadata.c:82
 msgid "invalid build host ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_metadata.c:92
+#: lib/inspect_metadata.c:95
 #, c-format
 msgid "Package Summary contains unprofessional language in %s"
 msgstr ""
 
-#: lib/inspect_metadata.c:93
+#: lib/inspect_metadata.c:96
 #, c-format
 msgid "Summary: %s"
 msgstr ""
 
-#: lib/inspect_metadata.c:97
+#: lib/inspect_metadata.c:100
 msgid "Summary contains unprofessional words on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_metadata.c:109
+#: lib/inspect_metadata.c:114
 #, c-format
 msgid "Package Description contains unprofessional language in %s:"
 msgstr ""
 
-#: lib/inspect_metadata.c:114
+#: lib/inspect_metadata.c:119
 msgid "Description contains unprofessional words on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_metadata.c:134
+#: lib/inspect_metadata.c:140
 #, c-format
 msgid "Gained Package Vendor \"%s\" in %s"
 msgstr ""
 
-#: lib/inspect_metadata.c:136
+#: lib/inspect_metadata.c:142
 #, c-format
 msgid "Lost Package Vendor \"%s\" in %s"
 msgstr ""
 
-#: lib/inspect_metadata.c:138
+#: lib/inspect_metadata.c:144
 #, c-format
 msgid "Package Vendor changed from \"%s\" to \"%s\" in %s"
 msgstr ""
 
-#: lib/inspect_metadata.c:156
+#: lib/inspect_metadata.c:162
 #, c-format
 msgid "Package Summary change from \"%s\" to \"%s\" in %s"
 msgstr ""
 
-#: lib/inspect_metadata.c:169
+#: lib/inspect_metadata.c:175
 #, c-format
 msgid "Package Description changed in %s"
 msgstr ""
 
-#: lib/inspect_metadata.c:170
+#: lib/inspect_metadata.c:176
 #, c-format
 msgid ""
 "from:\n"
@@ -1954,94 +1954,94 @@ msgstr ""
 msgid "%s probably moved to %s on %s\n"
 msgstr ""
 
-#: lib/inspect_patches.c:324
+#: lib/inspect_patches.c:330
 #, c-format
 msgid ""
 "Patch number %ld (%s) is missing a corresponding %%patch%ld macro, usually "
 "in %%prep."
 msgstr ""
 
-#: lib/inspect_patches.c:326
+#: lib/inspect_patches.c:332
 #, c-format
 msgid "missing %%patch macro for ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:328
+#: lib/inspect_patches.c:334
 #, c-format
 msgid "Patch number %ld (%s) is mismatched with %%patch%ld macro."
 msgstr ""
 
-#: lib/inspect_patches.c:330
+#: lib/inspect_patches.c:336
 #, c-format
 msgid "mismatched %%patch macro for ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:351
+#: lib/inspect_patches.c:357
 msgid "undefined Patch ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:352
+#: lib/inspect_patches.c:358
 #, c-format
 msgid "Undefined Patch file %s."
 msgstr ""
 
-#: lib/inspect_patches.c:365 lib/inspect_patches.c:373
+#: lib/inspect_patches.c:371 lib/inspect_patches.c:379
 #, c-format
 msgid "*** unable to uncompress patch: %s"
 msgstr ""
 
-#: lib/inspect_patches.c:402
+#: lib/inspect_patches.c:413
 msgid "corrupt patch ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:406 lib/inspect_patches.c:413
+#: lib/inspect_patches.c:417 lib/inspect_patches.c:424
 #, c-format
 msgid "Patch %s is under 4 bytes in size - is it corrupt?"
 msgstr ""
 
-#: lib/inspect_patches.c:435
+#: lib/inspect_patches.c:446
 #, c-format
 msgid "%s changed (%ld bytes -> %ld bytes)"
 msgstr ""
 
-#: lib/inspect_patches.c:439 lib/inspect_patches.c:464
+#: lib/inspect_patches.c:450 lib/inspect_patches.c:475
 msgid "patch file ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:460
+#: lib/inspect_patches.c:471
 #, c-format
 msgid "New patch file `%s` appeared"
 msgstr ""
 
-#: lib/inspect_patches.c:480
+#: lib/inspect_patches.c:491
 msgid "patch changes ${FILE}"
 msgstr ""
 
-#: lib/inspect_patches.c:488
+#: lib/inspect_patches.c:499
 #, c-format
 msgid "%s touches %ld files and as many as %ld lines"
 msgstr ""
 
-#: lib/inspect_patches.c:554 lib/inspect_upstream.c:142
+#: lib/inspect_patches.c:565 lib/inspect_upstream.c:142
 msgid "No source packages available, skipping inspection."
 msgstr ""
 
-#: lib/inspect_patches.c:641
+#: lib/inspect_patches.c:657
 #, c-format
 msgid "Unhandled patch file `%s` defined in spec file"
 msgstr ""
 
-#: lib/inspect_patches.c:759
+#: lib/inspect_patches.c:782
 #, c-format
 msgid "*** unrecognized %%patch line: %s"
 msgstr ""
 
-#: lib/inspect_patches.c:765
+#: lib/inspect_patches.c:788
 #, c-format
 msgid "*** unable to read spec file line: %s"
 msgstr ""
 
-#: lib/inspect_patches.c:817
+#: lib/inspect_patches.c:841
 #, c-format
 msgid "Patch file `%s` removed"
 msgstr ""
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "library ${FILE} removed on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_removedfiles.c:120
+#: lib/inspect_removedfiles.c:116
 #, c-format
 msgid ""
 "ABI break: Library %s with SONAME '%s' removed from package %s on %s; "
@@ -2096,51 +2096,51 @@ msgid ""
 "Response Team."
 msgstr ""
 
-#: lib/inspect_removedfiles.c:123
+#: lib/inspect_removedfiles.c:119
 #, c-format
 msgid "ABI break: Library %s with SONAME '%s' removed from package %s on %s"
 msgstr ""
 
-#: lib/inspect_removedfiles.c:126
+#: lib/inspect_removedfiles.c:122
 msgid "missing SONAME in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_removedfiles.c:130
+#: lib/inspect_removedfiles.c:126
 #, c-format
 msgid ""
 "ABI break: Library %s removed from package %s on %s; Removing security "
 "policy related files requires inspection by the Security Response Team."
 msgstr ""
 
-#: lib/inspect_removedfiles.c:132
+#: lib/inspect_removedfiles.c:128
 #, c-format
 msgid "ABI break: Library %s removed from package %s on %s"
 msgstr ""
 
-#: lib/inspect_removedfiles.c:137
+#: lib/inspect_removedfiles.c:133
 #, c-format
 msgid ""
 "%s removed from package %s on %s; Removing security policy related files "
 "requires inspection by the Security Response Team."
 msgstr ""
 
-#: lib/inspect_removedfiles.c:139
+#: lib/inspect_removedfiles.c:135
 #, c-format
 msgid "%s removed from package %s on %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:155
+#: lib/inspect_rpmdeps.c:156
 #, c-format
 msgid "Invalid looking %s dependency in the %s package on %s: %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:158 lib/inspect_rpmdeps.c:980
-#: lib/inspect_rpmdeps.c:998 lib/inspect_rpmdeps.c:1048
+#: lib/inspect_rpmdeps.c:159 lib/inspect_rpmdeps.c:1005
+#: lib/inspect_rpmdeps.c:1023 lib/inspect_rpmdeps.c:1072
 #, c-format
 msgid "'${FILE}' in %s on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:505
+#: lib/inspect_rpmdeps.c:528
 #, c-format
 msgid ""
 "Subpackage %s on %s carries '%s' which comes from subpackage %s but does not "
@@ -2149,108 +2149,108 @@ msgid ""
 "various combinations of old and new subpackages."
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:506
+#: lib/inspect_rpmdeps.c:529
 #, c-format
 msgid "missing 'Requires: ${FILE} = %s' in %s on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:528
+#: lib/inspect_rpmdeps.c:551
 #, c-format
 msgid ""
 "Multiple subpackages provide '%s': [%s] but these subpackages carry explicit "
 "Requires: [%s]"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:529
+#: lib/inspect_rpmdeps.c:552
 #, c-format
 msgid "%s all provide '${FILE}' on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:621
+#: lib/inspect_rpmdeps.c:644
 #, c-format
 msgid "Missing epoch prefix on the version-release in '%s' for %s on %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:622
+#: lib/inspect_rpmdeps.c:645
 #, c-format
 msgid "'${FILE}' needs epoch in %s on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:887
+#: lib/inspect_rpmdeps.c:914
 msgid "spec file"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:968
+#: lib/inspect_rpmdeps.c:993
 #, c-format
 msgid "Gained '%s' in source package %s; this is expected"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:970
+#: lib/inspect_rpmdeps.c:995
 #, c-format
 msgid "Gained '%s' in source package %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:974
+#: lib/inspect_rpmdeps.c:999
 #, c-format
 msgid "Gained '%s' in subpackage %s on %s; this is expected"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:976
+#: lib/inspect_rpmdeps.c:1001
 #, c-format
 msgid "Gained '%s' in subpackage %s on %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:986
+#: lib/inspect_rpmdeps.c:1011
 #, c-format
 msgid "Retained '%s' in source package %s; this is expected"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:988
+#: lib/inspect_rpmdeps.c:1013
 #, c-format
 msgid "Retained '%s' in source package %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:992
+#: lib/inspect_rpmdeps.c:1017
 #, c-format
 msgid "Retained '%s' in subpackage %s on %s; this is expected"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:994
+#: lib/inspect_rpmdeps.c:1019
 #, c-format
 msgid "Retained '%s' in subpackage %s on %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:1004
+#: lib/inspect_rpmdeps.c:1029
 #, c-format
 msgid "Changed '%s' to '%s' in source package %s; this is expected"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:1006
+#: lib/inspect_rpmdeps.c:1031
 #, c-format
 msgid "Changed '%s' to '%s' in source package %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:1010
+#: lib/inspect_rpmdeps.c:1035
 #, c-format
 msgid "Changed '%s' to '%s' in subpackage %s on %s; this is expected"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:1012
+#: lib/inspect_rpmdeps.c:1037
 #, c-format
 msgid "Changed '%s' to '%s' in subpackage %s on %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:1016
+#: lib/inspect_rpmdeps.c:1041
 #, c-format
 msgid "'%s' became '${FILE}' in %s on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:1040
+#: lib/inspect_rpmdeps.c:1064
 #, c-format
 msgid "Lost '%s' in source package %s"
 msgstr ""
 
-#: lib/inspect_rpmdeps.c:1042
+#: lib/inspect_rpmdeps.c:1066
 #, c-format
 msgid "Lost '%s' in subpackage %s on %s"
 msgstr ""
@@ -2278,149 +2278,149 @@ msgstr ""
 msgid "%s has both DT_RPATH and DT_RUNPATH on %s; this is not allowed"
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:188
+#: lib/inspect_shellsyntax.c:192
 #, c-format
 msgid "%s is a shell script but was not before on %s"
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:190
+#: lib/inspect_shellsyntax.c:194
 #, c-format
 msgid "%s is a %s script but was a %s script before on %s"
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:198
+#: lib/inspect_shellsyntax.c:202
 msgid "changed shell script ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:238
+#: lib/inspect_shellsyntax.c:242
 #, c-format
 msgid "%s is no longer a valid %s script on %s"
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:244 lib/inspect_shellsyntax.c:270
-#: lib/inspect_shellsyntax.c:292
+#: lib/inspect_shellsyntax.c:248 lib/inspect_shellsyntax.c:274
+#: lib/inspect_shellsyntax.c:296
 msgid "invalid shell script ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:250
+#: lib/inspect_shellsyntax.c:254
 #, c-format
 msgid ""
 "%s became a valid %s script on %s. The script fails with '-n' but passes "
 "with '-O extglob'; be sure 'shopt extglob' is set in the script."
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:252
+#: lib/inspect_shellsyntax.c:256
 #, c-format
 msgid "%s became a valid %s script on %s"
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:260 lib/inspect_shellsyntax.c:283
+#: lib/inspect_shellsyntax.c:264 lib/inspect_shellsyntax.c:287
 msgid "valid shell script ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:264 lib/inspect_shellsyntax.c:287
+#: lib/inspect_shellsyntax.c:268 lib/inspect_shellsyntax.c:291
 #, c-format
 msgid "%s is not a valid %s script on %s"
 msgstr ""
 
-#: lib/inspect_shellsyntax.c:277
+#: lib/inspect_shellsyntax.c:281
 #, c-format
 msgid ""
 "%s fails with '-n' but passes with '-O extglob'; be sure 'shopt extglob' is "
 "set in the script on %s"
 msgstr ""
 
-#: lib/inspect_specname.c:67
+#: lib/inspect_specname.c:70
 msgid "unexpected spec filename"
 msgstr ""
 
-#: lib/inspect_specname.c:70
+#: lib/inspect_specname.c:73
 #, c-format
 msgid "Spec filename does not exactly match the primary name %s; got '%s'"
 msgstr ""
 
-#: lib/inspect_specname.c:72
+#: lib/inspect_specname.c:75
 #, c-format
 msgid "Spec filename does not begin with the primary name %s; got '%s'"
 msgstr ""
 
-#: lib/inspect_specname.c:74
+#: lib/inspect_specname.c:77
 #, c-format
 msgid "Spec filename does not end with the primary name %s; got '%s'"
 msgstr ""
 
-#: lib/inspect_specname.c:107
+#: lib/inspect_specname.c:110
 msgid "The specname inspection is only for source packages, skipping."
 msgstr ""
 
-#: lib/inspect_subpackages.c:70
+#: lib/inspect_subpackages.c:75
 #, c-format
 msgid "Subpackage '%s' has disappeared on '%s'"
 msgstr ""
 
-#: lib/inspect_subpackages.c:76 lib/inspect_subpackages.c:104
+#: lib/inspect_subpackages.c:81 lib/inspect_subpackages.c:114
 msgid "subpackage ${FILE}"
 msgstr ""
 
-#: lib/inspect_subpackages.c:98
+#: lib/inspect_subpackages.c:108
 #, c-format
 msgid "Subpackage '%s' has appeared on '%s'"
 msgstr ""
 
-#: lib/inspect_symlinks.c:153
+#: lib/inspect_symlinks.c:151
 msgid "unable to read symlink ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_symlinks.c:154
+#: lib/inspect_symlinks.c:152
 #, c-format
 msgid "An error occurred reading symbolic link %s in %s on %s."
 msgstr ""
 
-#: lib/inspect_symlinks.c:205
+#: lib/inspect_symlinks.c:207
 #, c-format
 msgid ""
 "%s %s has too many levels of redirects and cannot be resolved in %s on %s"
 msgstr ""
 
-#: lib/inspect_symlinks.c:209
+#: lib/inspect_symlinks.c:211
 msgid "too many redirects for ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_symlinks.c:286
+#: lib/inspect_symlinks.c:295
 #, c-format
 msgid ""
 "Directory %s became a symbolic link (to %s) in %s on %s; this is not allowed!"
 msgstr ""
 
-#: lib/inspect_symlinks.c:293
+#: lib/inspect_symlinks.c:302
 #, c-format
 msgid ""
 "%s %s became a symbolic link (to %s) in %s on %s; and the link destination "
 "is reachable"
 msgstr ""
 
-#: lib/inspect_symlinks.c:297
+#: lib/inspect_symlinks.c:306
 #, c-format
 msgid ""
 "%s %s became a symbolic link (to %s) in %s on %s; and the link destination "
 "is unreachable"
 msgstr ""
 
-#: lib/inspect_symlinks.c:306
+#: lib/inspect_symlinks.c:315
 msgid "${FILE} became a symlink on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_symlinks.c:314
+#: lib/inspect_symlinks.c:323
 #, c-format
 msgid "%s %s became a dangling symbolic link in %s on %s"
 msgstr ""
 
-#: lib/inspect_symlinks.c:316
+#: lib/inspect_symlinks.c:325
 #, c-format
 msgid "%s %s is a dangling symbolic link in %s on %s"
 msgstr ""
 
-#: lib/inspect_symlinks.c:324
+#: lib/inspect_symlinks.c:333
 msgid "dangling symlink ${FILE} on ${ARCH}"
 msgstr ""
 
@@ -2463,35 +2463,35 @@ msgid ""
 "The 'udevadm verify' command does not operate as expected on this system."
 msgstr ""
 
-#: lib/inspect_unicode.c:491
+#: lib/inspect_unicode.c:505
 #, c-format
 msgid "*** empty localpath on %s"
 msgstr ""
 
-#: lib/inspect_unicode.c:505
+#: lib/inspect_unicode.c:519
 msgid "forbidden code point in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_unicode.c:572
+#: lib/inspect_unicode.c:587
 #, c-format
 msgid ""
 "A forbidden code point, 0x%04X, was found in the %s source file on line %ld "
 "at column %ld.  This source file is used by %s."
 msgstr ""
 
-#: lib/inspect_unicode.c:646
+#: lib/inspect_unicode.c:661
 #, c-format
 msgid "unable to run %prep in ${FILE}"
 msgstr ""
 
-#: lib/inspect_unicode.c:649
+#: lib/inspect_unicode.c:664
 #, c-format
 msgid ""
 "Unable to run through the %%prep section in %s or manually unpack sources "
 "for further scanning."
 msgstr ""
 
-#: lib/inspect_unicode.c:767
+#: lib/inspect_unicode.c:782
 msgid "The unicode inspection is only for source packages, skipping."
 msgstr ""
 
@@ -2522,36 +2522,51 @@ msgstr ""
 msgid "source file ${FILE} removed"
 msgstr ""
 
-#: lib/inspect_virus.c:117
+#: lib/inspect_virus.c:238
 msgid "clamav version information"
 msgstr ""
 
-#: lib/inspect_virus.c:122
+#: lib/inspect_virus.c:243
 #, c-format
 msgid "clamav version %s"
 msgstr ""
 
-#: lib/inspect_virus.c:127
+#: lib/inspect_virus.c:248
 #, c-format
 msgid "*** missing %s"
 msgstr ""
 
-#: lib/inspect_virus.c:151
+#: lib/inspect_virus.c:274
 #, c-format
 msgid "%s version %u (%s)"
 msgstr ""
 
-#: lib/inspect_virus.c:175
+#: lib/inspect_virus.c:298
 msgid "*** cl_engine_new returned NULL, check clamav library"
 msgstr ""
 
-#: lib/inspect_virus.c:229
+#: lib/inspect_virus.c:356
 msgid "virus or malware in ${FILE} on ${ARCH}"
 msgstr ""
 
-#: lib/inspect_virus.c:316
+#: lib/inspect_virus.c:469
 #, c-format
-msgid "Virus detected in %s in the %s package on %s: %s"
+msgid "Virus detected in %s in the %s source package: %s (infected file: %s)"
+msgstr ""
+
+#: lib/inspect_virus.c:471
+#, c-format
+msgid "Virus detected in %s in the %s source package: %s"
+msgstr ""
+
+#: lib/inspect_virus.c:475
+#, c-format
+msgid "Virus detected in %s in the %s package: %s (infected file: %s)"
+msgstr ""
+
+#: lib/inspect_virus.c:477
+#, c-format
+msgid "Virus detected in %s in the %s package: %s"
 msgstr ""
 
 #: lib/inspect_xml.c:221
@@ -2573,31 +2588,31 @@ msgstr ""
 msgid "*** XML-RPC Fault: %s (%d)"
 msgstr ""
 
-#: lib/koji.c:643
+#: lib/koji.c:630
 #, c-format
 msgid "*** xmlrpc fault code %s (%d): getBuild(%s) from %s"
 msgstr ""
 
-#: lib/koji.c:873
+#: lib/koji.c:865
 #, c-format
 msgid "*** Koji build state is %s for %s, cannot continue"
 msgstr ""
 
-#: lib/koji.c:1132
+#: lib/koji.c:1118
 #, c-format
 msgid "*** xmlrpc fault code %s (%d): getTaskInfo(%s) from %s"
 msgstr ""
 
-#: lib/koji.c:1156
+#: lib/koji.c:1147
 #, c-format
 msgid "*** Koji task state is %s for task %s, cannot continue"
 msgstr ""
 
-#: lib/koji.c:1400
+#: lib/koji.c:1388
 msgid "RPM package build"
 msgstr ""
 
-#: lib/koji.c:1402
+#: lib/koji.c:1390
 msgid "Module build consisting of multiple RPM package builds"
 msgstr ""
 
@@ -2643,19 +2658,19 @@ msgstr ""
 msgid "*** error opening %s for writing"
 msgstr ""
 
-#: lib/output_text.c:92 lib/output_xunit.c:83
+#: lib/output_text.c:92 lib/output_xunit.c:87
 #, c-format
 msgid "Result: %s\n"
 msgstr ""
 
-#: lib/output_text.c:95 lib/output_xunit.c:96
+#: lib/output_text.c:95 lib/output_xunit.c:100
 #, c-format
 msgid ""
 "Waiver Authorization: %s\n"
 "\n"
 msgstr ""
 
-#: lib/output_text.c:99 lib/output_xunit.c:110
+#: lib/output_text.c:99 lib/output_xunit.c:114
 #, c-format
 msgid ""
 "Details:\n"
@@ -2663,14 +2678,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: lib/output_text.c:103 lib/output_xunit.c:118
+#: lib/output_text.c:103 lib/output_xunit.c:122
 #, c-format
 msgid ""
 "Suggested Remedy:\n"
 "%s"
 msgstr ""
 
-#: lib/output_xunit.c:54
+#: lib/output_xunit.c:58
 #, c-format
 msgid "*** opening %s for writing"
 msgstr ""
@@ -2741,21 +2756,21 @@ msgstr ""
 msgid "${FILE} changed owner on ${ARCH}"
 msgstr ""
 
-#: lib/parse_yaml.c:90 lib/parse_yaml.c:115
+#: lib/parse_yaml.c:50
+msgid "*** malformed type - freed?"
+msgstr ""
+
+#: lib/parse_yaml.c:122 lib/parse_yaml.c:147
 #, c-format
 msgid "*** %s: broken document"
 msgstr ""
 
-#: lib/parse_yaml.c:134 lib/parse_yaml.c:281
+#: lib/parse_yaml.c:166 lib/parse_yaml.c:313
 #, c-format
 msgid "*** skipping token type %s"
 msgstr ""
 
-#: lib/parse_yaml.c:362
-msgid "*** malformed type - freed?"
-msgstr ""
-
-#: lib/peers.c:170
+#: lib/peers.c:176
 #, c-format
 msgid "There is not enough available space to unpack all of the RPMs.\n"
 msgstr ""
@@ -2940,14 +2955,14 @@ msgstr ""
 msgid "*** unable to close %s"
 msgstr ""
 
-#: lib/remedy.c:125
+#: lib/remedy.c:127
 msgid ""
 "ABI changes introduced during maintenance updates can lead to problems for "
 "users.  See the abidiff(1) documentation and the distribution ABI policies "
 "to determine if this detected change is allowed."
 msgstr ""
 
-#: lib/remedy.c:127
+#: lib/remedy.c:129
 msgid ""
 "Unexpected file additions were found.  Verify these changes are correct.  If "
 "they are not, adjust the build to prevent the file additions between "
@@ -2958,7 +2973,7 @@ msgid ""
 "forbidden_path_prefixes or forbidden_path_suffixes list."
 msgstr ""
 
-#: lib/remedy.c:129
+#: lib/remedy.c:131
 msgid ""
 "Ensure all object files are compiled with '-O2 -D_FORTIFY_SOURCE=2', and "
 "that all appropriate headers are included (no implicit function "
@@ -2966,24 +2981,24 @@ msgid ""
 "unable to determine the size of a buffer, which is not necessarily an error."
 msgstr ""
 
-#: lib/remedy.c:131
+#: lib/remedy.c:133
 msgid "See annocheck(1) for more information."
 msgstr ""
 
-#: lib/remedy.c:133
+#: lib/remedy.c:135
 msgid ""
 "A new architecture has appeared in the after build.  This may indicate "
 "progress in the world of computing."
 msgstr ""
 
-#: lib/remedy.c:135
+#: lib/remedy.c:137
 msgid ""
 "An architecture present in the before build is now missing in the after "
 "build.  This may be deliberate, but check to make sure you do not have any "
 "unexpected ExclusiveArch lines in the spec file."
 msgstr ""
 
-#: lib/remedy.c:137
+#: lib/remedy.c:139
 msgid ""
 "Forbidden symbols were found in an ELF file in the package.  The "
 "configuration settings for rpminspect indicate the named symbols are "
@@ -2995,17 +3010,17 @@ msgid ""
 "deprecated functions should not be used."
 msgstr ""
 
-#: lib/remedy.c:139
+#: lib/remedy.c:141
 msgid ""
 "Unprofessional language as defined in the configuration file was found in "
 "the text shown.  Remove or change the offending words and rebuild."
 msgstr ""
 
-#: lib/remedy.c:141
+#: lib/remedy.c:143
 msgid "Make sure the SRPM is built on a host within the expected subdomain."
 msgstr ""
 
-#: lib/remedy.c:143
+#: lib/remedy.c:145
 msgid ""
 "Unexpected capabilities were found on the indicated file.  Consult "
 "capabilities(7) and either adjust the files in the package or modify the "
@@ -3015,20 +3030,28 @@ msgid ""
 "send a patch to the project that owns the rpminspect data file."
 msgstr ""
 
-#: lib/remedy.c:145
+#: lib/remedy.c:147
 msgid ""
 "File changes were found.  In most cases these are expected, but it is a good "
 "idea to verify the changes found are deliberate."
 msgstr ""
 
-#: lib/remedy.c:147
+#: lib/remedy.c:149
 #, c-format
 msgid ""
-"Make sure the spec file in the after build contains a valid %changelog "
-"section."
+"Make sure the %changelog in the after build spec file does not contain any "
+"unprofessional languages as defined in the rpminspect configuration settings."
 msgstr ""
 
-#: lib/remedy.c:149
+#: lib/remedy.c:151
+#, c-format
+msgid ""
+"Make sure the %changelog in the after build spec file does not contain any "
+"entries that match defined forbidden regular expressions as defined in the "
+"rpminspect configuration settings."
+msgstr ""
+
+#: lib/remedy.c:153
 #, c-format
 msgid ""
 "Changes to %config should be done carefully.  Make sure you have installed "
@@ -3037,20 +3060,20 @@ msgid ""
 "package -or- honor the old file locations."
 msgstr ""
 
-#: lib/remedy.c:151
+#: lib/remedy.c:155
 msgid ""
 "Refer to the Desktop Entry Specification at https://"
 "standards.freedesktop.org/desktop-entry-spec/latest/ for help correcting the "
 "errors and warnings."
 msgstr ""
 
-#: lib/remedy.c:153
+#: lib/remedy.c:157
 msgid ""
 "The Release: tag in the spec file must include a '%{?dist}' string.  Please "
 "add this to the spec file per the distribution packaging guidelines."
 msgstr ""
 
-#: lib/remedy.c:155
+#: lib/remedy.c:159
 #, c-format
 msgid ""
 "Changes found among the %doc files.  Verify these changes are intended if "
@@ -3058,7 +3081,7 @@ msgid ""
 "documentation files and the spec file needs to account for those changes."
 msgstr ""
 
-#: lib/remedy.c:157
+#: lib/remedy.c:161
 msgid ""
 "DT_NEEDED symbols have been added or removed.  This happens when the build "
 "environment has different versions of the required libraries.  Sometimes "
@@ -3067,40 +3090,40 @@ msgid ""
 "the correct shared libraries."
 msgstr ""
 
-#: lib/remedy.c:159
+#: lib/remedy.c:163
 msgid ""
 "An ELF stack is marked as executable. Ensure that no execstack options are "
 "being passed to the linker, and that no functions are defined on the stack."
 msgstr ""
 
-#: lib/remedy.c:161
+#: lib/remedy.c:165
 msgid ""
 "The data in an ELF file appears to be corrupt; ensure that packaged ELF "
 "files are not being truncated or incorrectly modified."
 msgstr ""
 
-#: lib/remedy.c:163
+#: lib/remedy.c:167
 msgid ""
 "Ensure that the package is being built with the correct compiler and "
 "compiler flags."
 msgstr ""
 
-#: lib/remedy.c:165 lib/remedy.c:169
+#: lib/remedy.c:169 lib/remedy.c:173
 msgid "Ensure all object files are compiled with -fPIC."
 msgstr ""
 
-#: lib/remedy.c:167
+#: lib/remedy.c:171
 msgid "Ensure executables are linked with with '-z relro -z now'."
 msgstr ""
 
-#: lib/remedy.c:171 lib/remedy.c:201
+#: lib/remedy.c:175 lib/remedy.c:205
 #, c-format
 msgid ""
 "Check to see if you eliminated a subpackage but still have the %package and/"
 "or the %files section for it."
 msgstr ""
 
-#: lib/remedy.c:173
+#: lib/remedy.c:177
 msgid ""
 "rpminspect is expecting a fileinfo rule from the vendor data package for "
 "this file. Usually this means the file carries a non-standard set of "
@@ -3110,33 +3133,33 @@ msgid ""
 "the appropriate product release file."
 msgstr ""
 
-#: lib/remedy.c:175
+#: lib/remedy.c:179
 msgid ""
 "A previously non-empty file is now empty.  Make sure this change is intended "
 "and fix the package space file if necessary."
 msgstr ""
 
-#: lib/remedy.c:177
+#: lib/remedy.c:181
 msgid ""
 "A previously empty file is no longer empty.  Make sure this change is "
 "intended and fix the package spec file if necessary."
 msgstr ""
 
-#: lib/remedy.c:179
+#: lib/remedy.c:183
 msgid ""
 "A file grew by a noticeable amount.  Ensure this change is intended.  If it "
 "is, you can adjust the filesize inspection settings in the rpminspect.yaml "
 "file."
 msgstr ""
 
-#: lib/remedy.c:181
+#: lib/remedy.c:185
 msgid ""
 "A file shrank by a noticeable amount.  Ensure this change is intended.  If "
 "it is, you can adjust the filesize inspection settings in the "
 "rpminspect.yaml file."
 msgstr ""
 
-#: lib/remedy.c:183
+#: lib/remedy.c:187
 #, c-format
 msgid ""
 "Remove forbidden path references from the indicated line in the %files "
@@ -3145,7 +3168,7 @@ msgid ""
 "information."
 msgstr ""
 
-#: lib/remedy.c:185
+#: lib/remedy.c:189
 msgid ""
 "The License tag contains SPDX license identifiers.  When SPDX identifiers "
 "are used, the boolean joining terms must be written in all capital letters "
@@ -3153,79 +3176,79 @@ msgid ""
 "the boolean terms that must be in all capital letters."
 msgstr ""
 
-#: lib/remedy.c:187
+#: lib/remedy.c:191
 msgid ""
 "The Java bytecode version for one or more class files in the build was not "
 "met for the product release.  Ensure you are using the correct JDK for the "
 "build."
 msgstr ""
 
-#: lib/remedy.c:189
+#: lib/remedy.c:193
 msgid ""
 "Kernel Module Interface introduced during maintenance updates can lead to "
 "problems for users.  See the libabigail documentation and the distribution "
 "KMI policy to determine if this detected change is allowed."
 msgstr ""
 
-#: lib/remedy.c:191
+#: lib/remedy.c:195
 msgid ""
 "Kernel module device aliases changed between builds.  This may present "
 "usability problems for users if module device aliases changed in a "
 "maintenance update."
 msgstr ""
 
-#: lib/remedy.c:193
+#: lib/remedy.c:197
 msgid ""
 "Kernel module dependencies changed between builds.  This may present "
 "usability problems for users if module dependencies changed in a maintenance "
 "update."
 msgstr ""
 
-#: lib/remedy.c:195
+#: lib/remedy.c:199
 msgid ""
 "Kernel module parameters were removed between builds.  This may present "
 "usability problems for users if module parameters were removed in a "
 "maintenance update."
 msgstr ""
 
-#: lib/remedy.c:197
+#: lib/remedy.c:201
 msgid ""
 "Make sure the licensedb setting in the rpminspect configuration is set to a "
 "valid licensedb file.  This is also commonly due to a missing vendor "
 "specific rpminspect-data package on the system."
 msgstr ""
 
-#: lib/remedy.c:199
+#: lib/remedy.c:203
 msgid ""
 "The License tag must contain an approved license string as defined by the "
 "distribution (e.g., GPLv2+).  If the license in question is approved, the "
 "license database needs updating in the rpminspect-data package."
 msgstr ""
 
-#: lib/remedy.c:203
+#: lib/remedy.c:207
 msgid ""
 "ELF .o and .a files should not carry LTO (Link Time Optimization) bytecode.  "
 "Make sure you have stripped LTO bytecode from those files at install time."
 msgstr ""
 
-#: lib/remedy.c:205
+#: lib/remedy.c:209
 msgid "Correct the errors in the man page as reported by the libmandoc parser."
 msgstr ""
 
-#: lib/remedy.c:207
+#: lib/remedy.c:211
 msgid ""
 "Correct the installation path for the man page. Man pages must be installed "
 "in the directory beneath /usr/share/man that matches the section number of "
 "the page."
 msgstr ""
 
-#: lib/remedy.c:209
+#: lib/remedy.c:213
 msgid ""
 "This package is part of a module but is missing the %{modularitylabel} "
 "header tag.  Add this as a %define in the spec file and rebuild."
 msgstr ""
 
-#: lib/remedy.c:211
+#: lib/remedy.c:215
 msgid ""
 "This package is part of a module but lacks a conformant Release tag value.  "
 "A Release tag in a modular RPM needs to carry a substring that is more "
@@ -3233,7 +3256,7 @@ msgid ""
 "must carry '+module' as a substring before that specific dist tag."
 msgstr ""
 
-#: lib/remedy.c:213
+#: lib/remedy.c:217
 msgid ""
 "This build either contains a valid or invalid /data/static_context setting.  "
 "Refer to the module rules for the product you are building to determine what "
@@ -3242,13 +3265,13 @@ msgid ""
 "forbidden, or recommend."
 msgstr ""
 
-#: lib/remedy.c:215
+#: lib/remedy.c:219
 msgid ""
 "Unexpected file moves were found.  Verify these changes are correct.  If "
 "they are not, adjust the build to prevent the file moves between builds."
 msgstr ""
 
-#: lib/remedy.c:217
+#: lib/remedy.c:221
 msgid ""
 "Bin path files must be owned by the bin_group set in the rpminspect "
 "configuration, which is usually root. If this ownership is expected, update "
@@ -3256,7 +3279,7 @@ msgid ""
 "project that owns the rpminspect data files."
 msgstr ""
 
-#: lib/remedy.c:219
+#: lib/remedy.c:223
 msgid ""
 "Bin path files must be owned by the bin_owner set in the rpminspect "
 "configuration, which is usually root. If this ownership is expected, update "
@@ -3264,7 +3287,7 @@ msgid ""
 "project that owns the rpminspect data files."
 msgstr ""
 
-#: lib/remedy.c:221
+#: lib/remedy.c:225
 msgid ""
 "Verify the ownership changes are expected. If not, adjust the package build "
 "process to set correct owner and group information. If expected, update the "
@@ -3272,7 +3295,7 @@ msgid ""
 "project that owns the rpminspect data files."
 msgstr ""
 
-#: lib/remedy.c:223
+#: lib/remedy.c:227
 #, c-format
 msgid ""
 "Make sure the %files section includes the %defattr macro. If these "
@@ -3281,7 +3304,7 @@ msgid ""
 "data files."
 msgstr ""
 
-#: lib/remedy.c:225
+#: lib/remedy.c:229
 msgid ""
 "Either chgrp the file to the bin_group set in the rpminspect configuration "
 "or remove the group write bit on the file (chmod g-w). If this ownership is "
@@ -3289,7 +3312,7 @@ msgid ""
 "send a patch to the project that owns the rpminspect data files."
 msgstr ""
 
-#: lib/remedy.c:227
+#: lib/remedy.c:231
 msgid ""
 "Either chgrp the file to the bin_group set in the rpminspect configuration "
 "or remove the world execute bit on the file (chmod o-x). If this ownership "
@@ -3297,7 +3320,7 @@ msgid ""
 "send a patch to the project that owns the rpminspect data files."
 msgstr ""
 
-#: lib/remedy.c:229
+#: lib/remedy.c:233
 msgid ""
 "An invalid patch file was found.  This is usually the result of generating a "
 "collection of patches by comparing two trees.  When files disappear that can "
@@ -3306,7 +3329,7 @@ msgid ""
 "correct the problem."
 msgstr ""
 
-#: lib/remedy.c:231
+#: lib/remedy.c:235
 msgid ""
 "The named patch is defined but is mismatched by number with the %patch "
 "macro.  Make sure all numbered patches have corresponding %patch macros.  "
@@ -3317,7 +3340,7 @@ msgid ""
 "rpminspect is unable to read these lines."
 msgstr ""
 
-#: lib/remedy.c:233
+#: lib/remedy.c:237
 msgid ""
 "The named patch is defined in the source RPM header (this means it has a "
 "PatchN: definition in the spec file) but is not applied anywhere in the spec "
@@ -3331,19 +3354,19 @@ msgid ""
 "rpminspect is unable to read these lines."
 msgstr ""
 
-#: lib/remedy.c:235
+#: lib/remedy.c:239
 msgid ""
 "The defined patch file is not something rpminspect can handle.  This is "
 "likely a bug and should be reported to the upstream rpminspect project."
 msgstr ""
 
-#: lib/remedy.c:237
+#: lib/remedy.c:241
 msgid ""
 "Files should not be installed in old directory names.  Modify the package to "
 "install the affected file to the preferred directory."
 msgstr ""
 
-#: lib/remedy.c:239
+#: lib/remedy.c:243
 msgid ""
 "A file with potential politically sensitive content was found in the "
 "package.  If this file is permitted, it should be added to the rpminspect "
@@ -3352,13 +3375,13 @@ msgid ""
 "rpminspect data files."
 msgstr ""
 
-#: lib/remedy.c:241
+#: lib/remedy.c:245
 msgid ""
 "Unexpected file removals were found.  Verify these changes are correct.  If "
 "they are not, adjust the build to prevent the file removals between builds."
 msgstr ""
 
-#: lib/remedy.c:243
+#: lib/remedy.c:247
 msgid ""
 "A dependency listed in the before build changed to the indicated dependency "
 "in the after build.  If this is a VERIFY result, it means rpminspect noticed "
@@ -3367,7 +3390,7 @@ msgid ""
 "a rebased build."
 msgstr ""
 
-#: lib/remedy.c:245
+#: lib/remedy.c:249
 msgid ""
 "The package has an Epoch value greater than zero, but the explicit "
 "subpackage dependencies are not consistently using it.  For the dependency "
@@ -3375,7 +3398,7 @@ msgid ""
 "{version}-%{release}' to capture the package Epoch in the dependency."
 msgstr ""
 
-#: lib/remedy.c:247
+#: lib/remedy.c:251
 msgid ""
 "Add the indicated explicit Requires to the spec file for the named "
 "subpackage.  Subpackages depending on shared libraries in another subpackage "
@@ -3383,7 +3406,7 @@ msgid ""
 "in the spec file."
 msgstr ""
 
-#: lib/remedy.c:249
+#: lib/remedy.c:253
 msgid ""
 "Add the indicated explicit Requires to the spec file for the named "
 "subpackage.  Subpackages depending on shared libraries in another subpackage "
@@ -3391,7 +3414,7 @@ msgid ""
 "{release}' in the spec file."
 msgstr ""
 
-#: lib/remedy.c:251
+#: lib/remedy.c:255
 msgid ""
 "A new dependency is seen in the after build that was not present in the "
 "before build.  If this is a VERIFY result, it means rpminspect noticed the "
@@ -3400,7 +3423,7 @@ msgid ""
 "a rebased build."
 msgstr ""
 
-#: lib/remedy.c:253
+#: lib/remedy.c:257
 msgid ""
 "A dependency seen in the before build is not seen in the after build meaning "
 "it was removed or lost.  If this is a VERIFY result, it means rpminspect "
@@ -3409,14 +3432,14 @@ msgid ""
 "comparing a rebased build."
 msgstr ""
 
-#: lib/remedy.c:255
+#: lib/remedy.c:259
 msgid ""
 "Unexpanded RPM spec file macros were found in the noted dependency rule.  "
 "Check the spec file for this dependency and ensure you have not misspelled a "
 "macro or used a macro name that does not exist."
 msgstr ""
 
-#: lib/remedy.c:257
+#: lib/remedy.c:261
 #, c-format
 msgid ""
 "Check subpackage %files sections and explicit Provides statements.  Only one "
@@ -3426,14 +3449,14 @@ msgid ""
 "the shared library in question."
 msgstr ""
 
-#: lib/remedy.c:259
+#: lib/remedy.c:263
 msgid ""
 "Both DT_RPATH and DT_RUNPATH properties were found in an ELF shared object.  "
 "This indicates a linker error and should not happen.  ELF objects should "
 "only carry DT_RPATH or DT_RUNPATH, never both."
 msgstr ""
 
-#: lib/remedy.c:261
+#: lib/remedy.c:265
 #, c-format
 msgid ""
 "Either DT_RPATH or DT_RUNPATH properties were found on ELF shared objects in "
@@ -3444,42 +3467,42 @@ msgid ""
 "files."
 msgstr ""
 
-#: lib/remedy.c:263
+#: lib/remedy.c:267
 msgid ""
 "The referenced shell script is invalid. Consider debugging it with the '-n' "
 "option on the shell to find and fix the problem."
 msgstr ""
 
-#: lib/remedy.c:265
+#: lib/remedy.c:269
 msgid "Consult the shell documentation for proper syntax."
 msgstr ""
 
-#: lib/remedy.c:267
+#: lib/remedy.c:271
 msgid ""
 "The file referenced was not a known shell script in the before build but is "
 "now a shell script in the after build."
 msgstr ""
 
-#: lib/remedy.c:269
+#: lib/remedy.c:273
 msgid ""
 "The spec file name does not match the expected NAME.spec format.  Rename the "
 "spec file to conform to this policy."
 msgstr ""
 
-#: lib/remedy.c:271
+#: lib/remedy.c:275
 msgid ""
 "A new subpackage has appeared in the after build.  This may indicate "
 "progress in the world of computing."
 msgstr ""
 
-#: lib/remedy.c:273
+#: lib/remedy.c:277
 msgid ""
 "A subpackage present in the before build is now missing in the after build.  "
 "This may be deliberate, but check to make sure you have correct syntax "
 "defining the subpackage in the spec file."
 msgstr ""
 
-#: lib/remedy.c:275
+#: lib/remedy.c:279
 #, c-format
 msgid ""
 "Make sure symlinks point to a valid destination in one of the subpackages of "
@@ -3491,7 +3514,7 @@ msgid ""
 "'Scriptlet to replace a directory' for more information."
 msgstr ""
 
-#: lib/remedy.c:277
+#: lib/remedy.c:281
 msgid ""
 "Make sure symlinks point to a valid destination in one of the subpackages of "
 "the build; dangling symlinks are not allowed.  If you are comparing builds "
@@ -3499,20 +3522,20 @@ msgid ""
 "NOTE:  You cannot turn a directory in to a symlink due to RPM limitations."
 msgstr ""
 
-#: lib/remedy.c:279
+#: lib/remedy.c:283
 msgid ""
 "In many cases the changing MIME type is deliberate.  Verify that the change "
 "is intended and if necessary fix the spec file so the correct file is "
 "included in the built package."
 msgstr ""
 
-#: lib/remedy.c:281
+#: lib/remedy.c:285
 msgid ""
 "Refer to the udev documentation at https://www.freedesktop.org/software/"
 "systemd/man/udev.html for help correcting the errors and warnings."
 msgstr ""
 
-#: lib/remedy.c:283
+#: lib/remedy.c:287
 msgid ""
 "The specified license abbreviation is not listed as approved in the license "
 "database.  The license database is specified in the rpminspect configuration "
@@ -3522,7 +3545,7 @@ msgid ""
 "options for this software."
 msgstr ""
 
-#: lib/remedy.c:285
+#: lib/remedy.c:289
 #, c-format
 msgid ""
 "The %prep section of the spec file could not be executed for some reason.  "
@@ -3532,7 +3555,7 @@ msgid ""
 "program is executing."
 msgstr ""
 
-#: lib/remedy.c:287
+#: lib/remedy.c:291
 msgid ""
 "The rpminspect configuration file contains a list of forbidden Unicode code "
 "points.  One was found in the extracted and patched source tree or in one of "
@@ -3541,7 +3564,7 @@ msgid ""
 "correct course of action."
 msgstr ""
 
-#: lib/remedy.c:289
+#: lib/remedy.c:293
 msgid ""
 "Unexpected changed source archive content. The version of the package did "
 "not change between builds, but the source archive content did. This may be "
@@ -3550,11 +3573,11 @@ msgid ""
 "project that owns the rpminspect data files."
 msgstr ""
 
-#: lib/remedy.c:291
+#: lib/remedy.c:295
 msgid "Change the string specified on the 'Vendor:' line in the spec file."
 msgstr ""
 
-#: lib/remedy.c:293
+#: lib/remedy.c:297
 msgid ""
 "ClamAV has found a virus in the named file.  This may be a false positive, "
 "but you should manually inspect the file in question to ensure it is clean.  "
@@ -3563,18 +3586,18 @@ msgid ""
 "further help."
 msgstr ""
 
-#: lib/remedy.c:295
+#: lib/remedy.c:299
 msgid "Correct the reported errors in the XML document."
 msgstr ""
 
-#: lib/remedy.c:297
+#: lib/remedy.c:301
 msgid ""
 "The License tag contains mixed used of SPDX and legacy license identifiers.  "
 "You must use either all SPDX license identifiers or all legacy license "
 "identifiers; you cannot mix the two systems."
 msgstr ""
 
-#: lib/remedy.c:299
+#: lib/remedy.c:303
 #, c-format
 msgid ""
 "A file or directory was found in the package that matches an %%exclude "
@@ -3583,7 +3606,7 @@ msgid ""
 "section(s) in the spec file."
 msgstr ""
 
-#: lib/remedy.c:301
+#: lib/remedy.c:305
 #, c-format
 msgid ""
 "An unexpected file or directory was found in the package.  This file or "
@@ -3608,21 +3631,21 @@ msgstr ""
 msgid "*** file index %d is out of bounds for %s"
 msgstr ""
 
-#: lib/rpm.c:479
+#: lib/rpm.c:482
 msgid "*** error reading file from RPM payload"
 msgstr ""
 
-#: lib/runcmd.c:277
+#: lib/runcmd.c:295
 #, c-format
 msgid "%d"
 msgstr ""
 
-#: lib/runcmd.c:279
+#: lib/runcmd.c:297
 #, c-format
 msgid "%d (%s)"
 msgstr ""
 
-#: lib/runcmd.c:284
+#: lib/runcmd.c:302
 #, c-format
 msgid ""
 "%s\n"
@@ -3630,7 +3653,7 @@ msgid ""
 "%s tried to run the command and it received signal %s"
 msgstr ""
 
-#: lib/runcmd.c:288
+#: lib/runcmd.c:306
 #, c-format
 msgid "%s tried to run the command and it received signal %s"
 msgstr ""
@@ -3691,7 +3714,7 @@ msgstr ""
 msgid "ok"
 msgstr ""
 
-#: lib/strfuncs.c:289 src/rpminspect.c:999
+#: lib/strfuncs.c:289 src/rpminspect.c:1020
 msgid "skip"
 msgstr ""
 
@@ -3961,174 +3984,179 @@ msgid ""
 "*** See the 'favor_release' setting in the rpminspect configuration file."
 msgstr ""
 
-#: src/rpminspect.c:288
+#: src/rpminspect.c:289
 msgid "*** the -T and -E options are mutually exclusive"
 msgstr ""
 
-#: src/rpminspect.c:289 src/rpminspect.c:305 src/rpminspect.c:747
-#: src/rpminspect.c:786
+#: src/rpminspect.c:290 src/rpminspect.c:306 src/rpminspect.c:322
+#: src/rpminspect.c:767 src/rpminspect.c:806
 #, c-format
 msgid "*** See `%s --help` for more information."
 msgstr ""
 
-#: src/rpminspect.c:304
+#: src/rpminspect.c:305
 #, c-format
 msgid "*** unknown inspection: `%s`"
 msgstr ""
 
-#: src/rpminspect.c:465
+#: src/rpminspect.c:321
+#, c-format
+msgid "*** multiple instances of command line option: `%s`"
+msgstr ""
+
+#: src/rpminspect.c:485
 #, c-format
 msgid "*** unsupported build type: `%s`."
 msgstr ""
 
-#: src/rpminspect.c:474
+#: src/rpminspect.c:494
 #, c-format
 msgid "*** invalid build type: `%s`."
 msgstr ""
 
-#: src/rpminspect.c:491
+#: src/rpminspect.c:511
 #, c-format
 msgid "*** invalid output format: `%s`."
 msgstr ""
 
-#: src/rpminspect.c:503
+#: src/rpminspect.c:523
 #, c-format
 msgid "*** unable to expand working directory: `%s`"
 msgstr ""
 
-#: src/rpminspect.c:516
+#: src/rpminspect.c:536
 #, c-format
 msgid "*** unable to use `%s' as working directory"
 msgstr ""
 
-#: src/rpminspect.c:546
+#: src/rpminspect.c:566
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: src/rpminspect.c:549
+#: src/rpminspect.c:569
 #, c-format
 msgid "*** ?? getopt returned character code 0%o ??"
 msgstr ""
 
-#: src/rpminspect.c:556
+#: src/rpminspect.c:576
 #, c-format
 msgid "Available build types:\n"
 msgstr ""
 
-#: src/rpminspect.c:577
+#: src/rpminspect.c:597
 #, c-format
 msgid ""
 "\n"
 "Available output formats:\n"
 msgstr ""
 
-#: src/rpminspect.c:594
+#: src/rpminspect.c:614
 #, c-format
 msgid ""
 "\n"
 "Available inspections:\n"
 msgstr ""
 
-#: src/rpminspect.c:637 src/rpminspect.c:645 src/rpminspect.c:663
+#: src/rpminspect.c:657 src/rpminspect.c:665 src/rpminspect.c:683
 #, c-format
 msgid "*** failed to read configuration file %s"
 msgstr ""
 
-#: src/rpminspect.c:668
+#: src/rpminspect.c:688
 #, c-format
 msgid "*** Please specify a configuration file using '-c' or supply ./%s"
 msgstr ""
 
-#: src/rpminspect.c:746
+#: src/rpminspect.c:766
 msgid "*** Invalid before and after build specification."
 msgstr ""
 
-#: src/rpminspect.c:754
+#: src/rpminspect.c:774
 msgid "*** unable to read RPM configuration"
 msgstr ""
 
-#: src/rpminspect.c:785
+#: src/rpminspect.c:805
 #, c-format
 msgid "*** unsupported architecture specified: `%s`"
 msgstr ""
 
-#: src/rpminspect.c:803
+#: src/rpminspect.c:823
 #, c-format
 msgid "*** unable to create directory %s"
 msgstr ""
 
-#: src/rpminspect.c:861
+#: src/rpminspect.c:882
 #, c-format
 msgid ""
 "Version information for libraries and programs used by %s as well as storage "
 "requirements.  This result is for informational and diagnostic purposes only."
 msgstr ""
 
-#: src/rpminspect.c:868
+#: src/rpminspect.c:889
 #, c-format
 msgid "Space required to download artifacts: %lu bytes (%s)\n"
 msgstr ""
 
-#: src/rpminspect.c:876
+#: src/rpminspect.c:897
 #, c-format
 msgid "Space required to unpack artifacts: %lu bytes (%s)\n"
 msgstr ""
 
-#: src/rpminspect.c:888
+#: src/rpminspect.c:909
 #, c-format
 msgid "Command line arguments used to invoke %s."
 msgstr ""
 
-#: src/rpminspect.c:912
+#: src/rpminspect.c:933
 #, c-format
 msgid "Local configuration file: %s"
 msgstr ""
 
-#: src/rpminspect.c:922
+#: src/rpminspect.c:943
 msgid "Before Build"
 msgstr ""
 
-#: src/rpminspect.c:927
+#: src/rpminspect.c:948
 msgid "After Build"
 msgstr ""
 
-#: src/rpminspect.c:930
+#: src/rpminspect.c:951
 msgid "Build"
 msgstr ""
 
-#: src/rpminspect.c:947
+#: src/rpminspect.c:968
 msgid "*** no peers, ensure packages exist for specified architecture(s)"
 msgstr ""
 
-#: src/rpminspect.c:968
+#: src/rpminspect.c:989
 msgid ""
 "*** unable to find a set of peer packages between the before and after builds"
 msgstr ""
 
-#: src/rpminspect.c:982
+#: src/rpminspect.c:1003
 msgid "*** unable to determine product release or none specified (-r)."
 msgstr ""
 
-#: src/rpminspect.c:994
+#: src/rpminspect.c:1015
 #, c-format
 msgid "Skipping %s inspection..."
 msgstr ""
 
-#: src/rpminspect.c:1019
+#: src/rpminspect.c:1040
 #, c-format
 msgid "Running %s inspection..."
 msgstr ""
 
-#: src/rpminspect.c:1028
+#: src/rpminspect.c:1049
 msgid "pass"
 msgstr ""
 
-#: src/rpminspect.c:1028
+#: src/rpminspect.c:1049
 msgid "FAIL"
 msgstr ""
 
-#: src/rpminspect.c:1056
+#: src/rpminspect.c:1077
 #, c-format
 msgid ""
 "\n"


### PR DESCRIPTION
libclamav will scan archive files, which we do now.  But the current reporting just says if an archive has a virus signature in it.  This patch expands that reporting to tell you what file in the archive has the virus signature.  Slightly more useful information.
    
Fixes: #1583
    
Signed-off-by: Dave Cantrell <dcantrell@redhat.com>